### PR TITLE
Fix Dashboard redirect not working upon Login

### DIFF
--- a/frontend/views/containers/modals/Login.vue
+++ b/frontend/views/containers/modals/Login.vue
@@ -90,7 +90,7 @@ export default {
         })
         this.close()
         // BUG: TODO: find out why the router homeGuard doesn't redirect us to the dashboard
-        this.$router.push({ path: '/' })
+        if (this.userHasGroup) this.$router.push({ path: '/dashboard' })
       } catch (error) {
         this.form.response = L('Invalid username or password')
         console.error(error)
@@ -114,6 +114,11 @@ export default {
         password: null,
         response: null
       }
+    }
+  },
+  computed: {
+    userHasGroup () {
+      return !!this.$store.state.currentGroupId
     }
   },
   validations: {

--- a/frontend/views/containers/modals/Login.vue
+++ b/frontend/views/containers/modals/Login.vue
@@ -89,8 +89,7 @@ export default {
           identityContractID
         })
         this.close()
-        // BUG: TODO: find out why the router homeGuard doesn't redirect us to the dashboard
-        if (this.userHasGroup) this.$router.push({ path: '/dashboard' })
+        if (this.$store.state.currentGroupId) this.$router.push({ path: '/dashboard' })
       } catch (error) {
         this.form.response = L('Invalid username or password')
         console.error(error)
@@ -114,11 +113,6 @@ export default {
         password: null,
         response: null
       }
-    }
-  },
-  computed: {
-    userHasGroup () {
-      return !!this.$store.state.currentGroupId
     }
   },
   validations: {


### PR DESCRIPTION
closes #622 

- The possible reason for the bug
the navigation guard for the route '/', which is responsible for redirecting a user to dashboard, doesn't get executed because Login.vue makes a navigation request to the route which it's already in (It requests a navigation to Home.vue when it's already in Home.vue)

- The possible solution
Adding the 'check&redirect' logic inside Login.vue maybe