### PR TITLE
EJS 2.0 support in both .vue files and via `require`

### DIFF
--- a/frontend/simple/js/utils.js
+++ b/frontend/simple/js/utils.js
@@ -3,3 +3,20 @@
 export function wrap (s, tag = 'div') {
   return `<${tag}>${s}</${tag}>`
 }
+
+// This function is currently located in .Gruntfile.babel.js
+// The problem is that fs.readFileSync doesn't work here (we're not in node)
+// However it might be possible to do it this way (and avoid the ejsify thing)
+// by using this: https://github.com/substack/brfs
+// TODO: investigate this alternative. Then in main.js we'd do:
+//       template: loadEJS('./views/test.ejs')
+// export function loadEJS (pathOrStr, str, opts = {}) {
+//   var path = pathOrStr
+//   if (_.isPlainObject(str)) opts = str
+//   if (/\.ejs$/.test(pathOrStr)) str = fs.readFileSync(pathOrStr)
+//   str = require('ejs').render(str, opts.data || {}, _.merge({
+//     filename: path,
+//     compileDebug: process.env.NODE_ENV === 'development'
+//   }, opts))
+//   return opts.wrap ? wrap(str, opts.wrap) : str
+// }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "babel-runtime": "5.8.35",
     "babelify": "7.2.0",
     "ejs": "2.4.1",
-    "ejsify": "1.0.0",
     "grunt": "0.4.5",
     "grunt-browserify": "5.0.0",
     "grunt-contrib-clean": "1.0.0",
@@ -63,6 +62,7 @@
     "load-grunt-tasks": "3.4.1",
     "mocha": "2.4.5",
     "node-ssi": "0.3.1",
+    "through2": "2.0.1",
     "vue-hot-reload-api": "1.3.2",
     "vueify": "8.3.6",
     "vueify-insert-css": "1.0.0"


### PR DESCRIPTION
- replaced ejsify dependency with a single function
- use latest version of ejs
