### PR TITLE
Fix tab order on Create Group buttons

### DIFF
--- a/frontend/simple/components/Group/GroupMincome.vue
+++ b/frontend/simple/components/Group/GroupMincome.vue
@@ -14,7 +14,7 @@
           </select>
         </span>
       </div>
-      <div class="control">
+      <div class="control is-expanded">
         <input
           class="input is-large is-primary"
           :class="{ 'is-danger': v.incomeProvided.$error }"

--- a/frontend/simple/sass/bulma_overrides/elements/form.scss
+++ b/frontend/simple/sass/bulma_overrides/elements/form.scss
@@ -5,3 +5,18 @@
     color: rgba($input-color, 0.4); // To improve A11Y
   }
 }
+
+.gi- {
+  &is-grouped-reverse {
+    flex-direction: row-reverse;
+
+    &.field.is-grouped-right {
+      justify-content: flex-start;
+    }
+
+    &.field.is-grouped > .control:not(:last-child) {
+      margin-left: 0.75rem;
+      margin-right: 0;
+    }
+  }
+}

--- a/frontend/simple/views/CreateGroup.vue
+++ b/frontend/simple/views/CreateGroup.vue
@@ -8,7 +8,7 @@
           </router-view>
         </transition>
 
-        <div class="field is-grouped is-grouped-right form-actions">
+        <div class="field is-grouped is-grouped-right gi-is-grouped-reverse form-actions">
           <p class="control" v-if="currentStep !== 0">
             <button
               class="button is-light is-large"


### PR DESCRIPTION
since the recent theme updates, tabbing out from the group creation step input fields goes to the _back_ button first, instead of the _next_ button. fixing this (and an input field width) while trying to follow our new css conventions.