### PR TITLE
#343 Implement Modal Proposal component

### DIFF
--- a/frontend/simple/assets/sass/bulma_overrides/components/modal.scss
+++ b/frontend/simple/assets/sass/bulma_overrides/components/modal.scss
@@ -1,24 +1,43 @@
+$modal-content-margin-mobile: 0;
+$modal-content-margin-mobile: $gi-spacer-lg;
+
+$modal-card-head-background-color: $body-background-color;
+$modal-card-head-border-bottom: none;
+$modal-card-head-padding: $gi-spacer-lg $gi-spacer;
+$modal-card-title-line-height: inherit;
+$modal-card-foot-border-top: $modal-card-head-border-bottom;
+$modal-card-body-padding: 0;
+
 @import "../../node_modules/bulma/sass/components/modal";
 
-.modal-content {
-  &.gi-is-large {
-    background: white;
-    width: 980px;
-    max-width: 100%;
-    padding: $gi-spacer;
-    border-radius: $radius;
+// Bulma customization variables are not enough
+
+.modal-card {
+  .delete {
+    position: absolute;
+    top: $gi-spacer;
+    right: $gi-spacer;
+    z-index: 1;
   }
 
-  @include mobile {
-    &.gi-is-large {
-      margin: 0;
-    }
+  &-head {
+    display: block;
+  }
+
+  &-body,
+  &-foot {
+    flex-direction: column;
+    justify-content: center;
   }
 
   @include tablet {
-    &.gi-is-large {
-      padding: $gi-spacer-lg;
-      max-width: calc(100vw - #{$gi-spacer*2});
+    width: auto;
+
+    &-head,
+    &-body,
+    &-foot {
+      padding-left: $gi-spacer-xl;
+      padding-right: $gi-spacer-xl;
     }
   }
 }

--- a/frontend/simple/assets/sass/bulma_overrides/elements/button.scss
+++ b/frontend/simple/assets/sass/bulma_overrides/elements/button.scss
@@ -3,10 +3,7 @@
 .button {
   min-height: 2.5rem; // A11Y purposes
   color: $grey;
-
-  &.is-outlined {
-    font-weight: 600; // A11Y purposes
-  }
+  font-weight: 600; // A11Y purposes
 }
 
 .button.is-success.is-outlined {
@@ -14,6 +11,10 @@
 }
 
 .buttons {
+  &:last-child {
+    margin-bottom: 0; // overrides bulma layout bug
+  }
+
   &:not(:last-child) {
     margin-bottom: $gi-spacer-sm; // overrides bulma huge margin
   }

--- a/frontend/simple/assets/vendor/primus.js
+++ b/frontend/simple/assets/vendor/primus.js
@@ -3336,7 +3336,7 @@ module.exports = Primus;
 
 },{"demolish":1,"emits":2,"eventemitter3":3,"inherits":4,"querystringify":7,"recovery":8,"tick-tock":11,"url-parse":12,"yeast":13}]},{},[14])(14)
 ;
-Primus.prototype.ark["responder"] = function(){};
+Primus.prototype.ark["responder"] = function (){};
   return Primus;
 },
 [

--- a/frontend/simple/index.html
+++ b/frontend/simple/index.html
@@ -21,6 +21,7 @@
     <div id="app">
       <nav-bar></nav-bar>
       <router-view></router-view>
+      <modal></modal>
       <footer id="debug-pages" class="has-text-centered">
         <!-- Event Log test is hidden because we no longer do it.
              I've left this here to serve as an example of how links

--- a/frontend/simple/main.js
+++ b/frontend/simple/main.js
@@ -11,6 +11,8 @@ import router from './controller/router.js'
 import * as db from './model/database.js'
 import NavBar from './views/containers/NavBar.vue'
 import store from './model/state.js'
+import { LOGOUT } from './utils/events'
+import Modal from './views/components/Modal/Modal.vue'
 
 console.log('NODE_ENV:', process.env.NODE_ENV)
 
@@ -50,10 +52,10 @@ async function startApp () {
   /* eslint-disable no-new */
   new Vue({
     router: router,
-    components: {NavBar},
+    components: {NavBar, Modal},
     store // make this and all child components aware of the new store
   }).$mount('#app')
-  sbp('okTurtles.events/on', 'logout', () => router.push({path: '/'}))
+  sbp('okTurtles.events/on', LOGOUT, () => router.push({path: '/'}))
 }
 
 startApp()

--- a/frontend/simple/model/state.js
+++ b/frontend/simple/model/state.js
@@ -11,6 +11,8 @@ import debounce from 'lodash/debounce'
 import contracts from './contracts.js'
 import * as _ from '../utils/giLodash.js'
 import * as db from './database.js'
+import { LOGIN, LOGOUT, EVENT_HANDLED } from '../utils/events.js'
+
 // babel transforms lodash imports: https://github.com/lodash/babel-plugin-lodash#faq
 // for diff between 'lodash/map' and 'lodash/fp/map'
 // see: https://github.com/lodash/lodash/wiki/FP-Guide
@@ -55,12 +57,12 @@ const state = {
 const mutations = {
   login (state, user) {
     state.loggedIn = user
-    sbp('okTurtles.events/emit', 'login', user)
+    sbp('okTurtles.events/emit', LOGIN, user)
   },
   logout (state) {
     state.loggedIn = false
     state.currentGroupId = null
-    sbp('okTurtles.events/emit', 'logout')
+    sbp('okTurtles.events/emit', LOGOUT)
   },
   addContract (state, {contractID, type, HEAD, data}) {
     // "Mutations Follow Vue's Reactivity Rules" - important for modifying objects
@@ -308,7 +310,7 @@ const actions = {
       debouncedSave(dispatch)
       // let any listening components know that we've received, processed, and stored the event
       sbp('okTurtles.events/emit', HEAD, contractID, message)
-      sbp('okTurtles.events/emit', 'eventHandled', contractID, message)
+      sbp('okTurtles.events/emit', EVENT_HANDLED, contractID, message)
     } catch (e) {
       console.error('[ERROR] exception in handleEvent!', e.message, e)
       throw e // TODO: handle this better

--- a/frontend/simple/utils/events.js
+++ b/frontend/simple/utils/events.js
@@ -1,0 +1,8 @@
+export const LOGIN = 'login'
+export const LOGIN_MODAL = 'login-modal'
+export const LOGOUT = 'logout'
+
+export const EVENT_HANDLED = 'event-handled'
+export const REPLACED_STATE = 'replaced-state'
+
+export const OPEN_MODAL = 'open-modal'

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -31,10 +31,12 @@
 </style>
 <script>
 import sbp from '../../../shared/sbp.js'
+import { LOGIN_MODAL } from '../utils/events'
+
 export default {
   methods: {
     forwardToLogin: function () {
-      sbp('okTurtles.events/emit', 'loginModal')
+      sbp('okTurtles.events/emit', LOGIN_MODAL)
     }
   }
 }

--- a/frontend/simple/views/SignUp.vue
+++ b/frontend/simple/views/SignUp.vue
@@ -115,6 +115,8 @@ import _ from 'lodash'
 import { validationMixin } from 'vuelidate'
 import { required, minLength, email } from 'vuelidate/lib/validators'
 import { nonWhitespace } from './utils/validators.js'
+import { LOGIN_MODAL } from '../utils/events.js'
+
 // TODO: fix all this
 export default {
   name: 'SignUp',
@@ -182,7 +184,7 @@ export default {
       }
     },
     forwardToLogin: function () {
-      sbp('okTurtles.events/emit', 'loginModal')
+      sbp('okTurtles.events/emit', LOGIN_MODAL)
     }
   },
   data () {

--- a/frontend/simple/views/components/GroupSettings.vue
+++ b/frontend/simple/views/components/GroupSettings.vue
@@ -3,17 +3,17 @@
     <div class="column is-4">
       <p class="has-text-weight-bold settings-number" data-test="changePercentage">{{ group.changeThreshold | toPercent }}</p>
       <p class="is-size-5"><i18n>Change Rules</i18n></p>
-      <a href="#"><i18n>Propose change</i18n></a>
+      <a @click.prevent="openProposal('RuleChangeRule')"><i18n>Propose change</i18n></a>
     </div>
     <div class="column is-4">
       <p class="has-text-weight-bold settings-number" data-test="approvePercentage">{{ group.memberApprovalThreshold | toPercent }}</p>
       <p class="is-size-5"><i18n>Add Member</i18n></p>
-      <a href="#"><i18n>Propose change</i18n></a>
+      <a @click.prevent="openProposal('RuleAddMember')"><i18n>Propose change</i18n></a>
     </div>
     <div class="column is-4">
       <p class="has-text-weight-bold settings-number" data-test="removePercentage">{{ group.memberRemovalThreshold | toPercent }}</p>
       <p class="is-size-5"><i18n>Remove Member</i18n></p>
-      <a href="#"><i18n>Propose change</i18n></a>
+      <a @click.prevent="openProposal('RuleRemoveMember')"><i18n>Propose change</i18n></a>
     </div>
   </div>
 </template>
@@ -24,7 +24,18 @@
 }
 </style>
 <script>
-import { toPercent } from '../utils/filters'
+import sbp from '../../../../shared/sbp.js'
+import { toPercent } from '../utils/filters.js'
+import { OPEN_MODAL } from '../../utils/events.js'
+import RuleChangeRule from '../containers/proposals-form/RuleChangeRule.vue'
+import RuleAddMember from '../containers/proposals-form/RuleAddMember.vue'
+import RuleRemoveMember from '../containers/proposals-form/RuleRemoveMember.vue'
+
+const forms = {
+  RuleChangeRule,
+  RuleAddMember,
+  RuleRemoveMember
+}
 
 export default {
   name: 'GroupSettings',
@@ -33,6 +44,11 @@ export default {
   },
   filters: {
     toPercent
+  },
+  methods: {
+    openProposal (component) {
+      sbp('okTurtles.events/emit', OPEN_MODAL, forms[component])
+    }
   }
 }
 </script>

--- a/frontend/simple/views/components/GroupsMinIncome.vue
+++ b/frontend/simple/views/components/GroupsMinIncome.vue
@@ -1,15 +1,13 @@
 <template>
-  <div>
-    <div class="has-text-right">
-      <p class="min-income-label has-text-grey">Min Income</p>
-      <p class="min-income title is-1 is-marginless"
-        data-test="minIncome">
-        {{ currency }}{{ group.incomeProvided }}
-      </p>
-      <a href="#" @click="openProposal">
-        <i18n>Propose change</i18n>
-      </a>
-    </div>
+  <div class="has-text-right">
+    <p class="min-income-label has-text-grey">Min Income</p>
+    <p class="min-income title is-1 is-marginless"
+      data-test="minIncome">
+      {{ currency }}{{ group.incomeProvided }}
+    </p>
+    <a href="#" @click="openProposal">
+      <i18n>Propose change</i18n>
+    </a>
   </div>
 </template>
 <script>

--- a/frontend/simple/views/components/GroupsMinIncome.vue
+++ b/frontend/simple/views/components/GroupsMinIncome.vue
@@ -1,24 +1,37 @@
 <template>
-  <section class="has-text-right">
-    <p class="min-income-label has-text-grey">Min Income</p>
-    <p class="min-income title is-1 is-marginless"
-      data-test="minIncome">
-      {{ currency }}{{ group.incomeProvided }}
-    </p>
-    <a href="#">Propose change</a>
-  </section>
+  <div>
+    <div class="has-text-right">
+      <p class="min-income-label has-text-grey">Min Income</p>
+      <p class="min-income title is-1 is-marginless"
+        data-test="minIncome">
+        {{ currency }}{{ group.incomeProvided }}
+      </p>
+      <a href="#" @click="openProposal">
+        <i18n>Propose change</i18n>
+      </a>
+    </div>
+  </div>
 </template>
 <script>
-  import { symbol } from '../utils/currencies'
-  export default {
-    name: 'GroupsMinIncome',
-    props: {
-      group: Object
-    },
-    computed: {
-      currency: function () {
-        return symbol(this.group.incomeCurrency)
-      }
+import sbp from '../../../../shared/sbp.js'
+import { OPEN_MODAL } from '../../utils/events.js'
+import { symbol } from '../utils/currencies.js'
+import Mincome from '../containers/proposals-form/Mincome.vue'
+
+export default {
+  name: 'GroupsMinIncome',
+  props: {
+    group: Object
+  },
+  computed: {
+    currency: function () {
+      return symbol(this.group.incomeCurrency)
+    }
+  },
+  methods: {
+    openProposal () {
+      sbp('okTurtles.events/emit', OPEN_MODAL, Mincome)
     }
   }
+}
 </script>

--- a/frontend/simple/views/components/Modal/Modal.vue
+++ b/frontend/simple/views/components/Modal/Modal.vue
@@ -1,0 +1,37 @@
+<template>
+  <article class="modal is-active"
+    v-if="isActive"
+  >
+    <div class="modal-background" @click="handleCloseClick"></div>
+    <div class="modal-card">
+      <button class="delete" aria-label="close" @click="handleCloseClick"></button>
+      <component :is="activeModal"></component>
+    </div>
+  </article>
+</template>
+<script>
+import sbp from '../../../../../shared/sbp.js'
+import { OPEN_MODAL } from '../../../utils/events.js'
+
+export default {
+  name: 'ModalForm',
+  data () {
+    return {
+      isActive: false,
+      activeModal: null
+    }
+  },
+  created () {
+    sbp('okTurtles.events/on', OPEN_MODAL, ({ data }) => this.setModal(data))
+  },
+  methods: {
+    setModal (component) {
+      this.activeModal = component
+      this.isActive = true
+    },
+    handleCloseClick () {
+      this.isActive = false
+    }
+  }
+}
+</script>

--- a/frontend/simple/views/components/Modal/Modal.vue
+++ b/frontend/simple/views/components/Modal/Modal.vue
@@ -22,7 +22,7 @@ export default {
     }
   },
   created () {
-    sbp('okTurtles.events/on', OPEN_MODAL, ({ data }) => this.setModal(data))
+    sbp('okTurtles.events/on', OPEN_MODAL, component => this.setModal(component))
   },
   methods: {
     setModal (component) {

--- a/frontend/simple/views/containers/NavBar.vue
+++ b/frontend/simple/views/containers/NavBar.vue
@@ -117,6 +117,7 @@
 import sbp from '../../../../shared/sbp.js'
 import TimeTravel from './TimeTravel.vue'
 import LoginModal from '../containers/LoginModal.vue'
+import { LOGIN_MODAL } from '../../utils/events.js'
 
 export default {
   name: 'NavBar',
@@ -125,7 +126,7 @@ export default {
     TimeTravel
   },
   created () {
-    sbp('okTurtles.events/on', 'loginModal', this.showLoginModal)
+    sbp('okTurtles.events/on', LOGIN_MODAL, this.showLoginModal)
   },
   mounted () {
     global.addEventListener('keyup', this.handleKeyUp)

--- a/frontend/simple/views/containers/TimeTravel.vue
+++ b/frontend/simple/views/containers/TimeTravel.vue
@@ -31,6 +31,8 @@ import sbp from '../../../../shared/sbp.js'
 import VueSlider from 'vue-slider-component'
 import store from '../../model/state.js'
 import _ from 'lodash'
+import { REPLACED_STATE } from '../../utils/events.js'
+
 const disableTimeTravel = true
 export default {
   name: 'TimeTravel',
@@ -55,7 +57,7 @@ export default {
       var state = this.ephemeral.history[position]
       // console.log(`Firing position ${position}:`, state)
       store.replaceState(state)
-      sbp('okTurtles.events/emit', 'replacedState')
+      sbp('okTurtles.events/emit', REPLACED_STATE)
     }
   },
   data () {

--- a/frontend/simple/views/containers/proposals-form/Mincome.vue
+++ b/frontend/simple/views/containers/proposals-form/Mincome.vue
@@ -1,0 +1,24 @@
+<template>
+  <proposal-template
+    :subTitle="L('Change minimum income')"
+    :onSubmit="handleSubmit">
+    I step to change minimum income it's on the way.
+  </proposal-template>
+</template>
+<script>
+import ProposalTemplate from './ProposalTemplate.vue'
+import { mixinL } from '../../utils/mixins.js'
+
+export default {
+  name: 'Mincome',
+  mixins: [
+    mixinL
+  ],
+  components: { ProposalTemplate },
+  methods: {
+    handleSubmit () {
+      console.log('TODO: Logic to Propose a new mincome')
+    }
+  }
+}
+</script>

--- a/frontend/simple/views/containers/proposals-form/ProposalTemplate.vue
+++ b/frontend/simple/views/containers/proposals-form/ProposalTemplate.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <header class="modal-card-head has-text-centered">
+      <h1 class="modal-card-title title is-size-5 is-marginless has-text-grey">
+        <i18n>New Proposal</i18n>
+      </h1>
+      <h2 class="title is-size-3">
+        {{ subTitle }}
+      </h2>
+    </header>
+
+    <section class="modal-card-body">
+      <slot></slot>
+    </section>
+
+    <footer class="modal-card-foot">
+      <div class="buttons">
+        <button class="button is-primary" @click="onSubmit">
+          <i18n>Submit Proposal</i18n>
+        </button>
+      </div>
+      <span v-if="submitError" class="has-text-danger">{{ submitError }}</span>
+    </footer>
+  </div>
+</template>
+<script>
+export default {
+  name: 'ModalForm',
+  props: {
+    subTitle: String,
+    submitError: String,
+    onSubmit: Function
+  }
+}
+</script>

--- a/frontend/simple/views/containers/proposals-form/RuleAddMember.vue
+++ b/frontend/simple/views/containers/proposals-form/RuleAddMember.vue
@@ -1,0 +1,25 @@
+<template>
+  <proposal-template
+    :subTitle="L('Change Rule to Add Member')"
+    :onSubmit="handleSubmit">
+    I step to change rule of add member it's on the way.
+  </proposal-template>
+  </div>
+</template>
+<script>
+import ProposalTemplate from './ProposalTemplate.vue'
+import { mixinL } from '../../utils/mixins.js'
+
+export default {
+  name: 'Mincome',
+  mixins: [
+    mixinL
+  ],
+  components: { ProposalTemplate },
+  methods: {
+    handleSubmit () {
+      console.log('TODO: Logic to Propose a new rule of add member')
+    }
+  }
+}
+</script>

--- a/frontend/simple/views/containers/proposals-form/RuleAddMember.vue
+++ b/frontend/simple/views/containers/proposals-form/RuleAddMember.vue
@@ -4,7 +4,6 @@
     :onSubmit="handleSubmit">
     I step to change rule of add member it's on the way.
   </proposal-template>
-  </div>
 </template>
 <script>
 import ProposalTemplate from './ProposalTemplate.vue'

--- a/frontend/simple/views/containers/proposals-form/RuleChangeRule.vue
+++ b/frontend/simple/views/containers/proposals-form/RuleChangeRule.vue
@@ -1,0 +1,25 @@
+<template>
+  <proposal-template
+    :subTitle="L('Change Rule to change Rule')"
+    :onSubmit="handleSubmit">
+    I step to change rule of change rule it's on the way
+  </proposal-template>
+  </div>
+</template>
+<script>
+import ProposalTemplate from './ProposalTemplate.vue'
+import { mixinL } from '../../utils/mixins.js'
+
+export default {
+  name: 'Mincome',
+  mixins: [
+    mixinL
+  ],
+  components: { ProposalTemplate },
+  methods: {
+    handleSubmit () {
+      console.log('TODO: Logic to Propose a new rule to change a rule')
+    }
+  }
+}
+</script>

--- a/frontend/simple/views/containers/proposals-form/RuleChangeRule.vue
+++ b/frontend/simple/views/containers/proposals-form/RuleChangeRule.vue
@@ -4,7 +4,6 @@
     :onSubmit="handleSubmit">
     I step to change rule of change rule it's on the way
   </proposal-template>
-  </div>
 </template>
 <script>
 import ProposalTemplate from './ProposalTemplate.vue'

--- a/frontend/simple/views/containers/proposals-form/RuleRemoveMember.vue
+++ b/frontend/simple/views/containers/proposals-form/RuleRemoveMember.vue
@@ -1,0 +1,25 @@
+<template>
+  <proposal-template
+    :subTitle="L('Change Rule to Remove Member')"
+    :onSubmit="handleSubmit">
+    I step to change rule of remove member it's on the way
+  </proposal-template>
+  </div>
+</template>
+<script>
+import ProposalTemplate from './ProposalTemplate.vue'
+import { mixinL } from '../../utils/mixins.js'
+
+export default {
+  name: 'Mincome',
+  mixins: [
+    mixinL
+  ],
+  components: { ProposalTemplate },
+  methods: {
+    handleSubmit () {
+      console.log('TODO: Logic to Propose a new rule of remove member')
+    }
+  }
+}
+</script>

--- a/frontend/simple/views/containers/proposals-form/RuleRemoveMember.vue
+++ b/frontend/simple/views/containers/proposals-form/RuleRemoveMember.vue
@@ -4,7 +4,6 @@
     :onSubmit="handleSubmit">
     I step to change rule of remove member it's on the way
   </proposal-template>
-  </div>
 </template>
 <script>
 import ProposalTemplate from './ProposalTemplate.vue'

--- a/frontend/simple/views/utils/mixins.js
+++ b/frontend/simple/views/utils/mixins.js
@@ -1,0 +1,12 @@
+import L from './translations'
+import template from 'string-template'
+
+// TODO in the future the L function itself will do the template expansion,
+// and we'll get rid of 'string-template' dependency.
+export const mixinL = {
+  methods: {
+    L (text, opts = {}) {
+      return template(L(text), opts)
+    }
+  }
+}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14869087/41375472-21566530-6f4e-11e8-9427-a0f30d0a7fc9.png)

So, guys, I have some doubts about the code strategy/architecture of this proposals, so I'm opening this PR still WIP, to get your feedback.

## First things first
I've created `ModalForm.vue` under `components/Modals` because I'm pretty sure in the future we'll have other types of modal besides "ModalForm". So all Modals will be under that folder similar to `components/Graphs`

## Problem on the way
`ModalForm` has some props (isActive, title, onSubmit, etc...) and a `<slot>` where it would go the modal body, in this case, the proposal step. It seems okay at first but... I already added to `GroupMinIncome`, `GroupSettings` and `GroupMembers` the `ModalForm` and  so far 80% of the code it's the same:

```vue
<modal-form
  :isActive="isActive"
  :title="modalTitle"
  :subTitle="modalSubTitle"
  :submitText="modalSubmitText"
  :onSubmit="handleSubmit"
  :onClose="toggleModal"
>
      Particular step to propose something is on its way!
</modal-form>

// ...

<script>
// [1] - this is the only part that it's really different from each proposal

  data () {
    return {
      isActive: false
    }
  },
  methods: {
    toggleModal () {
      this.isActive = !this.isActive
    },
    handleSubmit () {
      console.log('TODO: Open Proposal - Add Member') // [1]
    }
  },
  computed: {
    modalTitle () { return L('New Proposal') },
    modalSubTitle () { return L('Add Member {name}') }, // [1]
    modalSubmitText () { return L('Start Proposal') }
  }
</script>
```

This is not DRY at all ... I would like to reuse this logic but I don't know exactly what's the best way to do it on Vue....

## Possible Solution?
I was thinking about something similar to a High Order Component (React concept) where we would create `components/ProposalForm.vue` with all common ui/logic between  each step (title, isActive, buttonText, etc...). Then each component that has a proposal trigger, just need to use it:

```vue
<button @click="openModal">Propose Change</button>

<proposal-form
  subtitle="Add Member"
  onSubmit="submitStep"
  someEventSlashEmit="openModal"
>
  <add-member-step-container someEventSlashEmit="submitStep" />
</proposal-form>
```

I don't even know if this is possible on Vue... or if I'm even over complicating things :X

Maybe to simplify things, this PR can be just `ModalForm`, and then we open a PR for each "propose change" calling the ModalForm + Logic to make it work.

What do you think guys? 

---

## Edit 2nd August

https://github.com/okTurtles/group-income-simple/pull/428#issuecomment-410067372