### PR TITLE
Bug Fixes: Unique Message Id | States passed by value

### DIFF
--- a/frontend/simple/views/Join.vue
+++ b/frontend/simple/views/Join.vue
@@ -1,6 +1,6 @@
 <template>
     <section class="section full-screen">
-      <div class="column is-10" >
+      <div class="centered" >
         <div class="columns" v-if="contract">
           <div class="column is-one-half">
             <div class="center ">
@@ -112,6 +112,7 @@ export default {
       let state = await latestContractState(this.$route.query.groupId)
       if (!state.invitees.find(invitee => invitee === this.$store.state.loggedIn)) {
         console.log(new Error('Invalid Invitation'))
+        await this.$store.dispatch('deleteMail', this.$route.query.inviteHash)
         this.$router.push({path: '/mailbox'})
       }
       this.contract = state
@@ -125,7 +126,8 @@ export default {
         let acceptance = new Events.AcceptInvitation({ username: this.$store.state.loggedIn, acceptanceDate: new Date() }, latest)
         this.$store.commit('setCurrentGroupId', this.$route.query.groupId)
         await backend.publishLogEntry(this.$route.query.groupId, acceptance)
-        this.$store.dispatch('deleteMail', this.$route.query.inviteHash)
+        this.$store.dispatch('deleteMessage', this.$route.query.inviteId)
+        this.$router.push({path: '/mailbox'})
       } catch (ex) {
         console.log(ex)
         this.errorMsg = L('Failed to Accept Invite')

--- a/frontend/simple/views/Mailbox.vue
+++ b/frontend/simple/views/Mailbox.vue
@@ -60,7 +60,7 @@
               <div><strong>From:</strong>&nbsp;{{currentMessage.messageType === 'Invite' ?  currentMessage.message : currentMessage.from}}</div>
             </div>
             <p class="panel-block" v-if="currentMessage.messageType === 'Message'" style="display: block; word-wrap: break-word;">{{currentMessage.message}}</p>
-            <p class="panel-block" v-if="currentMessage.messageType === 'Invite'"><router-link v-bind:to="{ path: '/join', query: { groupId: currentMessage.message} }" ><i18n>Respond to Invite</i18n></router-link></p>
+            <p class="panel-block" v-if="currentMessage.messageType === 'Invite'"><router-link v-bind:to="{ path: '/join', query: { groupId: currentMessage.message, inviteId: currentMessage.id} }" ><i18n>Respond to Invite</i18n></router-link></p>
             <div class="panel-block" >
               <button class="button is-danger" v-if="currentMessage.messageType === 'Message'" type="submit" style="margin-left:auto; margin-right: 0" v-on:click="remove(index)"><i18n>Delete</i18n></button>
               <button class="button is-primary" type="submit" v-on:click="inboxMode" style="margin-left:10px; margin-right: 0"><i18n>Return</i18n></button>
@@ -219,9 +219,9 @@ export default {
     },
     remove: function (index) {
       if (Number.isInteger(index)) {
-        this.$store.dispatch('deleteMessage', this.inbox[index].hash)
+        this.$store.dispatch('deleteMessage', this.inbox[index].id)
       } else {
-        this.$store.dispatch('deleteMessage', this.inbox[this.currentIndex].hash)
+        this.$store.dispatch('deleteMessage', this.inbox[this.currentIndex].id)
         this.currentIndex = null
         this.inboxMode()
       }
@@ -234,7 +234,7 @@ export default {
       if (Number.isInteger(index)) {
         this.currentMessage = this.inbox[index]
         this.currentIndex = index
-        this.$store.dispatch('markMessageAsRead', this.currentMessage.hash)
+        this.$store.dispatch('markMessageAsRead', this.currentMessage.id)
       }
     },
     readInvite: function (index) {
@@ -242,7 +242,7 @@ export default {
       if (Number.isInteger(index)) {
         this.currentMessage = this.invites[index]
         this.currentIndex = index
-        this.$store.dispatch('markMessageAsRead', this.currentMessage.hash)
+        this.$store.dispatch('markMessageAsRead', this.currentMessage.id)
       }
     },
     removeRecipient: function (index) {

--- a/shared/events.js
+++ b/shared/events.js
@@ -1,10 +1,10 @@
 'use strict'
-
 import multihash from 'multihashes'
 import protobuf from 'protobufjs/light'
 import {makeResponse} from './functions'
 import {RESPONSE_TYPE} from './constants'
 import type {JSONObject} from './types'
+import _ from 'lodash'
 
 const nacl = require('tweetnacl')
 const blake = require('blakejs')
@@ -157,7 +157,7 @@ export class HashableContract extends HashableEntry {
   }
   // returns .data converted to vuex state using transforms and any default state
   toVuexState () {
-    var state = {...this.constructor.vuex.state, ...this.data}
+    var state = _.cloneDeep({...this.constructor.vuex.state, ...this.data})
     for (let [param, fn] of Object.entries(this.constructor.transforms)) {
       fn.call(this, state, param)
     }
@@ -377,10 +377,10 @@ export class DeleteAttribute extends HashableAction {
 
 export class MailboxContract extends HashableContract {
   static vuex = MailboxContract.Vuex({
-    state: { messages: [] },
+    state: { messages: [], nextId: 0 },
     mutations: {
-      PostMessage (state, data) { state.messages.push(data) },
-      PostInvite (state, data) { state.messages.push(data) },
+      // TODO: verify the correctness of 'nextId' in more detail later
+      PostMessage (state, data) { state.messages.push({...data, id: state.nextId++}) },
       AuthorizeSender (state, data) { state.authorizations[AuthorizeSender.authorization.name].data = data.sender }
     }
   })


### PR DESCRIPTION
So there are bugs that were introduced in the Mailbox2 merge. First is the unique message Id needed  to mark as read and delete. The other is more obscure the state object return by the 'toVuexState' share references and will overlap data with anything that performs operation on them. The state object is now cloned before being returned.