### PR TITLE
add colors to docker-compose output

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,4 @@ services:
       - "35729:35729" # livereload
     volumes:
       - .:/opt
+    tty: true


### PR DESCRIPTION
I missed the colors from the `docker-compose up` output, this gave them back 