### PR TITLE
Update to Vue.js to 2.5.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2521,9 +2521,9 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000693",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000693.tgz",
-      "integrity": "sha1-hRDnqasErcyiOl3O+jTfnSjBziA=",
+      "version": "1.0.30000874",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000874.tgz",
+      "integrity": "sha1-Se3AJi79xsSdTZYrsW0fDHkPpE4=",
       "dev": true
     },
     "caniuse-lite": {
@@ -2697,9 +2697,9 @@
       "dev": true
     },
     "clap": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
-      "integrity": "sha1-WckP4+E3EEdG/xlGmiemNP9oyFc=",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
+      "integrity": "sha512-4CoL/A3hf90V3VIEjeuhSvlGFEHKzOz+Wfc2IVZc+FaUgU0ZQafJTP49fvnULipOPcAfqhyI2duwQyns6xqjYA==",
       "dev": true,
       "requires": {
         "chalk": "^1.1.3"
@@ -2810,9 +2810,9 @@
       "dev": true
     },
     "coa": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.3.tgz",
-      "integrity": "sha1-G1Sl4dz3fJkEVdTe6pjFZEFtyJM=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+      "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
       "dev": true,
       "requires": {
         "q": "^1.1.2"
@@ -2915,15 +2915,6 @@
             "clone": "^1.0.2",
             "color-convert": "^1.3.0",
             "color-string": "^0.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-          "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
-          "dev": true,
-          "requires": {
-            "color-name": "^1.1.1"
           }
         }
       }
@@ -3121,9 +3112,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
       "dev": true
     },
     "copy-descriptor": {
@@ -3331,9 +3322,9 @@
       },
       "dependencies": {
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         }
       }
@@ -3845,9 +3836,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.14",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz",
-      "integrity": "sha1-ZK8Pnv08PGrNV9cfg7Scp+6cS0M=",
+      "version": "1.3.55",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.55.tgz",
+      "integrity": "sha1-8VDhCyC3fZ1Br8yjEu/gw7Gn/c4=",
       "dev": true
     },
     "elliptic": {
@@ -7769,12 +7760,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "macaddress": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.9.tgz",
-      "integrity": "sha512-k4F1JUof6cQXxNFzx3thLby4oJzXTXQueAOOts944Vqizn+Rjc2QNFenT9FJSLU1CH3PmrHRSyZs2E+Cqw+P2w==",
-      "dev": true
-    },
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
@@ -9302,13 +9287,12 @@
       }
     },
     "postcss-filter-plugins": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+      "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "dev": true,
       "requires": {
-        "postcss": "^5.0.4",
-        "uniqid": "^4.0.0"
+        "postcss": "^5.0.4"
       }
     },
     "postcss-html": {
@@ -10037,9 +10021,9 @@
       "dev": true
     },
     "q": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-      "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE=",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
       "dev": true
     },
     "qs": {
@@ -12955,15 +12939,6 @@
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
     },
-    "uniqid": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true,
-      "requires": {
-        "macaddress": "^0.2.8"
-      }
-    },
     "uniqs": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz",
@@ -13209,9 +13184,9 @@
       "integrity": "sha1-/Idx2N/hE2/wKnB+EPuwlXxLAw8="
     },
     "vendors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-      "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+      "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
       "dev": true
     },
     "verror": {
@@ -13278,9 +13253,9 @@
       }
     },
     "vue": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-2.3.4.tgz",
-      "integrity": "sha512-oLCxuVcVQ2inwSbS7B+zfjB6CSjgQ0yyCOzPcg7S5CXeOCbtkaiN5frR6MtwvrveqbG86OsGd9jWf6JsGyQkLw=="
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.5.17.tgz",
+      "integrity": "sha512-mFbcWoDIJi0w0Za4emyLiW72Jae0yjANHbCVquMKijcavBGypqlF7zHRgMa5k4sesdv7hv2rB4JPdZfR+TPfhQ=="
     },
     "vue-circle-slider": {
       "version": "1.0.0",
@@ -13334,9 +13309,9 @@
       "integrity": "sha1-PA5/5V4MtlARK6B95r+1mgzH48Y="
     },
     "vue-template-compiler": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.3.4.tgz",
-      "integrity": "sha512-GezvHn6bw053zIo0TQIjimRpyELjCEOrc5hGHtHUeadbVSdKB9yqY6By9WiYvbFwOZiuMmFpSfjD8VzVibWGtQ==",
+      "version": "2.5.17",
+      "resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.5.17.tgz",
+      "integrity": "sha512-63uI4syCwtGR5IJvZM0LN5tVsahrelomHtCxvRkZPJ/Tf3ADm1U1wG6KWycK3qCfqR+ygM5vewUvmJ0REAYksg==",
       "dev": true,
       "requires": {
         "de-indent": "^1.0.2",
@@ -13344,9 +13319,9 @@
       }
     },
     "vue-template-es2015-compiler": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.5.2.tgz",
-      "integrity": "sha1-oKbFDJQdKkq9qWPy9CwzesRQ7pU=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz",
+      "integrity": "sha512-x3LV3wdmmERhVCYy3quqA57NJW7F3i6faas++pJQWtknWT+n7k30F4TVdHvCLn48peTJFRvCpxs3UuFPqgeELg==",
       "dev": true
     },
     "vueify": {
@@ -13391,9 +13366,9 @@
           }
         },
         "source-map": {
-          "version": "0.5.6",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
-          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "dev": true
         },
         "supports-color": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "tweetnacl-util": "0.15.0",
     "uws": "10.148.0",
     "velocity-animate": "1.5.0",
-    "vue": "2.3.4",
+    "vue": "2.5.17",
     "vue-circle-slider": "1.0.0",
     "vue-router": "2.6.0",
     "vue-script2": "2.0.0",


### PR DESCRIPTION
### Update Dependencies
#### Update `Vue` 2.3.4 -> 2.5.17
- Now we can [Disabling-Attribute-Inheritance](https://vuejs.org/v2/guide/components-props.html#Disabling-Attribute-Inheritance)
- And [much more](https://github.com/vuejs/vue/releases)

Note: `vueify`'s dependencies were updated too because of the following error:
>> Error:
>>
>> Vue packages version mismatch:
>>
>> - vue@2.5.17
>> - vue-template-compiler@2.3.4
>>
>> This may cause things to work incorrectly. Make sure to use the same version for both.
>> If you are using vue-loader@>=10.0, simply update vue-template-compiler.
>> If you are using vue-loader@<10.0 or vueify, re-installing vue-loader/vueify should bump vue-template-compiler to the latest.