### PR TITLE
Fix group creation link in navbar

### DIFF
--- a/frontend/simple/views/NavBar.vue
+++ b/frontend/simple/views/NavBar.vue
@@ -15,7 +15,9 @@
             class="nav-item is-tab"
             id="CreateGroup"
             to="new-group"
+            v-if="$store.state.loggedIn"
           >
+            <i18n>Start a Group</i18n>
           </router-link>
           <router-link
             active-class="is-active"

--- a/frontend/simple/views/NavBar.vue
+++ b/frontend/simple/views/NavBar.vue
@@ -23,7 +23,7 @@
             active-class="is-active"
             class="nav-item is-tab"
             to="pay-group"
-            v-show="$store.state.loggedIn"
+            v-if="$store.state.loggedIn"
           >
             <i18n>Pay Group</i18n>
           </router-link>


### PR DESCRIPTION
at some point poor "Start a Group" link got removed, then put back halfway without a text. it might be useful to be able to reach the current group creation page even while I'm working on the new one for #311 , so I put this in a separate PR