### PR TITLE
Proper CORS handling + Babel support for backend & tests

### DIFF
--- a/.Gruntfile.babel.js
+++ b/.Gruntfile.babel.js
@@ -14,13 +14,6 @@ var path = require('path')
 var url = require('url')
 var S = require('string')
 var fork = require('child_process').fork
-var vueify = require('vueify')
-// var envify = require('envify/custom') // not needed b/c of transform-inline-environment-variables
-
-vueify.compiler.applyConfig({ babel: {
-  presets: ['es2015', 'stage-3'],
-  plugins: ['transform-runtime', 'transform-inline-environment-variables']
-} })
 
 module.exports = grunt => {
   require('load-grunt-tasks')(grunt)
@@ -54,13 +47,9 @@ module.exports = grunt => {
     browserify: {
       dev: {
         options: {
-          transform: ['vueify', ['babelify', {
-            presets: ['es2015', 'stage-3'],
-            plugins: ['transform-inline-environment-variables'] // babelify plugins
-          }]],
-          plugins: ['transform-runtime'],                       // browserify plugins
+          transform: ['vueify', 'babelify'],
           browserifyOptions: {
-            debug: process.env.NODE_ENV === 'development'       // enables source maps
+            debug: process.env.NODE_ENV === 'development' // enables source maps
           }
         },
         files: { 'dist/simple/app.js': ['<%= files.frontend %>'] }
@@ -90,10 +79,9 @@ module.exports = grunt => {
     },
 
     execute: {
-      api_server: { src: 'backend/index.js' },
       api_test: {
         src: './node_modules/.bin/mocha',
-        options: { args: ['-R', 'spec', '--bail', 'test/'] }
+        options: { args: ['--compilers', 'js:babel-register', '-R', 'spec', '--bail', 'test/'] }
       },
       // we don't do `standard` linting this way (output not as pretty)
       // but keep it around just to show the alternative
@@ -171,6 +159,7 @@ module.exports = grunt => {
     var fork2 = (child) => {
       grunt.log.writeln('backend: forking...')
       var spawnOpts = {
+        execPath: './node_modules/.bin/babel-node',
         cwd: process.cwd(),
         env: process.env,
         stdio: 'inherit'

--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "stage-3"],
+  "plugins": ["transform-inline-environment-variables", "transform-runtime"]
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,19 +1,24 @@
-// We're doing this hack for now
 // See: https://github.com/okTurtles/group-income-simple/issues/23
-var _ = require('lodash')
-require('babel-polyfill') // required. http://stackoverflow.com/a/34195553/1781435
-// the stuff below + transform-inline-environment-variables
-// will replace process.env.VARIABLE strings like C macros (with their values)
+
+// make sure to read:
+// http://jamesknelson.com/the-six-things-you-need-to-know-about-babel-6/
+// TODO: figure out whether `babel-runtime` should be installed using --save
+//       instead of --save-dev per: https://babeljs.io/docs/plugins/transform-runtime/
+//       and figure out whether we should switch to using version 6:
+//       https://github.com/vuejs/vue-loader/issues/96#issuecomment-162910917
+
+require('babel-register') // http://stackoverflow.com/a/34195553/1781435
+                          // https://babeljs.io/docs/setup/#babel_register
+
+// transform-inline-environment-variables should will replace
+// process.env.VARIABLE strings like C macros (with their values)
 // And because of additional lines in .Gruntfile.babel.js this is done on both
 // the backend and the frontend.
+var _ = require('lodash')
 _.assign(process.env, {
   NODE_ENV: _.intersection(process.argv, ['dist', 'deploy'])[0] ? 'production' : 'development',
   API_PORT: 3000,
   API_URL: 'http://localhost:3000',
   FRONTEND_URL: 'http://localhost:8000'
-})
-require('babel-register')({
-  presets: ['es2015', 'stage-3'],
-  plugins: ['transform-inline-environment-variables']
 })
 module.exports = require('./.Gruntfile.babel.js')

--- a/backend/helpers/utils.js
+++ b/backend/helpers/utils.js
@@ -1,0 +1,19 @@
+// http://hapijs.com/api/#error-transformation
+const Boom = require('boom')
+
+// Babel doesn't support this!
+// https://babeljs.io/docs/learn-es2015/#proxies
+// export var ErrToBoom = new Proxy(Boom, {
+//   get: function (target, prop) {
+//     if (!target[prop]) throw new Error(`Boom has no property '${prop}'`)
+//     return function (err) {
+//       return target[prop](err.errors && err.errors[0].message || err.message)
+//     }
+//   }
+// })
+// TODO: autogen these by going through Boom's methods
+exports.ErrToBoom = {
+  badRequest: function (err) {
+    return Boom.badRequest(err.errors && err.errors[0].message || err.message)
+  }
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,11 +1,7 @@
-// Override global.Promise with bluebird.
-// Why? Because:
-//
-// - Bluebird adds many convenient APIs:
-//    http://bluebirdjs.com/docs/api-reference.html)
-// - Sequelize already uses bluebird, so we might as well take advantage of those APIs
-// - Bluebird's promises are better designed and have fewer issues than native ones:
-//    http://jamesknelson.com/are-es6-promises-swallowing-your-errors/)
+// Bluebird adds many convenient APIs: http://bluebirdjs.com/docs/api-reference.html
+// Sequelize already uses bluebird, so we might as well take advantage of those APIs
+// Bluebird's promises are better designed and have fewer issues than native ones:
+// http://jamesknelson.com/are-es6-promises-swallowing-your-errors/
 global.Promise = require('bluebird')
 
 global.logger = function (err) { // Improve this later
@@ -14,18 +10,17 @@ global.logger = function (err) { // Improve this later
 }
 var Hapi = require('hapi')
 var cookie = require('hapi-auth-cookie')
-var corsHeaders = require('hapi-cors-headers')
 
 var server = new Hapi.Server({
   // TODO: improve logging and base it on process.env.NODE_ENV
   debug: { request: ['error'], log: ['error'] }
-  // connections: {routes: {cors: cors}},
 })
 server.connection({
-  port: process.env.API_PORT
-  // host: '0.0.0.0', routes: { cors: cors }
+  host: '127.0.0.1', // Because sometimes I get a weird Error: listen EADDRINUSE 0.0.0.0:3000
+  port: process.env.API_PORT,
+  // See: https://github.com/hapijs/discuss/issues/262#issuecomment-204616831
+  routes: { cors: { origin: [process.env.FRONTEND_URL] } }
 })
-server.ext('onPreResponse', corsHeaders)
 server.register(cookie, function (err) {
   if (err) {
     console.error(err)

--- a/backend/session.js
+++ b/backend/session.js
@@ -3,6 +3,7 @@
 var Joi = require('joi')
 var bcrypt = require('bcrypt')
 var uuid = require('node-uuid')
+var Promise = require('bluebird')
 var compare = Promise.promisify(bcrypt.compare)
 module.exports = function (server, Sequelize, db) {
   server.route({

--- a/backend/user.js
+++ b/backend/user.js
@@ -1,9 +1,11 @@
 /* globals logger */
 
+var Promise = require('bluebird')
 var Joi = require('joi')
 var bcrypt = require('bcrypt')
 var email = require('./helpers/email')
 var uuid = require('node-uuid')
+var ErrToBoom = require('./helpers/utils')
 var hash = Promise.promisify(bcrypt.hash)
 
 module.exports = function (server, Sequelize, db) {
@@ -22,7 +24,8 @@ module.exports = function (server, Sequelize, db) {
       .then(reply)
       .catch(function (err) {
         logger(err)
-        reply(err)
+        // http://hapijs.com/api/#error-transformation
+        reply(ErrToBoom.badRequest(err))
       })
     }
   })
@@ -61,7 +64,7 @@ module.exports = function (server, Sequelize, db) {
       })
       .catch(function (err) {
         logger(err)
-        reply(err)
+        reply(ErrToBoom.badRequest(err))
       })
     }
   })
@@ -97,7 +100,7 @@ module.exports = function (server, Sequelize, db) {
       })
       .catch(function (err) {
         logger(err)
-        reply(err)
+        reply(ErrToBoom.badRequest(err))
       })
     }
   })

--- a/frontend/_static/css/main.css
+++ b/frontend/_static/css/main.css
@@ -137,10 +137,6 @@ b, h1, h2, h3, h4 {
   font-weight: 700;
 }
 
-header {
-  height: 
-}
-
 .groupincome-logo, nav {
   display: inline-block;
 }

--- a/frontend/simple/main.js
+++ b/frontend/simple/main.js
@@ -1,8 +1,5 @@
-// globals setup
 var Promise = global.Promise = require('bluebird') // see comment in backend/index.js
-// fix superagent so that .end() returns a promise
-var superagent = require('superagent')
-// going off the hint in: https://github.com/jomaxx/superagent-promise-plugin/blob/master/src/superagent-promise-plugin.js
+var superagent = require('superagent') // fix superagent so that .end() returns a promise
 superagent.Request.prototype.end = Promise.promisify(superagent.Request.prototype.end)
 
 // load components

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "bluebird": "3.3.4",
     "hapi": "12.1.0",
     "hapi-auth-cookie": "5.0.0",
-    "hapi-cors-headers": "1.0.0",
     "joi": "7.2.2",
     "jquery": "2.2.2",
     "lodash": "4.6.1",
@@ -41,6 +40,7 @@
     "vue-router": "0.7.11"
   },
   "devDependencies": {
+    "babel-cli": "6.6.5",
     "babel-core": "6.7.2",
     "babel-eslint": "5.0.0",
     "babel-plugin-transform-inline-environment-variables": "6.5.0",


### PR DESCRIPTION
- handle CORS properly now (Closes #39)
- rm'd `hapi-cors-headers` (no longer needed)
- Improved error messages sent by API in `backend/user.js` (see #40)
- Added `.babelrc` file and simplified both Gruntfiles
- Backend and tests now support async/await syntax
