### PR TITLE
#347 Update Sidebar + Navbar to match designs

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,7 +14,7 @@
           <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
       <![endif]-->
       <header class="hero-header">
-        <nav class="navbar container">
+        <nav class="navbar">
           <div class="navbar-start">
             <a href="simple/" class="navbar-item">
               <img src="/simple/images/logo-transparent.png"  alt="Groupincome's logo">

--- a/frontend/simple/components/YourGroupsList.vue
+++ b/frontend/simple/components/YourGroupsList.vue
@@ -1,70 +1,62 @@
 <template>
   <div>
-    <h3 class="list-title">YOUR GROUPS</h3>
-    <p class="group-name"
-      v-for="group in groups"
-      :class='{"is-active": currentGroupId === group.contractId}'
-      @click.prevent="changeGroup(group.contractId)"
-    >
-      {{ group.groupName }}
-    </p>
-    <router-link class="create-new-link" to="/new-group">+ CREATE NEW</router-link>
+    <h3 class="title is-7 is-uppercase gi-title">
+      Your groups
+    </h3>
+    <ul class="list">
+      <li class="list-item"
+        :class='{"is-active": currentGroupId === group.contractId}'
+        tabindex="0"
+        v-for="group in groups"
+        @click.prevent="changeGroup(group.contractId)"
+      >
+        {{ group.groupName }}
+      </li>
+    </ul>
+    <router-link to="/new-group" class="cta">
+      Create new group
+    </router-link>
   </div>
 </template>
 <style lang="scss" scoped>
-.list-title {
-  color: #9b9b9b;
-  font-family: HelveticaNeue-Light;
-  font-size: 14px;
-  letter-spacing: 5px;
-  margin-bottom: 13px;
+$spacer: 2rem;
+
+.gi-title {
+  padding-top: 2.5rem;
+  padding-left: $spacer;
+  margin-bottom: 0.5rem;
 }
 
-.group-name {
-  color: #616161;
-  font-family: HelveticaNeue-Bold;
-  font-size: 17px;
-  overflow: hidden;
-  padding: 5px 0;
-}
+.list {
+  &-item {
+    padding: 0.4rem 0.4rem 0.4rem $spacer;
+    font-weight: 600;
 
-.group-name:hover {
-  color: #222324;
-  cursor: pointer;
-}
-
-.group-name.is-active {
-  background: #ececec;
-  padding-left: 15px;
-  margin-left: -15px;
-}
-
-.create-new-link {
-  color: #9b9b9b;
-  display: block;
-  font-family: HelveticaNeue-Bold;
-  font-size: 12px;
-  letter-spacing: 3.43px;
-  margin-top: 13px;
-
-  &:hover {
-    color: #222324;
+    &.is-active {
+      background: #ededed;
+      border-right: 3px solid orange;
+    }
   }
+}
+
+.cta {
+  display: block;
+  padding-top: 0.25rem;
+  padding-left: $spacer;
 }
 
 </style>
 <script>
-  export default {
-    name: 'YourGroupsList',
-    props: {
-      groups: Array,
-      currentGroupId: String
-    },
-    methods: {
-      changeGroup (hash) {
-        this.$store.commit('setCurrentGroupId', hash)
-      }
+export default {
+  name: 'YourGroupsList',
+  props: {
+    groups: Array,
+    currentGroupId: String
+  },
+  methods: {
+    changeGroup (hash) {
+      this.$store.commit('setCurrentGroupId', hash)
     }
   }
+}
 </script>
-

--- a/frontend/simple/components/YourGroupsList.vue
+++ b/frontend/simple/components/YourGroupsList.vue
@@ -19,30 +19,32 @@
   </div>
 </template>
 <style lang="scss" scoped>
-$spacer: 2rem;
+@import "../sass/theme/index";
 
 .gi-title {
-  padding-top: 2.5rem;
-  padding-left: $spacer;
-  margin-bottom: 0.5rem;
+  padding-top: $gi-spacer-lg;
+  padding-left: $gi-spacer-lg;
+  margin-bottom: $gi-spacer-sm;
 }
 
 .list {
   &-item {
-    padding: 0.4rem 0.4rem 0.4rem $spacer;
+    padding: 0.4rem 0.4rem 0.4rem $gi-spacer-lg;
     font-weight: 600;
 
+    &:focus,
     &.is-active {
       background: #ededed;
       border-right: 3px solid orange;
+      outline: none;
     }
   }
 }
 
 .cta {
   display: block;
-  padding-top: 0.25rem;
-  padding-left: $spacer;
+  padding-top: $gi-spacer-xs;
+  padding-left: $gi-spacer-lg;
 }
 
 </style>

--- a/frontend/simple/sass/bulma_overrides/components/navbar.scss
+++ b/frontend/simple/sass/bulma_overrides/components/navbar.scss
@@ -1,10 +1,29 @@
+$navbar-height: 4.5rem;
+
 @import "../../node_modules/bulma/sass/components/navbar";
 
 .navbar {
-  box-shadow: none;
   display: flex;
   justify-content: space-between;
-  padding: 1rem 0;
+
+  &-item {
+    display: flex;
+    align-items: center;
+  }
+
+  a#{&}-main-item {
+    background-color: transparent;
+    border-bottom: 3px solid transparent;
+    font-weight: 600;
+
+    &.is-active,
+    &:focus,
+    &:hover {
+      outline: none;
+      color: inherit;
+      border-color: $orange;
+    }
+  }
 }
 
 // Copied Paste from Bulma's source
@@ -12,6 +31,8 @@
 // Keep it here until we design navbar to be full responsive
 .has-dropdown.gi-is-profile {
   .navbar-link {
+    padding-right: 3.5rem;
+
     &::after {
       border: 3px solid $link;
       border-radius: 2px;
@@ -27,6 +48,7 @@
       transform: rotate(-45deg);
       transform-origin: center;
       width: 0.625em;
+      right: 2rem;
     }
   }
 

--- a/frontend/simple/sass/bulma_overrides/components/navbar.scss
+++ b/frontend/simple/sass/bulma_overrides/components/navbar.scss
@@ -21,7 +21,7 @@ $navbar-height: 4.5rem;
     &:hover {
       outline: none;
       color: inherit;
-      border-color: $orange;
+      border-color: $tertiary;
     }
   }
 }

--- a/frontend/simple/sass/theme/index.scss
+++ b/frontend/simple/sass/theme/index.scss
@@ -7,6 +7,7 @@ $gi-spacer: 1rem; // same as gap but in rem
 $gi-spacer-lg: $gi-spacer * 2;
 $gi-spacer-md: $gi-spacer;
 $gi-spacer-sm: $gi-spacer / 2;
+$gi-spacer-xs: $gi-spacer / 4;
 
 // NOTE: Find a way to generated different import themes
 @import 'kindergarten-professional';

--- a/frontend/simple/views/GroupDashboard.vue
+++ b/frontend/simple/views/GroupDashboard.vue
@@ -3,7 +3,7 @@
     <div class="columns">
       <div class="column is-narrow gi-sidebar">
         <your-groups-list
-          :currentGroupId="currentGroupState.currentGroupId"
+          :currentGroupId="currentGroupId"
           :groups="groupsByName"
         />
       </div>
@@ -63,7 +63,7 @@
 }
 </style>
 <script>
-import {mapGetters} from 'vuex'
+import { mapGetters, mapState } from 'vuex'
 import YourGroupsList from '../components/YourGroupsList.vue'
 import GroupsMinIncome from '../components/GroupsMinIncome.vue'
 import GroupMembers from '../components/GroupMembers.vue'
@@ -75,6 +75,9 @@ import ProgressOverview from '../components/ProgressOverview.vue'
 export default {
   name: 'GroupDashboard',
   computed: {
+    ...mapState([
+      'currentGroupId'
+    ]),
     ...mapGetters([
       'currentGroupState',
       'groupsByName'

--- a/frontend/simple/views/GroupDashboard.vue
+++ b/frontend/simple/views/GroupDashboard.vue
@@ -8,7 +8,7 @@
         />
       </div>
 
-      <div class="column gi-main">
+      <div class="column container gi-main">
         <div class="gi-header">
           <div class='is-pulled-right'>
             <groups-min-income :group="currentGroupState" />

--- a/frontend/simple/views/GroupDashboard.vue
+++ b/frontend/simple/views/GroupDashboard.vue
@@ -1,25 +1,26 @@
 <template>
-  <section class="container section" data-test="dashboard">
+  <main data-test="dashboard">
     <div class="columns">
-
-      <div class="column is-2">
+      <div class="column is-narrow gi-sidebar">
         <your-groups-list
           :currentGroupId="currentGroupState.currentGroupId"
           :groups="groupsByName"
         />
       </div>
 
-      <div class="column">
-        <div class='is-pulled-right'>
-          <groups-min-income :group="currentGroupState" />
-        </div>
+      <div class="column gi-main">
+        <div class="gi-header">
+          <div class='is-pulled-right'>
+            <groups-min-income :group="currentGroupState" />
+          </div>
 
-        <h1 class="title is-1" data-test="groupName">
-          {{ currentGroupState.groupName }}
-        </h1>
-        <p data-test="sharedValues">
-          {{ currentGroupState.sharedValues }}
-        </p>
+          <h1 class="title is-1" data-test="groupName">
+            {{ currentGroupState.groupName }}
+          </h1>
+          <p data-test="sharedValues">
+            {{ currentGroupState.sharedValues }}
+          </p>
+        </div>
 
         <voting-banner class="widget"
           who="Sam"
@@ -39,43 +40,54 @@
           :group="currentGroupState" />
       </div>
     </div>
-  </section>
+  </main>
 </template>
 <style lang="scss" scoped>
-  .widget {
-    margin: 4rem 0;
-  }
+.widget {
+  margin: 4rem 0;
+}
 
-  .container {
-    max-width: 960px; // force until rethink layout on larger screens
-  }
+.gi-sidebar {
+  width: 15rem;
+  padding-right: 0;
+}
+
+.gi-main {
+  padding-right: calc(2rem + 0.75rem);
+  padding-left: 2rem;
+  max-width: 960px;
+}
+
+.gi-header {
+  padding-top: 1.5rem;
+}
 </style>
 <script>
-  import {mapGetters} from 'vuex'
-  import YourGroupsList from '../components/YourGroupsList.vue'
-  import GroupsMinIncome from '../components/GroupsMinIncome.vue'
-  import GroupMembers from '../components/GroupMembers.vue'
-  import SupportHistory from '../components/SupportHistory.vue'
-  import GroupSettings from '../components/GroupSettings.vue'
-  import VotingBanner from '../components/VotingBanner.vue'
-  import ProgressOverview from '../components/ProgressOverview.vue'
+import {mapGetters} from 'vuex'
+import YourGroupsList from '../components/YourGroupsList.vue'
+import GroupsMinIncome from '../components/GroupsMinIncome.vue'
+import GroupMembers from '../components/GroupMembers.vue'
+import SupportHistory from '../components/SupportHistory.vue'
+import GroupSettings from '../components/GroupSettings.vue'
+import VotingBanner from '../components/VotingBanner.vue'
+import ProgressOverview from '../components/ProgressOverview.vue'
 
-  export default {
-    name: 'GroupDashboard',
-    computed: {
-      ...mapGetters([
-        'currentGroupState',
-        'groupsByName'
-      ])
-    },
-    components: {
-      YourGroupsList,
-      GroupsMinIncome,
-      GroupMembers,
-      SupportHistory,
-      GroupSettings,
-      VotingBanner,
-      ProgressOverview
-    }
+export default {
+  name: 'GroupDashboard',
+  computed: {
+    ...mapGetters([
+      'currentGroupState',
+      'groupsByName'
+    ])
+  },
+  components: {
+    YourGroupsList,
+    GroupsMinIncome,
+    GroupMembers,
+    SupportHistory,
+    GroupSettings,
+    VotingBanner,
+    ProgressOverview
   }
+}
 </script>

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -4,7 +4,18 @@
         <img class="logo" src="images/group-income-icon-transparent.png">
         <br>
         <h1 class="title gi-foco-font"><i18n>Welcome to GroupIncome</i18n></h1>
-        <div v-if="!$store.state.loggedIn"><a v-on:click="forwardToLogin"><i18n>Login</i18n></a> or <router-link to="signup"><i18n>Sign Up</i18n></router-link> <i18n>to continue</i18n></div>
+        <div v-if="!$store.state.loggedIn">
+          <a v-on:click="forwardToLogin"><i18n>Login</i18n></a> or <router-link to="signup"><i18n>Sign Up</i18n></router-link> <i18n>to continue</i18n>
+        </div>
+        <div v-else>
+          <router-link
+            class="button is-success"
+            data-test="createGroup"
+            to="new-group"
+          >
+            <i18n>Start a Group</i18n>
+          </router-link>
+        </div>
       </div>
     </section>
 </template>

--- a/frontend/simple/views/NavBar.vue
+++ b/frontend/simple/views/NavBar.vue
@@ -1,46 +1,10 @@
 <template>
-  <nav class="navbar container">
-    <div class="navbar-start">
-      <router-link to="home" class="navbar-item gi-item" @click="toggleTimeTravel">
+  <nav class="navbar">
+    <div class="navbar-start is-flex">
+      <router-link to="home" class="navbar-item gi-logo" @click="toggleTimeTravel">
         <img src="/simple/images/logo-transparent.png"  alt="Groupincome's logo">
       </router-link>
     </div>
-      <div class="level gi-center" v-if="$store.state.loggedIn">
-        <!-- TODO: use v-for to dynamically generate these? -->
-        <router-link
-          active-class="is-active"
-          class="navbar-item gi-item"
-          data-test="createGroup"
-          to="new-group"
-        >
-          <i18n>Start a Group</i18n>
-        </router-link>
-
-        <router-link
-          active-class="is-active"
-          class="navbar-item gi-item"
-          to="pay-group"
-        >
-          <i18n>Pay Group</i18n>
-        </router-link>
-
-        <router-link
-          active-class ="is-active"
-          class="navbar-item gi-item"
-          data-test="mailboxLink"
-          to="mailbox"
-        >
-          <i18n>Inbox</i18n>
-          <span
-            data-test="alertNotification"
-            class="icon"
-            style="color: #ed6c63;"
-            v-if="$store.getters.unreadMessageCount || $store.getters.proposals.length"
-          >
-            <i class="fa fa-bell"></i>
-          </span>
-        </router-link>
-      </div>
       <div class="navbar-end is-flex">
         <div class="navbar-item signUp-item" v-if="!$store.state.loggedIn">
           <router-link
@@ -59,22 +23,52 @@
             <i18n>Login</i18n>
           </button>
         </div>
+        <router-link v-if="$store.state.loggedIn"
+          active-class="is-active"
+          class="navbar-item navbar-main-item"
+          to="pay-group"
+        >
+          <i18n>Pay Group</i18n>
+        </router-link>
+        <router-link v-if="$store.state.loggedIn"
+          active-class="is-active"
+          class="navbar-item navbar-main-item"
+          to="dashboard"
+        >
+          <i18n>Groups</i18n>
+        </router-link>
+        <router-link v-if="$store.state.loggedIn"
+          active-class ="is-active"
+          class="navbar-item navbar-main-item"
+          data-test="mailboxLink"
+          to="mailbox"
+        >
+          <i18n>Inbox</i18n>
+          <span
+            data-test="alertNotification"
+            class="icon"
+            style="color: #ed6c63;"
+            v-if="$store.getters.unreadMessageCount || $store.getters.proposals.length"
+          >
+            <i class="fa fa-bell"></i>
+          </span>
+        </router-link>
         <div data-test="openProfileDropDown"
           class="navbar-item has-dropdown is-hoverable gi-is-profile"
           v-if="$store.state.loggedIn">
           <a class="navbar-link">
-            <strong>
-              {{ ($store.getters.currentUserIdentityContract &&
-                $store.getters.currentUserIdentityContract.attributes &&
-                $store.getters.currentUserIdentityContract.attributes.displayName) ||
-                $store.state.loggedIn.name
-              }}
-            </strong>
             <img class="avatar" v-if="$store.getters.currentUserIdentityContract &&
               $store.getters.currentUserIdentityContract.attributes &&
               $store.getters.currentUserIdentityContract.attributes.picture"
               v-bind:src="$store.getters.currentUserIdentityContract.attributes.picture"
             >
+            <span>
+              {{ ($store.getters.currentUserIdentityContract &&
+                $store.getters.currentUserIdentityContract.attributes &&
+                $store.getters.currentUserIdentityContract.attributes.displayName) ||
+                $store.state.loggedIn.name
+              }}
+            </span>
           </a>
           <div class="navbar-dropdown is-right">
             <router-link
@@ -105,17 +99,8 @@
   </nav>
 </template>
 <style lang="scss" scoped>
-// @import "../../node_modules/bulma/sass/utilities/all";
-
-.gi-center {
-  &.level {
-    margin-bottom: 0;
-  }
-}
-
-.navbar-item.gi-item {
-  background-color: transparent;
-  // background-color: $primary;
+.gi-logo {
+  padding-left: 2rem;
 }
 
 .signUp-item {
@@ -125,7 +110,7 @@
 .avatar {
   border-radius: 50%;
   max-height: 2.5rem;
-  margin-left: 1rem;
+  margin: 0 0.5rem;
 }
 </style>
 <script>


### PR DESCRIPTION
Following and Closes #347 

I've updated Sidebar and Navbar layout to match the design on #347.
- Now the layout is fluid (100% window width), but the Dashboard itself has a max-width, so isn't too large.
- Sidebar `"is-active"` logic isn't working, so any tab is never active, but the design for the class is done. BTW, how can I debug easily a vue component? On react it's easy as `{ console.log('x')}` but on Vue I couldn't make it work, neither using breakpoints... What's the trick?
- I've noticed the designs don't have `Pay Group` link, so to not erase it, I've kept it on navbar until we figure out a better way.
- The "Create Group" link was added to homepage "Welcome to GroupIncome" when logged for the first time.

Some parts of the layout don't match exactly the design (typography sizes / colors). It only uses bulma classes for now. I believe we can still iterate a lot on the navigation (sidebar + navbar) and elements hierarchy, but let's keep that for another iteration when we have #387 merged. I prefer to have small but fast iterations, what do you think?

![image](https://user-images.githubusercontent.com/14869087/39399454-c58e2aa0-4b15-11e8-9892-452824eafb33.png)
