### PR TITLE
Make sure Navbar logo and logout buttons are visible as screen shrinks

### DIFF
--- a/frontend/simple/views/NavBar.vue
+++ b/frontend/simple/views/NavBar.vue
@@ -74,6 +74,16 @@
   </div>
 </template>
 
+<style lang="sass" scoped>
+div.nav-left
+  overflow: visible
+  z-index: 10
+  a
+    background-color: #fff
+div.nav-center
+  flex-shrink: inherit
+</style>
+
 <script>
 import Vue from 'vue'
 import {HapiNamespace} from '../js/backend/hapi'


### PR DESCRIPTION
Old:
![image](https://cloud.githubusercontent.com/assets/6340841/24328610/a8318a18-11a2-11e7-9e96-c78a86c4d818.png)

New:
![image](https://cloud.githubusercontent.com/assets/6340841/24328613/ac28deaa-11a2-11e7-9863-9c2caf3e4435.png)


Fixes https://github.com/okTurtles/group-income-simple/issues/214