### PR TITLE
Rename Rules step in Group Creation

### DIFF
--- a/frontend/simple/components/CreateGroup/CreateGroupRules.vue
+++ b/frontend/simple/components/CreateGroup/CreateGroupRules.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="rulesStep" class="has-text-centered">
-    <h1 class="title is-2"><i18n>Group Advanced Rules</i18n></h1>
+    <h1 class="title is-2"><i18n>Voting Rules</i18n></h1>
     <p class="content"><i18n>What percentage approval is necessary to adjust the group rules?</i18n></p>
     <div class="columns">
       <div class="column">


### PR DESCRIPTION
based on [this comment](https://github.com/okTurtles/group-income-simple/pull/338#issuecomment-357874124):

"The only suggestion I have is changing the title of "Group Advanced Rules" to "Voting Rules". But maybe let's leave that for a future PR? "