### PR TITLE
Remove "Invite Group Members" intermediary button from signup flow (part deux)

### DIFF
--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -188,7 +188,7 @@ import L from '../js/translations'
 export default {
   name: 'CreateGroupView',
   methods: {
-    async submit () {
+    submit: async function () {
       try {
         await this.$validator.validateAll()
       } catch (ex) {

--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -1,11 +1,12 @@
 <template>
-  <section class="section">
+  <section id="create-group-page" class="section">
     <!-- TODO: use Bulma's .field -->
     <!-- TODO: center using .centered like SignUp.vue -->
     <div class="columns">
       <div class="column is-1"></div>
       <div class="column is-10" >
-        <form ref="form"
+        <form
+          ref="form"
           name="CreateGroupForm"
           @submit.prevent="submit"
         >
@@ -43,7 +44,7 @@
               </div>
               <div class="box">
                 <p class="title is-5"><i18n>What percentage of members are required to change the rules?</i18n></p>
-                <p class="title is-3 percentage">{{changePercentage}}%</p>
+                <p class="title is-3 percentage">{{ changePercentage }}%</p>
                 <input
                   type="range"
                   v-validate
@@ -65,7 +66,7 @@
               <p class="title is-4"><i18n>Member relationships</i18n></p>
               <div class="box">
                 <p class="title is-5"><i18n>How many members should it take to approve a new member?</i18n></p>
-                <p class="title is-3">{{memberApprovalPercentage}}%</p>
+                <p class="title is-3">{{ memberApprovalPercentage }}%</p>
                 <input
                   type="range"
                   min="0"
@@ -90,7 +91,7 @@
               </div>
               <div class="box">
                 <p class="title is-5"><i18n>How many members should it take to remove a member?</i18n></p>
-                <p class="title is-3">{{memberRemovalPercentage}}%</p>
+                <p class="title is-3">{{ memberRemovalPercentage }}%</p>
                 <input
                   type="range"
                   min="0"
@@ -160,23 +161,14 @@
                 </i18n>
               </div>
               <div class="has-text-centered button-box">
-                <div id="errorMsg" v-if="errorMsg" class="help is-danger">{{errorMsg}}</div>
-                <div id="successMsg" v-if="created" class="text-message is-success"><i18n>Success</i18n></div>
+                <div id="errorMsg" v-if="errorMsg" class="help is-danger">{{ errorMsg }}</div>
                 <button
                   class="button is-success is-large"
-                  v-if="!created"
                   type="submit"
+                  @click="submit"
                 >
                   <i18n>Create Group</i18n>
                 </button>
-                <a
-                  class="button is-warning is-large"
-                  id="nextButton"
-                  v-if="created"
-                  @click="next"
-                >
-                  <i18n>Next: Invite Group Members</i18n>
-                </a>
               </div>
             </div>
           </div>
@@ -192,49 +184,47 @@ import Vue from 'vue'
 import backend from '../js/backend'
 import * as Events from '../../../shared/events'
 import L from '../js/translations'
+
 export default {
   name: 'CreateGroupView',
   methods: {
-    next () {
-      this.$router.push({path: '/invite'})
-    },
     async submit () {
-      let success
       try {
-        success = await this.$validator.validateAll()
+        await this.$validator.validateAll()
       } catch (ex) {
-        const firsErr = document.querySelector('span.help.is-danger')
-        const control = firsErr.dataset.control
-        const ctrlEl = document.querySelector(`input[name="${control}"], textarea[name="${control}"]`)
-        ctrlEl.focus()
-        ctrlEl.scrollIntoView()
+        const { control } = document.querySelector('span.help.is-danger').dataset
+        document
+          .querySelector(`input[name="${control}"], textarea[name="${control}"]`)
+          .focus()
+          .scrollIntoView()
+        return
       }
 
-      if (success) {
-        try {
-          this.errorMsg = null
-          let entry = new Events.GroupContract({
-            authorizations: [Events.CanModifyAuths.dummyAuth()],
-            groupName: this.groupName,
-            sharedValues: this.sharedValues,
-            changePercentage: this.changePercentage,
-            memberApprovalPercentage: this.memberApprovalPercentage,
-            memberRemovalPercentage: this.memberRemovalPercentage,
-            incomeProvided: this.incomeProvided,
-            contributionPrivacy: this.contributionPrivacy,
-            founderUsername: this.$store.state.loggedIn
-          })
-          let hash = entry.toHash()
-          await backend.subscribe(hash)
-          Vue.events.$once(hash, (contractId, entry) => {
-            this.$store.commit('setCurrentGroupId', hash)
-          })
-          await backend.publishLogEntry(hash, entry)
-          this.created = true
-        } catch (ex) {
-          console.log(ex)
-          this.errorMsg = L('Failed to Create Group')
-        }
+      try {
+        this.errorMsg = null
+        const entry = new Events.GroupContract({
+          authorizations: [Events.CanModifyAuths.dummyAuth()],
+          groupName: this.groupName,
+          sharedValues: this.sharedValues,
+          changePercentage: this.changePercentage,
+          memberApprovalPercentage: this.memberApprovalPercentage,
+          memberRemovalPercentage: this.memberRemovalPercentage,
+          incomeProvided: this.incomeProvided,
+          contributionPrivacy: this.contributionPrivacy,
+          founderUsername: this.$store.state.loggedIn
+        })
+        const hash = entry.toHash()
+        await backend.subscribe(hash)
+        Vue.events.$once(hash, (contractId, entry) => {
+          this.$store.commit('setCurrentGroupId', hash)
+        })
+        await backend.publishLogEntry(hash, entry)
+
+        // Take them to the invite group members page.
+        this.$router.push({path: '/invite'})
+      } catch (error) {
+        console.error(error)
+        this.errorMsg = L('Failed to Create Group')
       }
     }
   },
@@ -247,7 +237,6 @@ export default {
       memberRemovalPercentage: 80,
       incomeProvided: null,
       contributionPrivacy: 'Very Private',
-      created: false,
       errorMsg: null,
       // this determines whether or not to render proxy components for nightmare
       dev: process.env.NODE_ENV === 'development'

--- a/test/frontend.js
+++ b/test/frontend.js
@@ -53,7 +53,7 @@ describe('Frontend', function () {
 
   describe('Event Log Test', function () {
     it('Should Append to the log', async function () {
-      this.timeout(4000) // this one takes a while for some reason
+      this.timeout(5000) // this one takes a while for some reason
       await n.goto(page('event-log'))
         .should.finally.containEql({ code: 200, url: page('event-log') })
       const result = await n.wait('#random').evaluate(() => ({
@@ -173,19 +173,20 @@ describe('Frontend', function () {
     })
 
     it('Should create a group', async function () {
-      this.timeout(6000)
+      this.timeout(10000)
       await n.click('#CreateGroup')
       const created = await n
         .insert('input[name="groupName"]', 'Test Group')
         .insert('textarea[name="sharedValues"]', 'Testing this software')
         .insert('input[name="groupName"]', 'Test Group')
-        .insert('input[name="incomeProvided"]', '200')
-        .insert('input[name="proxyChangePercentage"]', '75')
-        .insert('input[name="proxyMemberApprovalPercentage"]', '75')
-        .insert('input[name="proxyMemberRemovalPercentage"]', '75')
+        .insert('input[name="incomeProvided"]', 200)
+        // .insert('input[name="proxyChangePercentage"]', 75)
+        // .insert('input[name="proxyMemberApprovalPercentage"]', 75)
+        // .insert('input[name="proxyMemberRemovalPercentage"]', 75)
         .select('select[name="contributionPrivacy"]', 'Very Private')
         .click('button[type="submit"]')
         // Should get to invite page:
+        .wait(500)
         .wait(() => !!document.getElementById('addButton'))
         .evaluate(() => !!document.getElementById('addButton'))
       should(created).equal(true)
@@ -193,10 +194,6 @@ describe('Frontend', function () {
 
     it('Should invite members to group', async function () {
       this.timeout(4000)
-
-      await n
-        .click('#nextButton')
-        .wait(() => Boolean(document.querySelector('#addButton')))
 
       const count = await n
         .wait(() => Boolean(document.querySelector('#addButton')))

--- a/test/frontend.js
+++ b/test/frontend.js
@@ -185,8 +185,9 @@ describe('Frontend', function () {
         .insert('input[name="proxyMemberRemovalPercentage"]', '75')
         .select('select[name="contributionPrivacy"]', 'Very Private')
         .click('button[type="submit"]')
-        .wait(() => !!document.getElementById('successMsg'))
-        .evaluate(() => !!document.getElementById('successMsg'))
+        // Should get to invite page:
+        .wait(() => !!document.getElementById('addButton'))
+        .evaluate(() => !!document.getElementById('addButton'))
       should(created).equal(true)
     })
 

--- a/test/frontend.js
+++ b/test/frontend.js
@@ -19,6 +19,7 @@ describe('Frontend', function () {
     show: !!process.env.SHOW_BROWSER,
     height: 900
   })
+
   after(() => { n.end() })
 
   it('Should start the backend server if necessary', function () {
@@ -26,6 +27,7 @@ describe('Frontend', function () {
   })
   let randInt = (min, max) => Math.floor(Math.random() * (max - min)) + min
   let username = `testuser${randInt(0, 10000000)}${randInt(10000000, 20000000)}`
+
   describe.skip('New user page', function () {
     it('Should create user George', function () {
       this.timeout(5000)
@@ -48,18 +50,19 @@ describe('Frontend', function () {
         .wait(() => document.getElementById('serverMsg').className.indexOf('danger') !== -1)
     })
   })
+
   describe('Event Log Test', function () {
     it('Should Append to the log', async function () {
       this.timeout(4000) // this one takes a while for some reason
       await n.goto(page('event-log'))
         .should.finally.containEql({ code: 200, url: page('event-log') })
-      let result = await n.wait('#random').evaluate(() => ({
+      const result = await n.wait('#random').evaluate(() => ({
         current: document.getElementById('LogPosition').innerText,
         eventCount: document.querySelectorAll('.event').length
       }))
       await n.click('#random')
         .wait(() => +document.getElementById('count').innerText > 0)
-      let obj = await n.insert('textarea[name="payload"]', 'This is a test payment event')
+      const obj = await n.insert('textarea[name="payload"]', 'This is a test payment event')
         .select('select[name="type"]', 'Payment')
         .click('#submit')
         .wait(() => +document.getElementById('count').innerText > 1)
@@ -70,22 +73,23 @@ describe('Frontend', function () {
       should(obj.eventCount).equal(result.eventCount + 2)
       should(obj.current !== result.current).equal(true)
     })
+
     // TODO: restore this based on the new TimeTravel
     it.skip('Should Traverse Log', async function () {
       this.timeout(4000)
       await n.goto(page('event-log'))
-      let prior = await n.evaluate(() => document.getElementById('LogPosition').innerText)
-      let initial = await n.wait('textarea[name="payload"]')
+      const prior = await n.evaluate(() => document.getElementById('LogPosition').innerText)
+      const initial = await n.wait('textarea[name="payload"]')
         .insert('textarea[name="payload"]', 'This is a test Group Payment Event')
         .select('select[name="type"]', 'Payment')
         .click('#submit')
         .wait(prior => document.getElementById('LogPosition').innerText !== prior, prior)
         .evaluate(() => document.getElementById('LogPosition').innerText)
-      let secondary = await n.click('a.backward')
+      const secondary = await n.click('a.backward')
         .wait(initial => document.getElementById('LogPosition').innerText !== initial, initial)
         .evaluate(() => document.getElementById('LogPosition').innerText)
       should(initial !== secondary).equal(true)
-      let tertiary = await n.click('a.forward')
+      const tertiary = await n.click('a.forward')
         .wait(secondary => document.getElementById('LogPosition').innerText !== secondary, secondary)
         .evaluate(() => document.getElementById('LogPosition').innerText)
       should(initial).equal(tertiary)
@@ -97,7 +101,7 @@ describe('Frontend', function () {
       this.timeout(4000)
       await n.goto(page('signup'))
         .wait('#name')
-      let signedup = await n.insert('#name', username)
+      const signedup = await n.insert('#name', username)
         .insert('#email', `test@testgroupincome.com`)
         .insert('#password', 'testtest')
         .click('button[type="submit"]')
@@ -113,9 +117,10 @@ describe('Frontend', function () {
         !document.getElementById('password').innerText)
         */
     })
+
     it('Test Logout and Login', async function () {
       this.timeout(4000)
-      let response = await n.click('#LoginBtn')
+      const response = await n.click('#LoginBtn')
         .wait(() => document.getElementById('LoginBtn').classList.contains('is-primary'))
         .click('#LoginBtn')
         .wait(() => document.getElementById('LoginModal').classList.contains('is-active'))
@@ -126,6 +131,7 @@ describe('Frontend', function () {
         .evaluate(() => document.getElementById('LoginResponse').innerText)
       should(response).not.equal('Invalid username or password')
     })
+
     /* There appears to be a bug in nightmare that causes the insert and type commands to enter old data into the field if the
     insert or type commands or used more than once on the same field. This concatenates the old values to the new.
      This occurs regardless of whether you clear the field or not. Until its fixed skip this validation test
@@ -133,19 +139,19 @@ describe('Frontend', function () {
     it.skip('Test Validation', async function () {
       this.timeout(4000)
       await n.goto(page('signup'))
-      let badUsername = 't e s t'
-      let badEmail = `@fail`
-      let badPassword = `789`// six is so afraid
-      let denied = await n.insert('#name', badUsername)
+      const badUsername = 't e s t'
+      const badEmail = `@fail`
+      const badPassword = `789`// six is so afraid
+      const denied = await n.insert('#name', badUsername)
         .insert('#email', badEmail)
         .insert('#password', badPassword)
         .evaluate(() => document.querySelector('button[type="submit"]').disabled)
       should(denied).equal(true)
-      let usernameMsg = await n.evaluate(() => !!document.getElementById('badUsername'))
+      const usernameMsg = await n.evaluate(() => !!document.getElementById('badUsername'))
       should(usernameMsg).equal(true)
-      let emailMsg = await n.evaluate(() => !!document.getElementById('badEmail'))
+      const emailMsg = await n.evaluate(() => !!document.getElementById('badEmail'))
       should(emailMsg).equal(true)
-      let passwordMsg = await n.evaluate(() => !!document.getElementById('badPassword'))
+      const passwordMsg = await n.evaluate(() => !!document.getElementById('badPassword'))
       should(passwordMsg).equal(true)
     })
   })
@@ -165,10 +171,12 @@ describe('Frontend', function () {
       .evaluate(() => !!document.getElementById('HomeLogo'))
       should(signedup).equal(true)
     })
+
     it('Should create a group', async function () {
-      this.timeout(4000)
+      this.timeout(6000)
       await n.click('#CreateGroup')
-      let created = await n.insert('input[name="groupName"]', 'Test Group')
+      const created = await n
+        .insert('input[name="groupName"]', 'Test Group')
         .insert('textarea[name="sharedValues"]', 'Testing this software')
         .insert('input[name="groupName"]', 'Test Group')
         .insert('input[name="incomeProvided"]', '200')
@@ -230,24 +238,24 @@ describe('Frontend', function () {
         .wait('#MailboxLink')
         .click('#MailboxLink')
         .wait(300)
-      let alert = await n.evaluate(() => !!document.getElementById('AlertNotification'))
+      const alert = await n.evaluate(() => !!document.getElementById('AlertNotification'))
       should(alert).equal(true)
-      let unread = await n.evaluate(() => +document.querySelector('.unread').innerText)
+      const unread = await n.evaluate(() => +document.querySelector('.unread').innerText)
       should(unread).equal(2)
-      let hasInvite = await n.evaluate(() => !!document.getElementsByClassName('invite-message'))
+      const hasInvite = await n.evaluate(() => !!document.getElementsByClassName('invite-message'))
       should(hasInvite).equal(true)
-      let hasMessage = await n.evaluate(() => !!document.getElementsByClassName('inbox-message'))
+      const hasMessage = await n.evaluate(() => !!document.getElementsByClassName('inbox-message'))
       should(hasMessage).equal(true)
-      unread = await n.click('.invite-message')
+      const newUnread = await n.click('.invite-message')
         .wait(300)
         .evaluate(() => +document.querySelector('.unread').innerText)
-      should(unread).equal(1)
+      should(newUnread).equal(1)
     })
   })
 
   describe('Test Localization Gathering Function', function () {
     it('Verify output of transform functions', function () {
-      let script = `
+      const script = `
         <template>
             <i18n comment = "Amazing Test">A test of sorts</i18n>
             <i18n comment="Amazing Test2">A test of wit</i18n>
@@ -259,13 +267,13 @@ describe('Frontend', function () {
         </script>
 
          `
-      let path = 'script.vue'
+      const path = 'script.vue'
       fs.writeFileSync(path, script)
-      let output = 'translation.json'
-      let args = ['scripts/i18n.js', path, output]
+      const output = 'translation.json'
+      const args = ['scripts/i18n.js', path, output]
       exec('node', args)
-      let json = fs.readFileSync(output, 'utf8')
-      let localeObject = JSON.parse(json)
+      const json = fs.readFileSync(output, 'utf8')
+      const localeObject = JSON.parse(json)
       should(localeObject).have.property('A test of sorts')
       should(localeObject).have.property('A test of wit')
       should(localeObject).have.property('A test of strength')
@@ -300,12 +308,9 @@ function page (page) {
 
 // returns the size of the document
 Nightmare.action('size', function (done) {
-  this.evaluate_now(function () {
-    var w = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
-    var h = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
-    return {
-      height: h,
-      width: w
-    }
+  this.evaluate_now(() => {
+    const width = Math.max(document.documentElement.clientWidth, window.innerWidth || 0)
+    const height = Math.max(document.documentElement.clientHeight, window.innerHeight || 0)
+    return { height, width }
   }, done)
 })


### PR DESCRIPTION
- Remove the "Next" button from the CreateGroup view.
- Simplify some logic
- Use `const` instead of `let` in tests
- Simplify a test helper
- Some whitespace to make differentiating blocks easier