### PR TITLE
fix: Create Group - Voting Rules - force new tab open on 'majority rule" link click

### DIFF
--- a/frontend/simple/components/CreateGroup/CreateGroupRules.vue
+++ b/frontend/simple/components/CreateGroup/CreateGroupRules.vue
@@ -67,7 +67,7 @@
           <i18n>The percentage value you are choosing is most likely too low
           for a decision that can have a potentially significant impact
           on a person’s life. Please consider using a supermajority threshold.</i18n>
-          <a href="https://groupincome.org/2016/09/deprecating-mays-theorem/#when-majority-rule-can-harm">
+          <a href="https://groupincome.org/2016/09/deprecating-mays-theorem/#when-majority-rule-can-harm" target="_blank">
             <i18n>Read more on our blog about the dangers of majority rule.</i18n>
           </a>
         </div>


### PR DESCRIPTION
**Problem**
While creating a new group, when user clicks on _"majority rule_" link it loads the new page on the same tab and the user might dropout/lose its progress on the task.

**Solution**
Add `target="_blank"` to the link, so on the click a new tab is opened and group income page persists in its own tab reducing the risk of the user dropout the task before it's done.