### PR TITLE
Add favicon with transparent background

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -8,6 +8,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="simple/css/main.css">
         <link rel="stylesheet" href="simple/css/index.css">
+        <link rel="icon" href="/simple/images/group-income-icon-transparent.png" sizes="32x32">
     </head>
     <body class="index">
       <!--[if lt IE 8]>

--- a/frontend/simple/index.html
+++ b/frontend/simple/index.html
@@ -7,6 +7,7 @@
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="css/main.css">
+    <link rel="icon" href="/simple/images/group-income-icon-transparent.png" sizes="32x32">
   </head>
   <body>
     <!--[if lt IE 9]>


### PR DESCRIPTION
Right now there is no favicon on the landing page or within the app. 

This PR adds the icon with the transparent background, as used on [groupincome.org](https://groupincome.org).

<img src="https://cloud.githubusercontent.com/assets/6340841/24334983/95f44ffc-1229-11e7-9565-dbe3daa18abf.png" height=70 />
