### PR TITLE
Make group creation screen real

### DIFF
--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -62,7 +62,7 @@
               <div class="box" >
                 <p class="title is-5"><i18n>How transparent should your group be about who contributes?</i18n></p>
                 <p class="select">
-                  <select v-validate data-vv-rules="required" data-vv-as="Conrtibution Privacy" name="contributionPrivacy" v-model="contributionPrivacy">
+                  <select v-validate data-vv-rules="required" data-vv-as="Contribution Privacy" name="contributionPrivacy" v-model="contributionPrivacy">
                     <option value="">Select an option</option>
                     <option value="Very Private">Very Private</option>
                   </select>

--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -31,15 +31,6 @@
             <div class="column is-one-third has-text-centered create-group">
               <p class="title is-4"><i18n>Member relationships</i18n></p>
               <div class="box">
-                <p class="title is-5"><i18n>Is your group open to new members?</i18n></p>
-                <p class="title is-3" v-show="openMembership"><i18n>Yes</i18n></p>
-                <p class="title is-3" v-show="!openMembership"><i18n>No</i18n></p>
-                <label class="switch">
-                  <input type="checkbox" name="openMembership" v-model="openMembership">
-                  <div class="slider round"></div>
-                </label>
-              </div>
-              <div class="box">
                 <p class="title is-5"><i18n>How many members should it take to approve a new member?</i18n></p>
                 <p class="title is-3">{{memberApprovalPercentage}}%</p>
                 <input type="range" min="0" max="100" data-vv-as="Member Approval Percentage" v-validate data-vv-rules="between:1,100" name="memberApprovalPercentage" v-model="memberApprovalPercentage">
@@ -119,7 +110,6 @@ export default {
           groupName: this.groupName,
           sharedValue: this.sharedValues,
           changePercentage: this.changePercentage,
-          openMembership: this.openMembership,
           memberApprovalPercentage: this.memberApprovalPercentage,
           memberRemovalPercentage: this.memberRemovalPercentage,
           incomeProvided: this.incomeProvided,
@@ -147,7 +137,6 @@ export default {
       groupName: null,
       sharedValues: null,
       changePercentage: 0,
-      openMembership: false,
       memberApprovalPercentage: 0,
       memberRemovalPercentage: 0,
       incomeProvided: null,

--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -140,7 +140,7 @@ export default {
       memberApprovalPercentage: 80,
       memberRemovalPercentage: 80,
       incomeProvided: null,
-      contributionPrivacy: '',
+      contributionPrivacy: 'Very Private',
       created: false,
       // this determines whether or not to render proxy components for nightmare
       dev: process.env.NODE_ENV === 'development'

--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -136,9 +136,9 @@ export default {
     return {
       groupName: null,
       sharedValues: null,
-      changePercentage: 0,
-      memberApprovalPercentage: 0,
-      memberRemovalPercentage: 0,
+      changePercentage: 80,
+      memberApprovalPercentage: 80,
+      memberRemovalPercentage: 80,
       incomeProvided: null,
       contributionPrivacy: '',
       created: false,


### PR DESCRIPTION
Addresses 2 of the items brought up in https://github.com/okTurtles/group-income-simple/issues/184:

> "Is your group open to new members?" — This is unclear, as right below it we ask them how many members it takes to approve a new member, regardless of what the answer to this question is.

- [x] https://github.com/dsernst/group-income-simple/commit/1b5b5c6f28384fb3040309236e7616d4ff03ed06 removes this question, per @taoeffect's specification that all groups are invite-only for now.

-------------

> The sliders are set to 0% by default. This is problematic because it will mislead most people into thinking they shouldn't pull the sliders very far (e.g. much farther above 50%), when in fact they should.
- [x] https://github.com/dsernst/group-income-simple/commit/940019271af5bf70f72ec9aad81740c18c31d404 sets these default to 80%, per @taoeffect's instructions

