### PR TITLE
#362 - Uniform way of target elements on FE tests

### DIFF
--- a/frontend/simple/components/CreateGroup/CreateGroupInvitees.vue
+++ b/frontend/simple/components/CreateGroup/CreateGroupInvitees.vue
@@ -8,6 +8,7 @@
           placeholder="Username"
           name="invitee"
           type="text"
+          data-test="inputInvitee"
           v-model="searchUser"
           ref="searchUser"
           @keyup.enter="addInvitee"
@@ -15,8 +16,8 @@
       </div>
       <div class="control">
         <button
-          id="addButton"
           class="button is-primary is-large"
+          data-test="addButton"
           @click="addInvitee"
         >
           <i18n>Add</i18n>
@@ -33,7 +34,10 @@
     </article>
 
     <div class="tile is-ancestor">
-      <div class="tile is-4 is-parent invitee" v-for="(invitee, index) in invitees">
+      <div class="tile is-4 is-parent invitee"
+        data-test="inviteeContainer"
+        v-for="(invitee, index) in invitees"
+      >
         <div class="card tile is-child">
           <div class="card-image">
             <figure class="image is-square">

--- a/frontend/simple/components/CreateGroup/CreateGroupName.vue
+++ b/frontend/simple/components/CreateGroup/CreateGroupName.vue
@@ -12,6 +12,7 @@
           :value="group.groupName"
           @input="update"
           ref="name"
+          data-test="groupName"
         >
       </div>
     </div>

--- a/frontend/simple/components/CreateGroup/CreateGroupPrivacy.vue
+++ b/frontend/simple/components/CreateGroup/CreateGroupPrivacy.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <h1 id="privacyStep" class="title is-2 has-text-centered"><i18n>Privacy Settings</i18n></h1>
+    <h1 class="title is-2 has-text-centered" data-test="privacyStep">
+      <i18n>Privacy Settings</i18n>
+    </h1>
     <p><i18n>This step is to be designed. What group privacy settings would you feel more comfortable having control over? Let us know at dunno@groupincome.org!</i18n></p>
   </div>
 </template>

--- a/frontend/simple/components/CreateGroup/CreateGroupRules.vue
+++ b/frontend/simple/components/CreateGroup/CreateGroupRules.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="rulesStep" class="has-text-centered">
+  <div class="rulesStep has-text-centered" data-test="rulesStep">
     <h1 class="title is-2"><i18n>Voting Rules</i18n></h1>
     <p class="content"><i18n>What percentage approval is necessary to adjust the group rules?</i18n></p>
     <div class="columns">
@@ -100,7 +100,7 @@
     margin-top: 2rem;
   }
 
-  #rulesStep .message-body {
+  .rulesStep .message-body {
     border-color: #f68b39;
   }
 

--- a/frontend/simple/components/CreateGroup/CreateGroupSummary.vue
+++ b/frontend/simple/components/CreateGroup/CreateGroupSummary.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <h1 id="summaryStep" class="title is-1 has-text-centered"><i18n>Review & Finish</i18n></h1>
+    <h1 class="title is-1 has-text-centered" data-test="summaryStep">
+      <i18n>Review & Finish</i18n>
+    </h1>
 
     <h2 class="title is-6"><i18n>Group name:</i18n></h2>
     <p class="subtitle is-2" v-if="group.groupName">{{ group.groupName }}</p>

--- a/frontend/simple/components/GroupSettings.vue
+++ b/frontend/simple/components/GroupSettings.vue
@@ -4,17 +4,17 @@
     <h3 class="title is-3"><i18n>Current Settings</i18n></h3>
     <div class="columns has-text-centered">
       <div class="column is-4">
-        <p id="changePercentage" class="settings-number">{{ group.changePercentage }}%</p>
+        <p class="settings-number" data-test="changePercentage">{{ group.changePercentage }}%</p>
         <p class="settings-label">Change Rules</p>
         <a href="#">Propose change</a>
       </div>
       <div class="column is-4">
-        <p id="approvePercentage" class="settings-number">{{ group.memberApprovalPercentage }}%</p>
+        <p class="settings-number" data-test="approvePercentage">{{ group.memberApprovalPercentage }}%</p>
         <p class="settings-label">Add Member</p>
         <a href="#">Propose change</a>
       </div>
       <div class="column is-4">
-        <p id="removePercentage" class="settings-number">{{ group.memberRemovalPercentage }}%</p>
+        <p class="settings-number" data-test="removePercentage">{{ group.memberRemovalPercentage }}%</p>
         <p class="settings-label">Remove Member</p>
         <a href="#">Propose change</a>
       </div>
@@ -37,10 +37,10 @@
 
 </style>
 <script>
-  export default {
-    name: 'GroupSettings',
-    props: {
-      group: Object
-    }
+export default {
+  name: 'GroupSettings',
+  props: {
+    group: Object
   }
+}
 </script>

--- a/frontend/simple/components/GroupsMinIncome.vue
+++ b/frontend/simple/components/GroupsMinIncome.vue
@@ -1,7 +1,10 @@
 <template>
   <section class="has-text-right">
     <p class="min-income-label">Min Income</p>
-    <p class="min-income">{{ currency }}{{ group.incomeProvided }}</p>
+    <p class="min-income"
+      data-test="minIncome">
+      {{ currency }}{{ group.incomeProvided }}
+    </p>
     <a href="#">Propose change</a>
   </section>
 </template>

--- a/frontend/simple/components/login-modal.vue
+++ b/frontend/simple/components/login-modal.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="modal is-active" ref="modal" id="LoginModal">
+  <div class="modal is-active"
+    ref="modal"
+    data-test="loginModal"
+  >
     <div class="modal-background" @click="close"></div>
     <div class="modal-content" style="width: 300px;">
       <div class="card is-rounded">
@@ -18,6 +21,7 @@
                 placeholder="username"
                 ref="username"
                 autofocus
+                data-test="loginName"
               >
               <span class="icon">
                 <i class="fa fa-user"></i>
@@ -37,19 +41,25 @@
                 @input="$v.form.password.$touch()"
                 placeholder="password"
                 type="password"
+                data-test="loginPassword"
               >
               <span class="icon"><i class="fa fa-lock"></i></span>
             </p>
             <i18n v-show="$v.form.password.$error" class="help is-danger">password must be at least 7 characters</i18n>
           </div>
-          <p class="help is-danger" id="LoginResponse" v-show="form.response">{{ form.response }}</p>
+          <p class="help is-danger"
+            v-show="form.response"
+            data-test="loginResponse"
+          >
+            {{ form.response }}
+          </p>
           <div class="field">
             <p class="control">
               <button
                 class="button is-primary is-medium is-fullwidth"
                 @click="login"
                 :disabled="$v.form.$invalid"
-                id="LoginButton"
+                data-test="loginSubmit"
               >
                 <span class="icon"><i class="fa fa-user"></i></span>
                 <i18n>Login</i18n>

--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -13,8 +13,8 @@
             <button
               class="button is-success is-large"
               @click="next"
-              id="nextBtn"
               :disabled="$v.steps[$route.name] && $v.steps[$route.name].$invalid"
+              data-test="nextBtn"
             >
               <i18n>Next</i18n>
               <span class="icon">
@@ -27,7 +27,7 @@
               class="button is-success is-large"
               @click="submit"
               :disabled="$v.form.$invalid"
-              id="finishBtn"
+              data-test="finishBtn"
             >
               <i18n>Finish</i18n>
               <span class="icon">
@@ -40,7 +40,7 @@
               class="button is-light is-large"
               @click="prev"
               :disabled="!this.currentStep"
-              id="prevBtn"
+              data-test="prevBtn"
             >
               <i18n>Back</i18n>
             </button>

--- a/frontend/simple/views/GroupDashboard.vue
+++ b/frontend/simple/views/GroupDashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <section id="dashboard" class="container section">
+  <section class="container section" data-test="dashboard">
     <div class="columns">
 
       <div class="column is-2">
@@ -14,8 +14,12 @@
           <groups-min-income :group="currentGroupState" />
         </div>
 
-        <h1 id="groupName" class="title is-1">{{ currentGroupState.groupName }}</h1>
-        <p id="sharedValues">{{ currentGroupState.sharedValues }}</p>
+        <h1 class="title is-1" data-test="groupName">
+          {{ currentGroupState.groupName }}
+        </h1>
+        <p data-test="sharedValues">
+          {{ currentGroupState.sharedValues }}
+        </p>
 
         <voting-banner class="widget"
           who="Sam"

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -1,6 +1,6 @@
 <template>
     <section class="section full-screen">
-      <div id="HomeLogo" class="centered" style="text-align: center;">
+      <div class="centered" style="text-align: center;" data-test="homeLogo">
         <img style="width: 160px; height: 160px;" src="images/group-income-icon-transparent.png">
         <br>
         <div style="display: block; margin-top: 45px;" class="title foco-font"><i18n>Welcome to GroupIncome</i18n></div>

--- a/frontend/simple/views/Invite.vue
+++ b/frontend/simple/views/Invite.vue
@@ -9,14 +9,17 @@
               <input
                       autofocus
                       class="input is-medium"
-                      id="searchUser"
                       placeholder="Add a new member by username"
                       type="text"
                       v-model="searchUser"
+                      data-test="searchUser"
               >
             </p>
             <p class="control">
-              <a id="addButton" class="button is-info is-medium" @click="add">
+              <a class="button is-info is-medium"
+                data-test="addButton"
+                @click="add"
+              >
                 <i18n>Add member</i18n>
               </a>
             </p>
@@ -29,9 +32,9 @@
     <div class="columns">
       <div class="column is-6 is-offset-3" >
 
-        <p
-                class="notification is-success has-text-centered"
-                v-if="invited"
+        <p  class="notification is-success has-text-centered"
+          data-test="notifyInvitedSuccess"
+          v-if="invited"
         >
           <i class='notification-icon fa fa-check'></i>
           <i18n>Members invited successfully!</i18n>
@@ -47,7 +50,9 @@
           </tr>
           </thead>
           <tbody>
-          <tr v-for="(member, index) in members" class="member">
+          <tr class="member"
+            data-test="member"
+            v-for="(member, index) in members">
             <td>
               <div class="media">
                 <div class="media-left">
@@ -62,7 +67,9 @@
                   <strong>{{member.state.attributes.name}}</strong>
                 </div>
                 <div class="media-right">
-                  <button class="delete" @click="remove(index)"></button>
+                  <button class="delete"
+                    @click="remove(index)"
+                    data-test="deleteMember"></button>
                 </div>
               </div>
             </td>
@@ -72,10 +79,11 @@
 
         <div class="has-text-centered">
           <button
-                  class="button is-success is-large"
-                  type="submit"
-                  v-if="members.length"
-                  @click="submit"
+            class="button is-success is-large"
+            type="submit"
+            v-if="members.length"
+            @click="submit"
+            data-test="submit"
           >
             <i18n>Send Invites</i18n>
           </button>

--- a/frontend/simple/views/Join.vue
+++ b/frontend/simple/views/Join.vue
@@ -18,7 +18,19 @@
               </table>
               <div class="panel-block center" style="display: block; text-align: center;">
                 <div id="errorMsg" v-if="errorMsg" class="help is-danger">{{errorMsg}}</div>
-                <a id="AcceptLink" class="button is-success is-large" v-on:click="accept" style="margin-left:auto; margin-right: 20px;"><i18n>Accept</i18n></a><a id="DeclineLink" class="button is-danger is-large" v-on:click="decline" style="margin-right:auto; margin-right: 20px;"><i18n>Decline</i18n></a>
+                <a data-test="acceptLink"
+                  class="button is-success is-large"
+                  v-on:click="accept"
+                  style="margin-left:auto; margin-right: 20px;"
+                >
+                  <i18n>Accept</i18n>
+                </a>
+                <a id="DeclineLink"
+                  class="button is-danger is-large"
+                  v-on:click="decline"
+                  style="margin-right:auto; margin-right: 20px;">
+                  <i18n>Decline</i18n>
+                </a>
               </div>
             </div>
           </div>

--- a/frontend/simple/views/Mailbox.vue
+++ b/frontend/simple/views/Mailbox.vue
@@ -11,13 +11,20 @@
               <span class="panel-icon">
                 <i class="fa fa-pencil"></i>
               </span>
-              <a id="ComposeLink" v-on:click="compose"><i18n>compose</i18n></a>
+              <a data-test="composeLink" v-on:click="compose"><i18n>compose</i18n></a>
             </div>
             <div class="panel-block">
               <span class="panel-icon">
                 <i class="fa fa-envelope"></i>
               </span>
-              <a id="InboxLink" v-on:click="inboxMode"><i18n>inbox</i18n> <span class="unread" v-if="$store.getters.unreadMessageCount">{{$store.getters.unreadMessageCount}}</span></a>
+              <a data-test="inboxLink" v-on:click="inboxMode"><i18n>inbox</i18n>
+                <span class="unread"
+                  data-test="inboxUnread"
+                  v-if="$store.getters.unreadMessageCount"
+                >
+                  {{$store.getters.unreadMessageCount}}
+                </span>
+              </a>
             </div>
           </div>
         </div>
@@ -27,7 +34,13 @@
             <div class="panel-heading">
               <div><strong><i18n>Type</i18n>:</strong>&nbsp;<i18n>Message</i18n></div>
               <div><strong style="margin-top: auto;"><i18n>To</i18n>:</strong>&nbsp;
-                <input id="AddRecipient" class="input is-small" type="text" style="width: 80%;" v-model="recipient" v-on:blur="addRecipient">
+                <input id="AddRecipient"
+                  class="input is-small"
+                  type="text"
+                  style="width: 80%;"
+                  data-test="addRecipient"
+                  v-model="recipient"
+                  v-on:blur="addRecipient">
                 <a class="button is-small" v-on:click="addRecipient">
                   <span class="icon is-small">
                     <i class="fa fa-plus-circle"></i>
@@ -45,11 +58,11 @@
               </table>
             </div>
             <div class="panel-block">
-              <textarea id="ComposedMessage" class="textarea" v-model="composedMessage"></textarea>
+              <textarea class="textarea" data-test="composedMessage" v-model="composedMessage"></textarea>
             </div>
             <div class="panel-block" >
               <div id="errorMsg" v-if="errorMsg" class="help is-danger">{{errorMsg}}</div>
-              <button id="SendButton" class="button is-success" type="submit" v-on:click="send" :disabled="!composedMessage"  style="margin-left:auto; margin-right: 0;"><i18n>Send</i18n></button>
+              <button class="button is-success" type="submit" data-test="sendButton" v-on:click="send" :disabled="!composedMessage"  style="margin-left:auto; margin-right: 0;"><i18n>Send</i18n></button>
               <button class="button is-danger" type="submit" v-on:click="cancel" style="margin-left:10px; margin-right: 0;"><i18n>Cancel</i18n></button>
             </div>
           </div>
@@ -60,7 +73,13 @@
               <div><strong>From:</strong>&nbsp;{{currentMessage.data.from}}</div>
             </div>
             <p class="panel-block" v-if="currentMessage.data.messageType === 'Message'" style="display: block; word-wrap: break-word;">{{currentMessage.data.message}}</p>
-            <p class="panel-block" v-if="currentMessage.data.messageType === 'Invite'"><router-link id="InviteLink" v-bind:to="{ path: '/join', query: { groupId: currentMessage.data.headers[0], inviteHash: currentMessage.hash} }" ><i18n>Respond to Invite</i18n></router-link></p>
+            <p class="panel-block" v-if="currentMessage.data.messageType === 'Invite'">
+              <router-link data-test="inviteLink"
+                v-bind:to="{ path: '/join', query: { groupId: currentMessage.data.headers[0], inviteHash: currentMessage.hash} }"
+              >
+                <i18n>Respond to Invite</i18n>
+              </router-link>
+            </p>
 
             <div class="panel-block" >
               <button class="button is-danger" v-if="currentMessage.data.messageType === 'Message'" type="submit" style="margin-left:auto; margin-right: 0;" v-on:click="remove(index)"><i18n>Delete</i18n></button>
@@ -83,7 +102,9 @@
                       <img src="images/128x128.png">
                     </p>
                   </div>
-                  <div class="media-content proposal-message" v-on:click="respondToProposal(index)">
+                  <div class="media-content proposal-message"
+                    data-test="proposalMessage"
+                    v-on:click="respondToProposal(index)">
                     <div><strong>Sent:</strong>&nbsp;{{formatDate(proposal.initiationDate)}}</div>
                     <div><strong>From:</strong>&nbsp;{{proposal.groupName}}</div>
                   </div>
@@ -108,7 +129,9 @@
                       <img src="images/default-avatar.png">
                     </p>
                   </div>
-                  <div class="media-content invite-message" v-on:click="read({index, type: message.data.messageType})">
+                  <div class="media-content invite-message"
+                    data-test="inviteMessage"
+                    v-on:click="read({index, type: message.data.messageType})">
                     <div><strong>Sent:</strong>&nbsp;{{formatDate(message.data.sentDate)}}</div>
                     <div><strong>From:</strong>&nbsp;{{message.data.from}}</div>
                   </div>
@@ -117,7 +140,9 @@
             </tr>
             </tbody>
           </table>
-          <table id="Inbox" class="table is-bordered is-striped is-narrow" v-if="(mode === 'Inbox')">
+          <table class="table is-bordered is-striped is-narrow"
+            data-test="inbox"
+            v-if="(mode === 'Inbox')">
             <thead>
             <tr>
               <th><i18n>Inbox</i18n></th>
@@ -132,7 +157,10 @@
                       <img src="images/default-avatar.png">
                     </p>
                   </div>
-                  <div class="media-content inbox-message" v-on:click="read({index, type: message.data.messageType})">
+                  <div class="media-content inbox-message"
+                    data-test="inboxMessage"
+                    v-on:click="read({index, type: message.data.messageType})"
+                  >
                     <div><strong>Sent:</strong>&nbsp;{{formatDate(message.data.sentDate)}}</div>
                     <div><strong>From:</strong>&nbsp;{{message.data.from}}</div>
                     <span style="color: grey;">{{message.data.message.substr(0,50)}}{{message.data.message.length > 50 ? '...' : ''}} </span>

--- a/frontend/simple/views/NavBar.vue
+++ b/frontend/simple/views/NavBar.vue
@@ -13,9 +13,9 @@
           <router-link
             active-class="is-active"
             class="nav-item is-tab"
-            id="CreateGroup"
             to="new-group"
             v-if="$store.state.loggedIn"
+            data-test="createGroup"
           >
             <i18n>Start a Group</i18n>
           </router-link>
@@ -30,15 +30,15 @@
           <router-link
             active-class ="is-active"
             class="nav-item"
-            id="MailboxLink"
             to="mailbox"
+            data-test="mailboxLink"
             v-if="$store.state.loggedIn"
           >
             <i18n>Inbox</i18n>
             <span
-              id="AlertNotification"
               class="icon"
               style="color: #ed6c63;"
+              data-test="alertNotification"
               v-if="$store.getters.unreadMessageCount || $store.getters.proposals.length"
             >
               <i class="fa fa-bell"></i>
@@ -49,24 +49,26 @@
           <span class="nav-item control">
             <router-link
               class="button is-success"
-              id="SignupBtn"
               style="margin-right: 15px;"
               to="signup"
               v-if="!$store.state.loggedIn"
+              data-test="signupBtn"
             >
               <i18n>Sign Up</i18n>
             </router-link>
             <a
               class="button is-primary"
               href="#"
-              id="LoginBtn"
               v-if="!$store.state.loggedIn"
               @click.prevent="showLoginModal"
+              data-test="loginBtn"
             >
               <i18n>Login</i18n>
             </a>
 
-            <div class="button profile-link" id="OpenProfileDropDown" v-if="$store.state.loggedIn" @click="toggleDropdown">
+            <div class="button profile-link"
+              data-test="openProfileDropDown"
+              v-if="$store.state.loggedIn" @click="toggleDropdown">
               <strong>{{ ($store.getters.currentUserIdentityContract && $store.getters.currentUserIdentityContract.attributes && $store.getters.currentUserIdentityContract.attributes.displayName ? $store.getters.currentUserIdentityContract.attributes.displayName : null) || $store.state.loggedIn.name}}</strong>
               <img v-if="$store.getters.currentUserIdentityContract && $store.getters.currentUserIdentityContract.attributes && $store.getters.currentUserIdentityContract.attributes.picture" v-bind:src="$store.getters.currentUserIdentityContract.attributes.picture">
               <i class="fa fa-caret-down" style="color: #d8d8d8;" aria-hidden="true"></i>
@@ -80,10 +82,10 @@
             <i class="fa fa-caret-down" style="color: #d8d8d8;" aria-hidden="true"></i>
           </div>
           <router-link
-            id="ProfileLink"
             class="nav-item is-tab"
             active-class="is-active"
             to="user"
+            data-test="profileLink"
             v-show="$store.state.loggedIn"
           >
             <i18n>Profile</i18n>
@@ -91,9 +93,9 @@
           <a
             class="is-danger"
             href="#"
-            id="LogoutBtn"
             v-if="$store.state.loggedIn"
             @click.prevent="logout"
+            data-test="logoutBtn"
           >
             <i18n>Signout</i18n>
           </a>

--- a/frontend/simple/views/ProposeMember.vue
+++ b/frontend/simple/views/ProposeMember.vue
@@ -8,14 +8,16 @@
                 <input
                   autofocus
                   class="input is-medium"
-                  id="searchUser"
                   placeholder="Propose a new member by username"
                   type="text"
                   v-model="searchUser"
+                  data-test="searchUser"
                 >
               </p>
               <p class="control">
-                <a id="ProposeButton" class="button is-info is-medium" @click="submit">
+                <a class="button is-info is-medium"
+                  data-test="proposeButton"
+                  @click="submit">
                   <i18n>Propose Member</i18n>
                 </a>
               </p>
@@ -26,9 +28,9 @@
     </div>
     <div class="columns">
       <div class="column is-6 is-offset-3" >
-        <p
-                class="notification is-success has-text-centered"
-                v-if="proposed"
+        <p class="notification is-success has-text-centered"
+          data-test="notifyProposedSuccess"
+          v-if="proposed"
         >
           <i class='notification-icon fa fa-check'></i>
           <i18n>Member proposed successfully!</i18n>

--- a/frontend/simple/views/SignUp.vue
+++ b/frontend/simple/views/SignUp.vue
@@ -7,7 +7,9 @@
      .block      base/classes.sass (just adds 20px margin-bottom except for last)
      -->
     <form novalidate ref="form"
-      name="formData" class="container signup"
+      name="formData"
+      class="container signup"
+      data-test="signup"
       @submit.prevent="submit"
     >
       <div class="box centered" style="max-width:400px;">
@@ -33,10 +35,14 @@
               @input="debounceName"
               placeholder="username"
               autofocus
+              data-test="signName"
             >
             <span class="icon"><i class="fa fa-user"></i></span>
           </p>
-          <p class="help is-danger" v-if="$v.form.name.$error" id="badUsername">
+          <p class="help is-danger"
+            data-test="badUsername"
+            v-if="$v.form.name.$error"
+          >
             <i18n v-if="!$v.form.name.isAvailable">name is unavailable</i18n>
             <i18n v-if="!$v.form.name.nonWhitespace">cannot contain spaces</i18n>
           </p>
@@ -52,10 +58,11 @@
               @blur="$v.form.email.$touch()"
               type="email"
               placeholder="email"
+              data-test="signEmail"
             >
             <span class="icon"><i class="fa fa-envelope"></i></span>
           </p>
-          <i18n v-if="$v.form.email.$error" id="badEmail" class="help is-danger">not an email</i18n>
+          <i18n v-if="$v.form.email.$error" class="help is-danger" data-test="badEmail">not an email</i18n>
         </div>
         <div class="field">
           <p class="control has-icon">
@@ -68,15 +75,19 @@
               @input="$v.form.password.$touch()"
               placeholder="password"
               type="password"
+              data-test="signPassword"
             >
             <span class="icon"><i class="fa fa-lock"></i></span>
           </p>
-          <i18n v-if="$v.form.password.$error" id="badPassword" class="help is-danger">password must be at least 7 characters</i18n>
+          <i18n v-if="$v.form.password.$error" class="help is-danger" data-test="badPassword">password must be at least 7 characters</i18n>
         </div>
         <div class="level is-mobile">
           <div class="level-left">
             <div class="level-item content is-small">
-              <span id="serverMsg" class="help is-marginless" :class="[form.error ? 'is-danger' : 'is-success']">
+              <span class="help is-marginless"
+                :class="[form.error ? 'is-danger' : 'is-success']"
+                data-test="serverMsg"
+              >
                 {{form.response}}
               </span>
             </div>
@@ -87,6 +98,7 @@
                 class="button submit is-success"
                 type="submit"
                 :disabled="$v.form.$invalid"
+                data-test="signSubmit"
               >
                 <i18n>Sign Up</i18n>
               </button>

--- a/frontend/simple/views/UserProfileView.vue
+++ b/frontend/simple/views/UserProfileView.vue
@@ -10,7 +10,7 @@
           <p
             class="notification is-success has-text-centered"
             v-if="profileSaved"
-            id="ProfileSaveSuccess"
+            data-test='profileSaveSuccess'
           >
             <i class='notification-icon fa fa-check'></i>
             <i18n>Profile saved successfully!</i18n>
@@ -42,6 +42,7 @@
                   v-model="edited.picture"
                   @input="$v.edited.picture.$touch()"
                   placeholder="http://"
+                  data-test="profilePicture"
                 >
                 <i18n v-if="$v.edited.picture.$error" class="help is-danger">
                   The profile picture must be a valid url
@@ -50,7 +51,14 @@
             </div>
             <div class="panel-block">
               <div class="media-content">
-                <strong><i18n>Display Name</i18n>:</strong> <input class="input" name="displayName" type="text" v-model="edited.displayName" placeholder="Name">
+                <strong><i18n>Display Name</i18n>:</strong>
+                <input class="input"
+                  name="displayName"
+                  type="text"
+                  v-model="edited.displayName"
+                  placeholder="Name"
+                  data-test="displayName"
+                >
               </div>
             </div>
             <div class="panel-block">
@@ -64,18 +72,31 @@
                   v-model="edited.email"
                   @input="$v.edited.email.$touch()"
                   placeholder="Email"
+                  data-test="profileEmail"
                 >
                 <i18n v-if="$v.edited.email.$error" class="help is-danger">Not an email</i18n>
               </div>
             </div>
             <div class="panel-block">
               <div class="media-content">
-                <strong><i18n>Bio</i18n>:</strong> <textarea type="text" class="textarea" name="bio" v-model="edited.bio" placeholder="Bio"></textarea>
+                <strong><i18n>Bio</i18n>:</strong>
+                <textarea type="text"
+                  class="textarea"
+                  name="bio"
+                  v-model="edited.bio"
+                  placeholder="Bio"
+                  data-test="bio"></textarea>
               </div>
             </div>
           </div>
           <div class="has-text-centered button-box">
-            <button class="button is-success is-large" id='SaveProfileButton' :disabled="$v.edited.$invalid" type="submit"><i18n>Save Profile</i18n></button>
+            <button class="button is-success is-large"
+              :disabled="$v.edited.$invalid"
+              type="submit"
+              data-test="submit"
+            >
+              <i18n>Save Profile</i18n>
+            </button>
           </div>
         </form>
         <br>

--- a/frontend/simple/views/Vote.vue
+++ b/frontend/simple/views/Vote.vue
@@ -18,7 +18,20 @@
           </div>
           <div class="panel-block center" style="display: block; text-align: center;">
             <div id="errorMsg" v-if="errorMsg" class="help is-danger">{{errorMsg}}</div>
-            <a id="ForLink" class="button is-success is-large" v-on:click="four" style="margin-left:auto; margin-right: 20px;"><i18n>For</i18n></a><a id="AgainstLink" class="button is-danger is-large" v-on:click="against" style="margin-right:auto; margin-right: 20px;"><i18n>Against</i18n></a>
+            <a class="button is-success is-large"
+              data-test="forLink"
+              v-on:click="four"
+              style="margin-left:auto; margin-right: 20px;"
+            >
+              <i18n>For</i18n>
+            </a>
+            <a class="button is-danger is-large"
+              id="AgainstLink"
+              v-on:click="against"
+              style="margin-right:auto; margin-right: 20px;"
+            >
+              <i18n>Against</i18n>
+            </a>
           </div>
         </div>
       </div>

--- a/test/frontend.js
+++ b/test/frontend.js
@@ -122,33 +122,37 @@ describe('Frontend', function () {
   describe('Sign up Test', function () {
     it('Should register User', async function () {
       this.timeout(10000)
-      await n.goto(page('signup')).wait('#name')
+      await n.goto(page('signup')).wait(elT('signName'))
       const signedup = await n
-        .insert('#name', username)
-        .insert('#email', `test@testgroupincome.com`)
-        .insert('#password', 'testtest')
-        .wait(() => !document.querySelector('button[type="submit"]').disabled)
-        .click('button[type="submit"]')
-        .wait('#HomeLogo')
-        .evaluate(() => !!document.getElementById('HomeLogo'))
+        .insert(elT('signName'), username)
+        .insert(elT('signEmail'), `test@testgroupincome.com`)
+        .insert(elT('signPassword'), 'testtest')
+        .wait(
+          (el) => !document.querySelector(el).disabled,
+          elT('signSubmit')
+        )
+        .click(elT('signSubmit'))
+        .wait(elT('homeLogo'))
+        .evaluate(() => !!document.querySelector('[data-test="homeLogo"]'))
       should(signedup).equal(true)
     })
+
     it('Test Profile Change', async function () {
       this.timeout(10000)
       let success = await n
-        .click('#OpenProfileDropDown')
-        .click('#ProfileLink')
-        .wait('input[name="profilePicture"]')
-        .insert('textarea[name="bio"]', 'Born in a test case')
-        .insert('input[name="displayName"]', 'Tester T Test')
-        .insert('textarea[name="bio"]', 'Born in a test case')
-        .insert('input[name="profilePicture"]') // clear
-        .insert('input[name="profilePicture"]', 'http://testing.rocks')
-        .insert('input[name="profileEmail"]') // clear
-        .insert('input[name="profileEmail"]', 'email@testing.rocks')
-        .click('#SaveProfileButton')
-        .wait('#ProfileSaveSuccess')
-        .exists('#ProfileSaveSuccess')
+        .click(elT('openProfileDropDown'))
+        .click(elT('profileLink'))
+        .wait(elT('profilePicture'))
+        .insert(elT('bio'), 'Born in a test case')
+        .insert(elT('displayName'), 'Tester T Test')
+        .insert(elT('bio'), 'Born in a test case')
+        .insert(elT('profilePicture')) // clear
+        .insert(elT('profilePicture'), 'http://testing.rocks')
+        .insert(elT('profileEmail')) // clear
+        .insert(elT('profileEmail'), 'email@testing.rocks')
+        .click(elT('submit'))
+        .wait(elT('profileSaveSuccess'))
+        .exists(elT('profileSaveSuccess'))
       should(success).equal(true)
       // TODO Make more complex. Unfortunately bugs in Nightmare prevent the clearing and re-entering of fields
       // those Nightmare bugs seem to be gone now, so TODO it is
@@ -156,17 +160,17 @@ describe('Frontend', function () {
     it('Test Logout and Login', async function () {
       this.timeout(10000)
       const loggedin = await n
-        .click('#LogoutBtn')
-        .wait('#LoginBtn')
-        .click('#LoginBtn')
-        .wait('#LoginModal.is-active')
-        .insert('#LoginName', username)
-        .insert('#LoginPassword', 'testtest')
-        .click('#LoginButton')
-        .wait('#LoginResponse')
-        .wait('#OpenProfileDropDown')
-        .click('#OpenProfileDropDown')
-        .exists('#LogoutBtn')
+        .click(elT('logoutBtn'))
+        .wait(elT('loginBtn'))
+        .click(elT('loginBtn'))
+        .wait(elT('loginModal'))
+        .insert(elT('loginName'), username)
+        .insert(elT('loginPassword'), 'testtest')
+        .click(elT('loginSubmit'))
+        .wait(elT('loginResponse'))
+        .wait(elT('openProfileDropDown'))
+        .click(elT('openProfileDropDown'))
+        .exists(elT('logoutBtn'))
       should(loggedin).equal(true)
     })
 
@@ -180,16 +184,31 @@ describe('Frontend', function () {
       const badUsername = 't e s t'
       const badEmail = `@fail`
       const badPassword = `789`// six is so afraid
-      const denied = await n.insert('#name', badUsername)
-        .insert('#email', badEmail)
-        .insert('#password', badPassword)
-        .evaluate(() => document.querySelector('button[type="submit"]') && document.querySelector('button[type="submit"]').disabled)
+      const denied = await n.insert(elT('signName'), badUsername)
+        .insert(elT('signEmail'), badEmail)
+        .insert(elT('signPassword'), badPassword)
+        .evaluate(
+          (el) => document.querySelector(el) && document.querySelector(el).disabled,
+          elT('signSubmit')
+        )
       should(denied).equal(true)
-      const usernameMsg = await n.evaluate(() => !!document.getElementById('badUsername'))
+
+      const usernameMsg = await n.evaluate(
+        (el) => !!document.querySelector(el),
+        elT('badUsername')
+      )
       should(usernameMsg).equal(true)
-      const emailMsg = await n.evaluate(() => !!document.getElementById('badEmail'))
+
+      const emailMsg = await n.evaluate(
+        (el) => !!document.querySelector(el),
+        elT('badEmail')
+      )
       should(emailMsg).equal(true)
-      const passwordMsg = await n.evaluate(() => !!document.getElementById('badPassword'))
+
+      const passwordMsg = await n.evaluate(
+        (el) => !!document.querySelector(el),
+        elT('badPassword')
+      )
       should(passwordMsg).equal(true)
     })
   })
@@ -198,73 +217,85 @@ describe('Frontend', function () {
     it('Create Additional User', async function () {
       this.timeout(8000)
       const signedup = await n
-        .wait('#LogoutBtn')
-        .click('#LogoutBtn')
-        .wait('#SignupBtn')
-        .click('#SignupBtn')
-        .wait('#name')
-        .insert('#name', username + '2')
-        .insert('#email', 'test2@testgroupincome.com')
-        .insert('#password', 'testtest')
-        .wait(() => document.querySelector('button[type="submit"]') && !document.querySelector('button[type="submit"]').disabled)
-        .click('button[type="submit"]')
-        .wait('#HomeLogo')
-        .exists('#HomeLogo')
+        .wait(elT('logoutBtn'))
+        .click(elT('logoutBtn'))
+        .wait(elT('signupBtn'))
+        .click(elT('signupBtn'))
+        .wait(elT('signName'))
+        .insert(elT('signName'), username + '2')
+        .insert(elT('signEmail'), 'test2@testgroupincome.com')
+        .insert(elT('signPassword'), 'testtest')
+        .wait(
+          (el) => document.querySelector(el) && !document.querySelector(el).disabled,
+          elT('signSubmit')
+        )
+        .click(elT('signSubmit'))
+        .wait(elT('homeLogo'))
+        .exists(elT('homeLogo'))
       should(signedup).equal(true)
     })
 
     it('Create Additional User 3', async function () {
       this.timeout(8000)
       const signedup = await n
-        .click('#OpenProfileDropDown')
-        .wait('#LogoutBtn')
-        .click('#LogoutBtn')
-        .wait('#SignupBtn')
-        .click('#SignupBtn')
-        .wait('#name')
-        .insert('#name', username + '3')
-        .insert('#email', `test2@testgroupincome.com`)
-        .insert('#password', 'testtest')
-        .wait(() => document.querySelector('button[type="submit"]') && !document.querySelector('button[type="submit"]').disabled)
-        .click('button[type="submit"]')
-        .wait('#HomeLogo')
-        .exists('#HomeLogo')
+        .click(elT('openProfileDropDown'))
+        .wait(elT('logoutBtn'))
+        .click(elT('logoutBtn'))
+        .wait(elT('signupBtn'))
+        .click(elT('signupBtn'))
+        .wait(elT('signName'))
+        .insert(elT('signName'), username + '3')
+        .insert(elT('signEmail'), 'test3@testgroupincome.com')
+        .insert(elT('signPassword'), 'testtest')
+        .wait(
+          (el) => document.querySelector(el) && !document.querySelector(el).disabled,
+          elT('signSubmit')
+        )
+        .click(elT('signSubmit'))
+        .wait(elT('homeLogo'))
+        .exists(elT('homeLogo'))
       should(signedup).equal(true)
     })
 
     it('Create Additional User 4', async function () {
       this.timeout(8000)
       const signedup = await n
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
-        .wait('#SignupBtn')
-        .click('#SignupBtn')
-        .wait('#name')
-        .insert('#name', username + '4')
-        .insert('#email', `test2@testgroupincome.com`)
-        .insert('#password', 'testtest')
-        .wait(() => document.querySelector('button[type="submit"]') && !document.querySelector('button[type="submit"]').disabled)
-        .click('button[type="submit"]')
-        .wait('#HomeLogo')
-        .exists('#HomeLogo')
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
+        .wait(elT('signupBtn'))
+        .click(elT('signupBtn'))
+        .wait(elT('signName'))
+        .insert(elT('signName'), username + '4')
+        .insert(elT('signEmail'), 'test4@testgroupincome.com')
+        .insert(elT('signPassword'), 'testtest')
+        .wait(
+          (el) => document.querySelector(el) && !document.querySelector(el).disabled,
+          elT('signSubmit')
+        )
+        .click(elT('signSubmit'))
+        .wait(elT('homeLogo'))
+        .exists(elT('homeLogo'))
       should(signedup).equal(true)
     })
 
     it('Create Additional User 5', async function () {
       this.timeout(8000)
       const signedup = await n
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
-        .wait('#SignupBtn')
-        .click('#SignupBtn')
-        .wait('#name')
-        .insert('#name', username + '5')
-        .insert('#email', `test2@testgroupincome.com`)
-        .insert('#password', 'testtest')
-        .wait(() => document.querySelector('button[type="submit"]') && !document.querySelector('button[type="submit"]').disabled)
-        .click('button[type="submit"]')
-        .wait('#HomeLogo')
-        .exists('#HomeLogo')
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
+        .wait(elT('signupBtn'))
+        .click(elT('signupBtn'))
+        .wait(elT('signName'))
+        .insert(elT('signName'), username + '5')
+        .insert(elT('signEmail'), 'test5@testgroupincome.com')
+        .insert(elT('signPassword'), 'testtest')
+        .wait(
+          (el) => document.querySelector(el) && !document.querySelector(el).disabled,
+          elT('signSubmit')
+        )
+        .click(elT('signSubmit'))
+        .wait(elT('homeLogo'))
+        .exists(elT('homeLogo'))
       should(signedup).equal(true)
     })
 
@@ -275,49 +306,52 @@ describe('Frontend', function () {
       const testSetting = 80
       this.timeout(10000)
       await n
-        .click('#CreateGroup')
+        .click(elT('createGroup'))
         // fill group data
-        .wait('input[name="groupName"]')
-        .insert('input[name="groupName"]', testName)
-        .click('#nextBtn')
+        .wait(elT('groupName'))
+        .insert(elT('groupName'), testName)
+        .click(elT('nextBtn'))
         .wait('textarea[name="sharedValues"]')
         .insert('textarea[name="sharedValues"]', testValues)
-        .click('#nextBtn')
+        .click(elT('nextBtn'))
         .wait('input[name="incomeProvided"]')
         .insert('input[name="incomeProvided"]', testIncome)
-        .click('#nextBtn')
-        .wait('#rulesStep')
+        .click(elT('nextBtn'))
+        .wait(elT('rulesStep'))
         // set rules step skipped for now
-        .click('#nextBtn')
-        .wait('#privacyStep')
-        .click('#nextBtn')
+        .click(elT('nextBtn'))
+        .wait(elT('privacyStep'))
+        .click(elT('nextBtn'))
         // invite members
-        .wait('input[name="invitee"]')
-        .insert('input[name="invitee"]', username + '4')
-        .click('#addButton')
-        .wait('.invitee')
+        .wait(elT('inputInvitee'))
+        .insert(elT('inputInvitee'), username + '4')
+        .click(elT('addButton'))
+        .wait(elT('inviteeContainer'))
 
-      const invited = await n.evaluate(() => document.querySelectorAll('.invitee').length)
+      const invited = await n.evaluate(
+        (el) => document.querySelectorAll('[data-test="inviteeContainer"]').length,
+        elT('inviteeContainer')
+      )
       should(invited).equal(1)
 
       await n
-        .click('#nextBtn')
-        .wait('#summaryStep')
+        .click(elT('nextBtn'))
+        .wait(elT('summaryStep'))
       // summary page sees group as valid
-      const valid = await n.exists('#finishBtn:not(:disabled)')
+      const valid = await n.exists(`${elT('finishBtn')}:not(:disabled)`)
       should(valid).equal(true)
       // submit group
       await n
-        .click('#finishBtn')
-        .wait('#dashboard')
+        .click(elT('finishBtn'))
+        .wait(elT('dashboard'))
 
       const created = await n.evaluate(() => ({
-        groupName: document.querySelector('#groupName').innerText,
-        sharedValues: document.querySelector('#sharedValues').innerText,
-        incomeProvided: document.querySelector('.min-income').innerText,
-        changePercentage: document.querySelector('#changePercentage').innerText,
-        memberApprovalPercentage: document.querySelector('#approvePercentage').innerText,
-        memberRemovalPercentage: document.querySelector('#removePercentage').innerText
+        groupName: document.querySelector('[data-test="groupName"]').innerText,
+        sharedValues: document.querySelector('[data-test="sharedValues"]').innerText,
+        incomeProvided: document.querySelector('[data-test="minIncome"]').innerText,
+        changePercentage: document.querySelector('[data-test="changePercentage"]').innerText,
+        memberApprovalPercentage: document.querySelector('[data-test="approvePercentage"]').innerText,
+        memberRemovalPercentage: document.querySelector('[data-test="removePercentage"]').innerText
       }))
       should(created.groupName).equal(testName)
       should(created.sharedValues).equal(testValues)
@@ -332,26 +366,47 @@ describe('Frontend', function () {
 
       const count = await n
         .click(elT('inviteButton'))
-        .wait('#addButton')
-        .insert('#searchUser', username)
-        .click('#addButton')
-        .wait(() => document.querySelectorAll('.member').length > 0)
-        .wait('.delete')
-        .click('.delete')
-        .wait(() => document.querySelectorAll('.member').length < 1)
-        .evaluate(() => +document.querySelectorAll('.member').length)
+        .wait(elT('addButton'))
+        .insert(elT('searchUser'), username)
+        .click(elT('addButton'))
+        .wait(
+          (el) => document.querySelectorAll(el).length > 0,
+          elT('member')
+        )
+        .wait(elT('deleteMember'))
+        .click(elT('deleteMember'))
+        .wait(
+          (el) => document.querySelectorAll(el).length < 1,
+          elT('member')
+        )
+        .evaluate(
+          (el) => +document.querySelectorAll(el).length,
+          elT('member')
+        )
       should(count).equal(0)
 
       const created = await n
-        .insert('#searchUser', username)
-        .click('#addButton')
-        .wait(() => document.querySelectorAll('.member').length > 0)
-        .insert('#searchUser', username + '2')
-        .click('#addButton')
-        .wait(() => document.querySelectorAll('.member').length > 1)
-        .click('button[type="submit"]')
-        .wait(() => !!document.querySelector('.notification.is-success'))
-        .evaluate(() => !!document.querySelector('.notification.is-success'))
+        .insert(elT('searchUser'), username)
+        .click(elT('addButton'))
+        .wait(
+          (el) => document.querySelectorAll(el).length > 0,
+          elT('member')
+        )
+        .insert(elT('searchUser'), username + '2')
+        .click(elT('addButton'))
+        .wait(
+          (el) => document.querySelectorAll(el).length > 1,
+          elT('member')
+        )
+        .click(elT('submit'))
+        .wait(
+          (el) => !!document.querySelector(el),
+          elT('notifyInvitedSuccess')
+        )
+        .evaluate(
+          (el) => !!document.querySelector(el),
+          elT('notifyInvitedSuccess')
+        )
       should(created).equal(true)
     })
 
@@ -359,166 +414,187 @@ describe('Frontend', function () {
       this.timeout(10000)
       await n
         .goto(page('mailbox'))
-        .wait('#Inbox')
-        .click('#ComposeLink')
-        .wait('#AddRecipient')
-        .insert('#AddRecipient', username)
-        .insert('#ComposedMessage', 'Best test ever!!')
-        .click('#SendButton')
-        .wait('#Inbox')
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
-        .wait('#LoginBtn')
-        .click('#LoginBtn')
-        .wait('#LoginModal')
-        .insert('#LoginName', username)
-        .insert('#LoginPassword', 'testtest')
-        .click('#LoginButton')
-        .wait('#MailboxLink')
-        .click('#MailboxLink')
+        .wait(elT('inbox'))
+        .click(elT('composeLink'))
+        .wait(elT('addRecipient'))
+        .insert(elT('addRecipient'), username)
+        .insert(elT('composedMessage'), 'Best test ever!!')
+        .click(elT('sendButton'))
+        .wait(elT('inbox'))
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
+        .wait(elT('loginBtn'))
+        .click(elT('loginBtn'))
+        .wait(elT('loginModal'))
+        .insert(elT('loginName'), username)
+        .insert(elT('loginPassword'), 'testtest')
+        .click(elT('loginSubmit'))
+        .wait(elT('mailboxLink'))
+        .click(elT('mailboxLink'))
 
-      const alert = await n.exists('#AlertNotification')
+      const alert = await n.exists(elT('alertNotification'))
       should(alert).equal(true)
-      const unread = await n.evaluate(() => document.querySelector('.unread') && +document.querySelector('.unread').innerText)
+      const unread = await n.evaluate(
+        (el) => document.querySelector(el) && +document.querySelector(el).innerText,
+        elT('inboxUnread')
+      )
       should(unread).equal(2)
-      const hasInvite = await n.exists('.invite-message')
+      const hasInvite = await n.exists(elT('inviteMessage'))
       should(hasInvite).equal(true)
-      const hasMessage = await n.exists('.inbox-message')
+      const hasMessage = await n.exists(elT('inboxMessage'))
       should(hasMessage).equal(true)
       const newUnread = await n
-        .click('.invite-message')
-        .evaluate(() => +document.querySelector('.unread').innerText)
+        .click(elT('inviteMessage'))
+        .evaluate(
+          (el) => +document.querySelector(el).innerText,
+          elT('inboxUnread')
+        )
       should(newUnread).equal(1)
     })
     it('Should Accept Invite', async function () {
       this.timeout(30000)
       // Accept invitation
-      let success = await n.click('#InboxLink')
-        .wait('.invite-message')
-        .click('.invite-message')
-        .wait('#InviteLink')
-        .click('#InviteLink')
-        .wait('#AcceptLink')
-        .click('#AcceptLink')
-        .wait('#Inbox')
-        .exists('#Inbox')
+      let success = await n.click(elT('inboxLink'))
+        .wait(elT('inviteMessage'))
+        .click(elT('inviteMessage'))
+        .wait(elT('inviteLink'))
+        .click(elT('inviteLink'))
+        .wait(elT('acceptLink'))
+        .click(elT('acceptLink'))
+        .wait(elT('inbox'))
+        .exists(elT('inbox'))
       should(success).equal(true)
       // Logout
       success = await n
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
         // Open login modal
-        .wait('#LoginBtn')
-        .click('#LoginBtn')
+        .wait(elT('loginBtn'))
+        .click(elT('loginBtn'))
         // Login
-        .wait('#LoginModal.is-active')
-        .wait('#LoginName')
-        .insert('#LoginName', username + '2')
-        .insert('#LoginPassword', 'testtest')
-        .click('#LoginButton')
-        .wait(() => !document.querySelector('#LoginModal.is-active'))
-        .wait('#MailboxLink')
+        .wait(`${elT('loginModal')}.is-active`)
+        .wait(elT('loginName'))
+        .insert(elT('loginName'), username + '2')
+        .insert(elT('loginPassword'), 'testtest')
+        .click(elT('loginSubmit'))
+        .wait(
+          (el) => !document.querySelector(el),
+          `${elT('loginModal')}.is-active`
+        )
+        .wait(elT('mailboxLink'))
       // BUG: Why isn't there an await here?
       // Accept invitation
-      n.click('#MailboxLink')
-        .wait('.invite-message')
-        .click('.invite-message')
-        .wait('#InviteLink')
-        .click('#InviteLink')
-        .wait('#AcceptLink')
-        .click('#AcceptLink')
-        .wait('#Inbox')
-        .exists('#Inbox')
+      n.click(elT('mailboxLink'))
+        .wait(elT('inviteMessage'))
+        .click(elT('inviteMessage'))
+        .wait(elT('inviteLink'))
+        .click(elT('inviteLink'))
+        .wait(elT('acceptLink'))
+        .click(elT('acceptLink'))
+        .wait(elT('inbox'))
+        .exists(elT('inbox'))
       should(!success).equal(true)
     })
     it('Should Vote on Additional Members', async function () {
       this.timeout(10000)
       await n
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
         // Open login modal
-        .wait('#LoginBtn')
-        .click('#LoginBtn')
+        .wait(elT('loginBtn'))
+        .click(elT('loginBtn'))
         // Login
-        .wait('#LoginModal.is-active')
-        .wait('#LoginName')
-        .insert('#LoginName', username + '5')
-        .insert('#LoginPassword', 'testtest')
-        .wait('#LoginButton')
-        .click('#LoginButton')
-        .wait(() => !document.querySelector('#LoginModal.is-active'))
+        .wait(`${elT('loginModal')}.is-active`)
+        .wait(elT('loginName'))
+        .insert(elT('loginName'), username + '5')
+        .insert(elT('loginPassword'), 'testtest')
+        .wait(elT('loginSubmit'))
+        .click(elT('loginSubmit'))
+        .wait(
+          (el) => !document.querySelector(el),
+          `${elT('loginModal')}.is-active`
+        )
       // BUG: Why isn't there an await here?
       await n
-        .wait('#MailboxLink')
+        .wait(elT('mailboxLink'))
         .goto(page('invite'))
-        .wait('#ProposeButton')
-        .insert('#searchUser', username + '3')
-        .click('#ProposeButton')
-        .wait('.notification.is-success')
+        .wait(elT('proposeButton'))
+        .insert(elT('searchUser'), username + '3')
+        .click(elT('proposeButton'))
+        .wait(elT('notifyProposedSuccess'))
         // Logout
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
         // Open login modal
-        .wait('#LoginBtn')
-        .click('#LoginBtn')
+        .wait(elT('loginBtn'))
+        .click(elT('loginBtn'))
       // Login
       await n
-        .wait('#LoginModal.is-active')
-        .insert('#LoginName', username)
-        .insert('#LoginPassword', 'testtest')
-        .click('#LoginButton')
-        .wait(() => !document.querySelector('#LoginModal.is-active'))
+        .wait(`${elT('loginModal')}.is-active`)
+        .insert(elT('loginName'), username)
+        .insert(elT('loginPassword'), 'testtest')
+        .click(elT('loginSubmit'))
+        .wait(
+          (el) => !document.querySelector(el),
+          `${elT('loginModal')}.is-active`
+        )
 
       let success = await n
-        .wait('#MailboxLink')
-        .click('#MailboxLink')
-        .wait('.proposal-message')
-        .click('.proposal-message')
-        .wait('#ForLink')
-        .click('#ForLink')
-        .wait('#Inbox')
-        .exists('#Inbox')
+        .wait(elT('mailboxLink'))
+        .click(elT('mailboxLink'))
+        .wait(elT('proposalMessage'))
+        .click(elT('proposalMessage'))
+        .wait(elT('forLink'))
+        .click(elT('forLink'))
+        .wait(elT('inbox'))
+        .exists(elT('inbox'))
       should(success).equal(true)
 
       success = await n
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
         // Open login modal
-        .wait('#LoginBtn')
-        .click('#LoginBtn')
+        .wait(elT('loginBtn'))
+        .click(elT('loginBtn'))
         // Login
-        .wait('#LoginModal.is-active')
-        .insert('#LoginName', username + '2')
-        .insert('#LoginPassword', 'testtest')
-        .click('#LoginButton')
-        .wait(() => !document.querySelector('#LoginModal.is-active'))
-        .wait('#MailboxLink')
-        .click('#MailboxLink')
-        .wait('.proposal-message')
-        .click('.proposal-message')
-        .wait('#ForLink')
-        .click('#ForLink')
-        .wait('#Inbox')
-        .exists('#Inbox')
+        .wait(`${elT('loginModal')}.is-active`)
+        .insert(elT('loginName'), username + '2')
+        .insert(elT('loginPassword'), 'testtest')
+        .click(elT('loginSubmit'))
+        .wait(
+          (el) => !document.querySelector(el),
+          `${elT('loginModal')}.is-active`
+        )
+        .wait(elT('mailboxLink'))
+        .click(elT('mailboxLink'))
+        .wait(elT('proposalMessage'))
+        .click(elT('proposalMessage'))
+        .wait(elT('forLink'))
+        .click(elT('forLink'))
+        .wait(elT('inbox'))
+        .exists(elT('inbox'))
       should(success).equal(true)
 
       success = await n
-        .click('#OpenProfileDropDown')
-        .click('#LogoutBtn')
+        .click(elT('openProfileDropDown'))
+        .click(elT('logoutBtn'))
         // Open login modal
-        .wait('#LoginBtn')
-        .click('#LoginBtn')
+        .wait(elT('loginBtn'))
+        .click(elT('loginBtn'))
         // Login
-        .wait('#LoginModal.is-active')
-        .insert('#LoginName', username + '3')
-        .insert('#LoginPassword', 'testtest')
-        .click('#LoginButton')
-        .wait(() => !document.querySelector('#LoginModal.is-active'))
-        .wait('#MailboxLink')
+        .wait(`${elT('loginModal')}.is-active`)
+        .insert(elT('loginName'), username + '3')
+        .insert(elT('loginPassword'), 'testtest')
+        .click(elT('loginSubmit'))
+        .wait(
+          (el) => !document.querySelector(el),
+          `${elT('loginModal')}.is-active`
+        )
+        .wait(elT('mailboxLink'))
         // Accept invitation
-        .click('#MailboxLink')
-        .wait('.invite-message')
-        .exists('.invite-message')
+        .click(elT('mailboxLink'))
+        .wait(elT('inviteMessage'))
+        .exists(elT('inviteMessage'))
       should(success).equal(true)
     })
   })


### PR DESCRIPTION
Following #362 I've refactored all elements targeted by `id`, `class` or  any other attribute to a single way of targeting: `data-test` attribute.

I've created a utility function to avoid repeating `'[data-test="x"]'` everytime.

```js
// Access any element by its data-test attribute
function elT (el) {
  return `[data-test=${el}]`
}
```

Example of the refactor made:

```diff
- .insert('textarea[name="bio"]', 'Born in a test case')
+ .insert(elT('bio'), 'Born in a test case')
```

```diff
<textarea name="bio"
+  data-test="bio"  
>
```

Still, I couldn't use the utility function `elT` inside wait() callbacks.
```js
// raw way
.wait(() => !document.querySelector('[data-test="signSubmit"]').disabled)

// with elT()
.wait(() => !document.querySelector(elT('signSubmit')).disabled)
```
> `Error: the string "elT is not defined" was thrown, throw an Error :)`
> `at <anonymous>`

Why does that happen? 🤔 

---

Closes #362.
