### PR TITLE
#439 refactor login modal to use modal component

### DIFF
--- a/frontend/simple/assets/sass/bulma_overrides/components/modal.scss
+++ b/frontend/simple/assets/sass/bulma_overrides/components/modal.scss
@@ -38,6 +38,12 @@ $modal-card-body-padding: 0;
     &-foot {
       padding-left: $gi-spacer-xl;
       padding-right: $gi-spacer-xl;
+
+      .is-small & {
+        width: 20rem;
+        padding-left: $gi-spacer-lg;
+        padding-right: $gi-spacer-lg;
+      }
     }
   }
 }

--- a/frontend/simple/utils/events.js
+++ b/frontend/simple/utils/events.js
@@ -1,8 +1,8 @@
 export const LOGIN = 'login'
-export const LOGIN_MODAL = 'login-modal'
 export const LOGOUT = 'logout'
 
 export const EVENT_HANDLED = 'event-handled'
 export const REPLACED_STATE = 'replaced-state'
 
 export const OPEN_MODAL = 'open-modal'
+export const CLOSE_MODAL = 'close-modal'

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -31,12 +31,13 @@
 </style>
 <script>
 import sbp from '../../../shared/sbp.js'
-import { LOGIN_MODAL } from '../utils/events'
+import LoginModal from './containers/LoginModal.vue'
+import { OPEN_MODAL } from '../utils/events'
 
 export default {
   methods: {
     forwardToLogin: function () {
-      sbp('okTurtles.events/emit', LOGIN_MODAL)
+      sbp('okTurtles.events/emit', OPEN_MODAL, LoginModal)
     }
   }
 }

--- a/frontend/simple/views/SignUp.vue
+++ b/frontend/simple/views/SignUp.vue
@@ -115,7 +115,8 @@ import _ from 'lodash'
 import { validationMixin } from 'vuelidate'
 import { required, minLength, email } from 'vuelidate/lib/validators'
 import { nonWhitespace } from './utils/validators.js'
-import { LOGIN_MODAL } from '../utils/events.js'
+import { OPEN_MODAL } from '../utils/events.js'
+import LoginModal from './containers/LoginModal.vue'
 
 // TODO: fix all this
 export default {
@@ -183,8 +184,8 @@ export default {
         this.form.error = true
       }
     },
-    forwardToLogin: function () {
-      sbp('okTurtles.events/emit', LOGIN_MODAL)
+    forwardToLogin () {
+      sbp('okTurtles.events/emit', OPEN_MODAL, LoginModal)
     }
   },
   data () {

--- a/frontend/simple/views/components/Modal/Modal.vue
+++ b/frontend/simple/views/components/Modal/Modal.vue
@@ -1,5 +1,6 @@
 <template>
   <article class="modal is-active"
+    data-test="modal"
     v-if="isActive"
   >
     <div class="modal-background" @click="handleCloseClick"></div>
@@ -11,7 +12,7 @@
 </template>
 <script>
 import sbp from '../../../../../shared/sbp.js'
-import { OPEN_MODAL } from '../../../utils/events.js'
+import { OPEN_MODAL, CLOSE_MODAL } from '../../../utils/events.js'
 
 export default {
   name: 'ModalForm',
@@ -21,15 +22,27 @@ export default {
       activeModal: null
     }
   },
+  mounted () {
+    global.addEventListener('keyup', this.handleKeyUp)
+  },
   created () {
-    sbp('okTurtles.events/on', OPEN_MODAL, component => this.setModal(component))
+    sbp('okTurtles.events/on', OPEN_MODAL, component => this.openModal(component))
+    sbp('okTurtles.events/on', CLOSE_MODAL, this.closeModal)
   },
   methods: {
-    setModal (component) {
+    openModal (component) {
       this.activeModal = component
       this.isActive = true
     },
     handleCloseClick () {
+      this.closeModal()
+    },
+    handleKeyUp (event) {
+      if (this.isActive && event.keyCode === 27) { // esc key
+        this.closeModal()
+      }
+    },
+    closeModal () {
       this.isActive = false
     }
   }

--- a/frontend/simple/views/components/Modal/ModalBody.vue
+++ b/frontend/simple/views/components/Modal/ModalBody.vue
@@ -1,0 +1,10 @@
+<template>
+  <section class="modal-card-body">
+    <slot></slot>
+  </section>
+</template>
+<script>
+export default {
+  name: 'ModalBody'
+}
+</script>

--- a/frontend/simple/views/components/Modal/ModalFooter.vue
+++ b/frontend/simple/views/components/Modal/ModalFooter.vue
@@ -1,0 +1,16 @@
+<template>
+  <footer class="modal-card-foot">
+    <div class="buttons">
+      <slot></slot>
+    </div>
+    <p v-if="submitError" class="has-text-danger" data-test="submitError">{{ submitError }}</p>
+  </footer>
+</template>
+<script>
+export default {
+  name: 'ModalHeader',
+  props: {
+    submitError: String
+  }
+}
+</script>

--- a/frontend/simple/views/components/Modal/ModalHeader.vue
+++ b/frontend/simple/views/components/Modal/ModalHeader.vue
@@ -1,0 +1,16 @@
+<template>
+  <header class="modal-card-head has-text-centered">
+    <h1 class="modal-card-title title is-size-5 is-marginless has-text-grey" v-if="$slots.subTitle">
+      <slot></slot>
+    </h1>
+    <h2 class="title is-size-3">
+      <slot name="subTitle" v-if="$slots.subTitle"></slot>
+      <slot v-else></slot>
+    </h2>
+  </header>
+</template>
+<script>
+export default {
+  name: 'ModalHeader'
+}
+</script>

--- a/frontend/simple/views/containers/LoginModal.vue
+++ b/frontend/simple/views/containers/LoginModal.vue
@@ -1,86 +1,82 @@
 <template>
-  <div class="modal is-active"
-    ref="modal"
-    data-test="loginModal"
-  >
-    <div class="modal-background" @click="close"></div>
-    <div class="modal-content" style="width: 300px;">
-      <div class="card is-rounded">
-        <div class="card-content">
-          <h1 class="title has-text-centered"><i18n>Log In</i18n></h1>
-          <div class="field">
-            <p class="control has-icon">
-              <input
-                id="LoginName"
-                class="input"
-                :class="{'is-danger': $v.form.name.$error}"
-                name="name"
-                v-model="form.name"
-                @keyup.enter="login"
-                @input="$v.form.name.$touch()"
-                placeholder="username"
-                ref="username"
-                autofocus
-                data-test="loginName"
-              >
-              <span class="icon">
-                <i class="fa fa-user"></i>
-              </span>
-            </p>
-            <i18n v-show="$v.form.name.$error" class="help is-danger">username cannot contain spaces</i18n>
-          </div>
-          <div class="field">
-            <p class="control has-icon">
-              <input
-                class="input"
-                :class="{'is-danger': $v.form.password.$error}"
-                id="LoginPassword"
-                name="password"
-                v-model="form.password"
-                @keyup.enter="login"
-                @input="$v.form.password.$touch()"
-                placeholder="password"
-                type="password"
-                data-test="loginPassword"
-              >
-              <span class="icon"><i class="fa fa-lock"></i></span>
-            </p>
-            <i18n v-show="$v.form.password.$error" class="help is-danger">password must be at least 7 characters</i18n>
-          </div>
-          <p class="help is-danger"
-            v-show="form.response"
-            data-test="loginResponse"
+  <div class="is-small">
+    <modal-header>
+      <i18n>Log In</i18n>
+    </modal-header>
+
+    <modal-body>
+      <div class="field">
+        <p class="control has-icon">
+          <input
+            id="LoginName"
+            class="input"
+            :class="{'is-danger': $v.form.name.$error}"
+            name="name"
+            v-model="form.name"
+            @keyup.enter="login"
+            @input="$v.form.name.$touch()"
+            placeholder="username"
+            ref="username"
+            autofocus
+            data-test="loginName"
           >
-            {{ form.response }}
-          </p>
-          <div class="field">
-            <p class="control">
-              <button
-                class="button is-primary is-medium is-fullwidth"
-                @click="login"
-                :disabled="$v.form.$invalid"
-                data-test="loginSubmit"
-              >
-                <span class="icon"><i class="fa fa-user"></i></span>
-                <i18n>Login</i18n>
-              </button>
-            </p>
-          </div>
-        </div>
+          <span class="icon">
+            <i class="fa fa-user"></i>
+          </span>
+        </p>
+        <i18n v-show="$v.form.name.$error" class="help is-danger">username cannot contain spaces</i18n>
       </div>
-    </div>
-    <div class="modal-close" @click="close"></div>
+      <div class="field">
+        <p class="control has-icon">
+          <input
+            class="input"
+            :class="{'is-danger': $v.form.password.$error}"
+            id="LoginPassword"
+            name="password"
+            v-model="form.password"
+            @keyup.enter="login"
+            @input="$v.form.password.$touch()"
+            placeholder="password"
+            type="password"
+            data-test="loginPassword"
+          >
+          <span class="icon"><i class="fa fa-lock"></i></span>
+        </p>
+        <i18n v-show="$v.form.password.$error" class="help is-danger">password must be at least 7 characters</i18n>
+      </div>
+    </modal-body>
+
+    <modal-footer :submitError="form.response">
+      <button
+        class="button is-primary"
+        :disabled="$v.form.$invalid"
+        data-test="loginSubmit"
+        @click="login"
+      >
+        <span class="icon"><i class="fa fa-user"></i></span>
+        <i18n>Login</i18n>
+      </button>
+    </modal-footer>
   </div>
 </template>
 <script>
-import sbp from '../../../../shared/sbp.js'
-import L from '../utils/translations.js'
 import { validationMixin } from 'vuelidate'
 import { required, minLength } from 'vuelidate/lib/validators'
+import sbp from '../../../../shared/sbp.js'
+import L from '../utils/translations.js'
+import { CLOSE_MODAL } from '../../utils/events.js'
+import ModalHeader from '../components/Modal/ModalHeader.vue'
+import ModalBody from '../components/Modal/ModalBody.vue'
+import ModalFooter from '../components/Modal/ModalFooter.vue'
 
 export default {
   name: 'LoginModal',
   mixins: [ validationMixin ],
+  components: {
+    ModalHeader,
+    ModalBody,
+    ModalFooter
+  },
   inserted () {
     this.$refs.username.focus()
   },
@@ -99,7 +95,7 @@ export default {
       }
     },
     close () {
-      this.$emit('close')
+      sbp('okTurtles.events/emit', CLOSE_MODAL)
     }
   },
   data () {

--- a/frontend/simple/views/containers/NavBar.vue
+++ b/frontend/simple/views/containers/NavBar.vue
@@ -90,10 +90,6 @@
           </div>
         </div>
       </div>
-      <login-modal
-        v-if="loginModalVisible"
-        @close="closeLoginModal"
-      />
       <time-travel v-show="showTimeTravel" :toggleVisibility="toggleTimeTravel" />
     </div>
   </nav>
@@ -116,20 +112,13 @@
 <script>
 import sbp from '../../../../shared/sbp.js'
 import TimeTravel from './TimeTravel.vue'
-import LoginModal from '../containers/LoginModal.vue'
-import { LOGIN_MODAL } from '../../utils/events.js'
+import LoginModal from './LoginModal.vue'
+import { OPEN_MODAL } from '../../utils/events.js'
 
 export default {
   name: 'NavBar',
   components: {
-    LoginModal,
     TimeTravel
-  },
-  created () {
-    sbp('okTurtles.events/on', LOGIN_MODAL, this.showLoginModal)
-  },
-  mounted () {
-    global.addEventListener('keyup', this.handleKeyUp)
   },
   computed: {
     currentGroupId () {
@@ -140,19 +129,11 @@ export default {
     }
   },
   methods: {
-    handleKeyUp (event) {
-      if (this.visible && event.keyCode === 27) {
-        this.closeLoginModal()
-      }
-    },
     logout () {
       this.$store.dispatch('logout')
     },
     showLoginModal () {
-      this.loginModalVisible = true
-    },
-    closeLoginModal () {
-      this.loginModalVisible = false
+      sbp('okTurtles.events/emit', OPEN_MODAL, LoginModal)
     },
     toggleTimeTravel (event) {
       if (!event.altKey) return
@@ -162,8 +143,7 @@ export default {
   },
   data () {
     return {
-      showTimeTravel: false,
-      loginModalVisible: false
+      showTimeTravel: false
     }
   }
 }

--- a/frontend/simple/views/containers/proposals-form/ProposalTemplate.vue
+++ b/frontend/simple/views/containers/proposals-form/ProposalTemplate.vue
@@ -1,31 +1,33 @@
 <template>
   <div>
-    <header class="modal-card-head has-text-centered">
-      <h1 class="modal-card-title title is-size-5 is-marginless has-text-grey">
-        <i18n>New Proposal</i18n>
-      </h1>
-      <h2 class="title is-size-3">
-        {{ subTitle }}
-      </h2>
-    </header>
+    <modal-header>
+      <i18n>New Proposal</i18n>
+      <template slot="subTitle">{{ subTitle }}</template>
+    </modal-header>
 
-    <section class="modal-card-body">
+    <modal-body>
       <slot></slot>
-    </section>
+    </modal-body>
 
-    <footer class="modal-card-foot">
-      <div class="buttons">
-        <button class="button is-primary" @click="onSubmit">
-          <i18n>Submit Proposal</i18n>
-        </button>
-      </div>
-      <span v-if="submitError" class="has-text-danger">{{ submitError }}</span>
-    </footer>
+    <modal-footer :submitError="submitError">
+      <button class="button is-primary" @click="onSubmit">
+        <i18n>Submit Proposal</i18n>
+      </button>
+    </modal-footer>
   </div>
 </template>
 <script>
+import ModalHeader from '../../components/Modal/ModalHeader.vue'
+import ModalBody from '../../components/Modal/ModalBody.vue'
+import ModalFooter from '../../components/Modal/ModalFooter.vue'
+
 export default {
   name: 'ModalForm',
+  components: {
+    ModalHeader,
+    ModalBody,
+    ModalFooter
+  },
   props: {
     subTitle: String,
     submitError: String,

--- a/test/frontend.js
+++ b/test/frontend.js
@@ -37,7 +37,7 @@ function login (name) {
   return function (n) {
     n.wait(elT('loginBtn'))
       .click(elT('loginBtn'))
-      .wait(`${elT('loginModal')}.is-active`)
+      .wait(elT('modal'))
       .insert(elT('loginName'), name)
       .insert(elT('loginPassword'), 'testtest')
       .click(elT('loginSubmit'))


### PR DESCRIPTION
### Important:
Review/Merge this only after #428 is merged.

---

Closes #439. `LoginModal.vue` uses `components/Modal` logic using `sbp()`.

Common parts between `LoginModal` and `ProposalsTemplate` were abstracted to their own components `ModalHeader`, `ModalBody` and `ModalFooter`.

### Old vs New design
Now all modals headings, borders and paddings should be similar.

<img width="402" alt="screen shot 2018-08-02 at 11 11 28" src="https://user-images.githubusercontent.com/14869087/43618942-16d83fbc-9667-11e8-8808-3579fdf2531b.png">
<img width="427" alt="screen shot 2018-08-02 at 15 16 34" src="https://user-images.githubusercontent.com/14869087/43618944-17097442-9667-11e8-8f07-c607f5dd3632.png">

### Scout rule
Reused eventListener to key `esc` to close a modal when's open from `LoginModal` to `components/Modal`, so now it will be applied in every modal. Closes #188.