### PR TITLE
fix: #618 solve sourcemaps conflicts with rollup-plugin-vue

### DIFF
--- a/.Gruntfile.babel.js
+++ b/.Gruntfile.babel.js
@@ -309,6 +309,7 @@ module.exports = (grunt) => {
           // https://rollup-plugin-vue.vuejs.org/options.html
           // https://github.com/vuejs/rollup-plugin-vue/blob/master/src/index.ts
           // https://github.com/vuejs/vue-component-compiler#api
+          needMap: false,
           css: false,
           style: {
             preprocessOptions: {

--- a/.Gruntfile.babel.js
+++ b/.Gruntfile.babel.js
@@ -256,10 +256,7 @@ module.exports = (grunt) => {
       output: {
         format: 'system',
         dir: distJS,
-        // NOTE: If you are facing errors related to sourcemaps, run `grunt dev`
-        // like so: DISABLE_SOURCEMAPS=1 grunt dev
-        // Read more about at docs/Troubleshooting.md.
-        sourcemap: !process.env.DISABLE_SOURCEMAPS && development,
+        sourcemap: development,
         sourcemapPathTransform: relativePath => {
           // const relativePath2 = '/' + path.relative('../../../', relativePath)
           const relativePath2 = path.relative('../', relativePath)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -13,27 +13,6 @@ Try:
 - `npm cache clean` - This fixed a real problem someone was having
 - `npm install npm@latest -g`
 
-## "Multiple conflicting contents for sourcemap"
-
-Problem: `grunt dev` outputs something like the following when you save:
-
-```
-rollup: frontend/main.js
->> rollup:watch {
->>   code: 'ERROR',
->>   error: Error: Multiple conflicting contents for sourcemap source /path/to/group-income-simple/frontend/views/containers/sidebar/GroupsList.vue
->>       at error (/path/to/group-income-simple/node_modules/rollup/dist/rollup.js:9396:30)
-```
-
-We're not sure why this happens, but there are some hackish solutions while we wait for someone to [fix this bug](https://github.com/vuejs/rollup-plugin-vue/issues/238):
-
-- Create a newline near the top of the file with a comment and save again - delete that line on the next save and repeat the process for each save...
-- Run `grunt dev` with `DISABLE_SOURCEMAPS` enabled like so:
-
-    ```
-    $ DISABLE_SOURCEMAPS=1 grunt dev
-    ```
-
 ## Can not sign-up user when databases get out of sync
 
 *NOTE: this should no longer be an issue, but we're leaving this here just in case.*


### PR DESCRIPTION
Closes #618 for good this time.

Based on this comment https://github.com/vuejs/rollup-plugin-vue/issues/238#issuecomment-523133535

> Not a "fix" but a plausible solution was committed in [3f879f3](https://github.com/vuejs/rollup-plugin-vue/commit/3f879f384c39887dc21e359cee9aaa8abdd39079)
> 
> It seems it has to do with how rollup's `watch` works and the source maps accumulating in the plugin. To bypass the issue, set `needMap` to `false` in your options:
> 
> ```
> config.plugins.push(vue({
>     needMap: false,
> }));
> ```
> 
> I am using TypeScript and haven't found issues with the source maps even after adding `needMap: false`, so there's that, YMMV though

Tested in several files and it did work :tada: