### PR TITLE
#503 center splash screen

### DIFF
--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -33,7 +33,7 @@
 <style scoped lang="scss">
 @import "../assets/sass/theme/index";
 
-.gi-splash {
+.c-splash {
   justify-content: center;
   min-height: 100vh;
   display: flex;

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-    <main class="splash has-text-centered">
+    <main class="gi-splash has-text-centered">
       <div data-test="homeLogo">
         <img class="logo" src="assets/images/group-income-icon-transparent.png">
         <br>
@@ -33,11 +33,12 @@
 <style scoped lang="scss">
 @import "../assets/sass/theme/index";
 
-.splash {
+.gi-splash {
   justify-content: center;
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  position: relative;
 }
 
 .title {

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-    <main class="gi-splash has-text-centered">
+    <main class="c-splash has-text-centered">
       <div data-test="homeLogo">
         <img class="logo" src="assets/images/group-income-icon-transparent.png">
         <br>

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -1,5 +1,5 @@
 <template>
-    <main class="container has-text-centered">
+    <main class="splash has-text-centered">
       <div data-test="homeLogo">
         <img class="logo" src="assets/images/group-income-icon-transparent.png">
         <br>
@@ -33,10 +33,7 @@
 <style scoped lang="scss">
 @import "../assets/sass/theme/index";
 
-.container {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+.splash {
   justify-content: center;
 }
 

--- a/frontend/simple/views/Home.vue
+++ b/frontend/simple/views/Home.vue
@@ -35,6 +35,9 @@
 
 .splash {
   justify-content: center;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 .title {


### PR DESCRIPTION
Instead of applying the `container` style to the splash screen and overwriting it,
let flexbox take care of the positioning of everything. `container`  was setting a
width.

![screenshot from 2018-11-27 19-27-54](https://user-images.githubusercontent.com/485583/49127002-9ab0a580-f27a-11e8-9ebc-23d2395f5f53.png)
