### PR TITLE
#442 Change signup view from page to modal

### DIFF
--- a/frontend/simple/controller/router.js
+++ b/frontend/simple/controller/router.js
@@ -19,7 +19,6 @@ import Home from '../views/Home.vue'
 import Invite from '../views/Invite.vue'
 import Join from '../views/Join.vue'
 import Mailbox from '../views/Mailbox.vue'
-import SignUp from '../views/SignUp.vue'
 import PayGroup from '../views/PayGroup.vue'
 import UserProfile from '../views/UserProfile.vue'
 import Vote from '../views/Vote.vue'
@@ -37,11 +36,7 @@ var homeGuard = {
 }
 var loginGuard = {
   guard: (to, from) => !store.state.loggedIn,
-  redirect: (to, from) => ({ path: '/signup', query: { next: to.path } })
-}
-var signupGuard = {
-  guard: (to, from) => !!store.state.loggedIn,
-  redirect: (to, from) => ({ path: '/' })
+  redirect: (to, from) => ({ path: '/', query: { next: to.path } })
 }
 // Check if user has a group
 var groupGuard = {
@@ -86,15 +81,6 @@ var router = new Router({
         title: 'Design System'
       }
       // beforeEnter: createEnterGuards(designGuard)
-    },
-    {
-      path: '/signup',
-      component: SignUp,
-      name: SignUp.name, // route name. important!
-      meta: {
-        title: 'Sign Up' // page title. see issue #45
-      },
-      beforeEnter: createEnterGuards(signupGuard)
     },
     {
       path: '/new-group',
@@ -192,7 +178,8 @@ var router = new Router({
       component: PayGroup,
       meta: {
         title: 'Pay Group'
-      }
+      },
+      beforeEnter: createEnterGuards(loginGuard)
     },
     /* Guards need to be created for any route that should not be directly accessed by url */
     {

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -5,7 +5,7 @@
         <br>
         <h1 class="title is-3"><i18n>Welcome to GroupIncome</i18n></h1>
         <div v-if="!$store.state.loggedIn">
-          <a v-on:click="forwardToLogin"><i18n>Login</i18n></a> or <router-link to="signup"><i18n>Sign Up</i18n></router-link> <i18n>to continue</i18n>
+          <a v-on:click="showLoginModal"><i18n>Login</i18n></a> or <a @click="showSignUpModal"><i18n>Sign Up</i18n></a> <i18n>to continue</i18n>
         </div>
         <div v-else>
           <router-link
@@ -30,14 +30,25 @@
   }
 </style>
 <script>
+import '../controller/router.js'
 import sbp from '../../../shared/sbp.js'
 import LoginModal from './containers/LoginModal.vue'
+import SignUp from './containers/SignUp.vue'
 import { OPEN_MODAL } from '../utils/events'
 
 export default {
+  name: 'Home',
+  mounted () {
+    if (this.$route.query.next) {
+      this.showLoginModal()
+    }
+  },
   methods: {
-    forwardToLogin: function () {
+    showLoginModal () {
       sbp('okTurtles.events/emit', OPEN_MODAL, LoginModal)
+    },
+    showSignUpModal () {
+      sbp('okTurtles.events/emit', OPEN_MODAL, SignUp)
     }
   }
 }

--- a/frontend/simple/views/components/Modal/ModalFooter.vue
+++ b/frontend/simple/views/components/Modal/ModalFooter.vue
@@ -4,6 +4,7 @@
       <slot></slot>
     </div>
     <p v-if="submitError" class="has-text-danger" data-test="submitError">{{ submitError }}</p>
+    <slot name="footer"></slot>
   </footer>
 </template>
 <script>

--- a/frontend/simple/views/containers/LoginModal.vue
+++ b/frontend/simple/views/containers/LoginModal.vue
@@ -56,6 +56,9 @@
         <span class="icon"><i class="fa fa-user"></i></span>
         <i18n>Login</i18n>
       </button>
+      <template slot="footer">
+        <a @click="showSignUpModal"><i18n>Don't have an account?</i18n></a>
+      </template>
     </modal-footer>
   </div>
 </template>
@@ -64,10 +67,11 @@ import { validationMixin } from 'vuelidate'
 import { required, minLength } from 'vuelidate/lib/validators'
 import sbp from '../../../../shared/sbp.js'
 import L from '../utils/translations.js'
-import { CLOSE_MODAL } from '../../utils/events.js'
+import { OPEN_MODAL, CLOSE_MODAL } from '../../utils/events.js'
 import ModalHeader from '../components/Modal/ModalHeader.vue'
 import ModalBody from '../components/Modal/ModalBody.vue'
 import ModalFooter from '../components/Modal/ModalFooter.vue'
+import SignUp from './SignUp.vue'
 
 export default {
   name: 'LoginModal',
@@ -96,6 +100,9 @@ export default {
     },
     close () {
       sbp('okTurtles.events/emit', CLOSE_MODAL)
+    },
+    showSignUpModal () {
+      sbp('okTurtles.events/emit', OPEN_MODAL, SignUp)
     }
   },
   data () {

--- a/frontend/simple/views/containers/NavBar.vue
+++ b/frontend/simple/views/containers/NavBar.vue
@@ -7,13 +7,13 @@
     </div>
       <div class="navbar-end is-flex">
         <div class="navbar-item signUp-item" v-if="!$store.state.loggedIn">
-          <router-link
+          <button
             class="button is-success"
             data-test="signupBtn"
-            to="signup"
+            @click="showSignUpModal"
           >
             <i18n>Sign Up</i18n>
-          </router-link>
+          </button>
         </div>
         <div class="navbar-item" v-if="!$store.state.loggedIn">
           <button class="button is-primary"
@@ -113,6 +113,7 @@
 import sbp from '../../../../shared/sbp.js'
 import TimeTravel from './TimeTravel.vue'
 import LoginModal from './LoginModal.vue'
+import SignUp from './SignUp.vue'
 import { OPEN_MODAL } from '../../utils/events.js'
 
 export default {
@@ -134,6 +135,9 @@ export default {
     },
     showLoginModal () {
       sbp('okTurtles.events/emit', OPEN_MODAL, LoginModal)
+    },
+    showSignUpModal () {
+      sbp('okTurtles.events/emit', OPEN_MODAL, SignUp)
     },
     toggleTimeTravel (event) {
       if (!event.altKey) return

--- a/frontend/simple/views/containers/SignUp.vue
+++ b/frontend/simple/views/containers/SignUp.vue
@@ -1,64 +1,56 @@
 <template>
-  <section class="section level">
-    <form class="signup level-item"
-      novalidate ref="form"
-      name="formData"
-      data-test="signup"
-      @submit.prevent="submit"
-    >
-      <div class="box gi-box">
-        <div class="level is-mobile">
-          <div class="level-left">
-            <div class="level-item">
-              <p class="title is-5"><i18n>Sign Up</i18n></p>
-            </div>
-          </div>
-          <div class="level-right">
-            <p class="level-item content is-small">
-              <a @click="forwardToLogin"><i18n>Have an account?</i18n></a>
-            </p>
-          </div>
-        </div>
-        <div class="field">
-          <p class="control has-icon">
-            <input
-              id="name"
-              class="input"
-              :class="{'is-danger': $v.form.name.$error}"
-              name="name"
-              @input="debounceName"
-              placeholder="username"
-              autofocus
-              data-test="signName"
-            >
-            <span class="icon"><i class="fa fa-user"></i></span>
-          </p>
-          <p class="help is-danger"
-            data-test="badUsername"
-            v-if="$v.form.name.$error"
+  <form class="is-small"
+    novalidate ref="form"
+    name="formData"
+    data-test="signup"
+    @submit.prevent="submit">
+
+    <modal-header>
+      <i18n>Sign Up</i18n>
+    </modal-header>
+
+    <modal-body>
+      <div class="field">
+        <p class="control has-icon">
+          <input
+            id="name"
+            class="input"
+            :class="{'is-danger': $v.form.name.$error}"
+            name="name"
+            @input="debounceName"
+            placeholder="username"
+            ref="username"
+            autofocus
+            data-test="signName"
           >
-            <i18n v-if="!$v.form.name.isAvailable">name is unavailable</i18n>
-            <i18n v-if="!$v.form.name.nonWhitespace">cannot contain spaces</i18n>
-          </p>
-        </div>
-        <div class="field">
-          <p class="control has-icon">
-            <input
-              class="input"
-              :class="{'is-danger': $v.form.email.$error}"
-              id="email"
-              name="email"
-              v-model="form.email"
-              @blur="$v.form.email.$touch()"
-              type="email"
-              placeholder="email"
-              data-test="signEmail"
-            >
-            <span class="icon"><i class="fa fa-envelope"></i></span>
-          </p>
-          <i18n v-if="$v.form.email.$error" class="help is-danger" data-test="badEmail">not an email</i18n>
-        </div>
-        <div class="field">
+          <span class="icon"><i class="fa fa-user"></i></span>
+        </p>
+        <p class="help is-danger"
+          data-test="badUsername"
+          v-if="$v.form.name.$error"
+        >
+          <i18n v-if="!$v.form.name.isAvailable">name is unavailable</i18n>
+          <i18n v-if="!$v.form.name.nonWhitespace">cannot contain spaces</i18n>
+        </p>
+      </div>
+      <div class="field">
+        <p class="control has-icon">
+          <input
+            class="input"
+            :class="{'is-danger': $v.form.email.$error}"
+            id="email"
+            name="email"
+            v-model="form.email"
+            @blur="$v.form.email.$touch()"
+            type="email"
+            placeholder="email"
+            data-test="signEmail"
+          >
+          <span class="icon"><i class="fa fa-envelope"></i></span>
+        </p>
+        <i18n v-if="$v.form.email.$error" class="help is-danger" data-test="badEmail">not an email</i18n>
+      </div>
+      <div class="field">
           <p class="control has-icon">
             <input
               class="input"
@@ -75,33 +67,23 @@
           </p>
           <i18n v-if="$v.form.password.$error" class="help is-danger" data-test="badPassword">password must be at least 7 characters</i18n>
         </div>
-        <div class="level is-mobile">
-          <div class="level-left">
-            <div class="level-item content is-small">
-              <span class="help is-marginless"
-                :class="[form.error ? 'is-danger' : 'is-success']"
-                data-test="serverMsg"
-              >
-                {{form.response}}
-              </span>
-            </div>
-          </div>
-          <div class="level-right">
-            <div class="level-item is-narrow">
-              <button
-                class="button submit is-success"
-                type="submit"
-                :disabled="$v.form.$invalid"
-                data-test="signSubmit"
-              >
-                <i18n>Sign Up</i18n>
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
-    </form>
-  </section>
+    </modal-body>
+
+    <modal-footer :submitError="form.response">
+      <button
+        class="button is-primary"
+        type="submit"
+        :disabled="$v.form.$invalid"
+        data-test="signSubmit"
+      >
+        <i18n>Sign Up</i18n>
+      </button>
+
+      <template slot="footer">
+        <a @click="showLoginModal"><i18n>Have an account?</i18n></a>
+      </template>
+    </modal-footer>
+  </form>
 </template>
 <style scoped>
 .gi-box {
@@ -110,18 +92,29 @@
 }
 </style>
 <script>
-import sbp from '../../../shared/sbp.js'
 import _ from 'lodash'
 import { validationMixin } from 'vuelidate'
 import { required, minLength, email } from 'vuelidate/lib/validators'
-import { nonWhitespace } from './utils/validators.js'
-import { OPEN_MODAL } from '../utils/events.js'
-import LoginModal from './containers/LoginModal.vue'
+import sbp from '../../../../shared/sbp.js'
+import { nonWhitespace } from '../utils/validators.js'
+import { OPEN_MODAL, CLOSE_MODAL } from '../../utils/events.js'
+import LoginModal from './LoginModal.vue'
+import ModalHeader from '../components/Modal/ModalHeader.vue'
+import ModalBody from '../components/Modal/ModalBody.vue'
+import ModalFooter from '../components/Modal/ModalFooter.vue'
 
 // TODO: fix all this
 export default {
   name: 'SignUp',
   mixins: [ validationMixin ],
+  components: {
+    ModalHeader,
+    ModalBody,
+    ModalFooter
+  },
+  inserted () {
+    this.$refs.username.focus()
+  },
   methods: {
     debounceName: _.debounce(function (e) {
       // "Validator is evaluated on every data change, as it is essentially a computed value.
@@ -166,6 +159,7 @@ export default {
           name: this.form.name,
           identityContractId: user.hash()
         })
+        sbp('okTurtles.events/emit', CLOSE_MODAL)
         this.form.response = 'success' // TODO: get rid of this and fix/update tests accordingly
         if (this.$route.query.next) {
           // TODO: get rid of this timeout and fix/update tests accordingly
@@ -184,7 +178,7 @@ export default {
         this.form.error = true
       }
     },
-    forwardToLogin () {
+    showLoginModal () {
       sbp('okTurtles.events/emit', OPEN_MODAL, LoginModal)
     }
   },

--- a/test/frontend.js
+++ b/test/frontend.js
@@ -48,8 +48,10 @@ function login (name) {
 
 function signup (name, email, password) {
   return function (n) {
-    n.goto(page('signup'))
-      .wait(elT('signName'))
+    n.goto(page('/'))
+      .wait(elT('signupBtn'))
+      .click(elT('signupBtn'))
+      .wait(elT('modal'))
       .insert(elT('signName'), name)
       .insert(elT('signEmail'), email)
       .insert(elT('signPassword'), password)
@@ -165,7 +167,7 @@ describe('Frontend', function () {
     // TODO: implement this now that we're using `type` instead of `insert`
     it.skip('Test Validation', async function () {
       this.timeout(4000)
-      await n.goto(page('signup'))
+      await n.goto(page('/'))
       const badUsername = 't e s t'
       const badEmail = `@fail`
       const badPassword = `789`// six is so afraid


### PR DESCRIPTION
Closes #442 
## Now both Login and Signup views are consistent

- Added a link in both modals to quickly switch to the other option (login to signup or signup to login)
- Add router guarder to pay-group

![image](https://user-images.githubusercontent.com/14869087/43672100-5390805a-9742-11e8-80cc-263477712501.png)



