### PR TITLE
Add test to accept group invitation

### DIFF
--- a/frontend/views/containers/sidebar/Navigation.vue
+++ b/frontend/views/containers/sidebar/Navigation.vue
@@ -33,6 +33,14 @@ nav.c-navigation(
             i18n Chat
           list-item(tag='router-link' icon='cog' to='/group-settings')
             i18n Group Settings
+          list-item(
+            tag='router-link'
+            to='/mailbox'
+            icon='envelope'
+            data-test='mailboxLink'
+            :badgeCount='unreadMessageCount || activityCount'
+          )
+            i18n Inbox (deprecated)
 
         .c-navigation-separator(v-if="groupsByName.length < 2")
           router-link.button.is-small.is-outlined(
@@ -51,16 +59,6 @@ nav.c-navigation(
           :badgeCount='2'
         )
           i18n Messages
-
-        list-item(
-          tag='router-link'
-          to='/mailbox'
-          style='opacity: 0; cursor: default;'
-          icon='envelope'
-          data-test='mailboxLink'
-          :badgeCount='unreadMessageCount || activityCount'
-        )
-          i18n Inbox (deprecated)
 
       .c-navigation-body-bottom
         ul.c-menu-list-bottom

--- a/frontend/views/pages/Mailbox.vue
+++ b/frontend/views/pages/Mailbox.vue
@@ -90,6 +90,7 @@ page(pageTestName='dashboard' pageTestHeaderName='groupName')
           strong From:
           | &nbsp;{{ ephemeral.currentMessage.data.from }}
       p(
+        data-test="message"
         style='display: block; word-wrap: break-word;'
       ) {{ephemeral.currentMessage.data.message}}
 

--- a/test/cypress/integration/group-creation-and-invite.spec.js
+++ b/test/cypress/integration/group-creation-and-invite.spec.js
@@ -1,5 +1,6 @@
 describe('Group Creation and Inviting Members', () => {
   const userId = new Date().getMilliseconds()
+  const groupName = 'Dreamers'
 
   it('successfully loads the homepage', function () {
     cy.visit('/')
@@ -10,19 +11,26 @@ describe('Group Creation and Inviting Members', () => {
     cy.giLogOut()
   })
 
-  it('register user2', () => {
+  it('register user2 and logout', () => {
     cy.giSignUp(`user2-${userId}`)
+    cy.giLogOut()
   })
 
-  it('user2 create new Group', () => {
-    const testName = 'Test Group'
+  it('register user3 and logout', () => {
+    cy.giSignUp(`user3-${userId}`)
+    cy.giLogOut()
+  })
+
+  it('user1 logins back and creates new Group', () => {
     const testValues = 'Testing this software'
     const testIncome = 200
     // const testSetting = 80
     const groupImage = 'imageTest.png' // at fixtures/imageTest
 
+    cy.giLogin(`user1-${userId}`)
+
     cy.getByDT('createGroup').click()
-    cy.getByDT('groupName').type(testName)
+    cy.getByDT('groupName').type(groupName)
 
     // TODO make a custom command for this
     cy.fixture(groupImage).then((picture) =>
@@ -51,41 +59,51 @@ describe('Group Creation and Inviting Members', () => {
 
     cy.getByDT('finishBtn').click()
 
-    cy.getByDT('welcomeGroup').should('contain', `Welcome ${testName}!`)
+    cy.getByDT('welcomeGroup').should('contain', `Welcome ${groupName}!`)
   })
 
-  it('user2 starts inviting user1 to the Group', () => {
+  it('user1 starts inviting user2 to the Group', () => {
     cy.getByDT('toDashboardBtn').click()
 
     cy.getByDT('inviteButton').click()
 
-    cy.getByDT('searchUser').clear().type(`user1-${userId}`)
+    cy.getByDT('searchUser').clear().type(`user2-${userId}`)
 
     cy.getByDT('addButton').click()
 
     cy.getByDT('member').should('lengthOf', 1)
   })
 
-  it('user2 cancels user1 invitation', () => {
+  it('user1 cancels user2 invitation', () => {
     cy.getByDT('deleteMember').click()
 
     cy.getByDT('member').should('not.exist')
   })
 
-  it('user2 decides to actually invite user1', () => {
-    cy.getByDT('searchUser').clear().type(`user1-${userId}`)
+  it('user1 decides to actually invite user2 and user3 to the group', () => {
+    cy.getByDT('searchUser').clear().type(`user2-${userId}`)
+    cy.getByDT('addButton').click()
 
+    cy.getByDT('searchUser').clear().type(`user3-${userId}`)
     cy.getByDT('addButton').click()
 
     cy.getByDT('submit').click()
 
     cy.getByDT('notifyInvitedSuccess')
       .should('contain', 'Members invited successfully!')
-  })
 
-  it('user2 logs out', () => {
     cy.giLogOut()
   })
 
-  it.skip('Testing Proposal Member Invitation', () => {})
+  it('user2 accepts the invite', () => {
+    cy.giLogin(`user2-${userId}`)
+    cy.giAcceptGroupInvite(groupName)
+    cy.giLogOut()
+  })
+
+  it('user3 accepts the invite', () => {
+    cy.giLogin(`user3-${userId}`)
+    cy.giAcceptGroupInvite(groupName)
+    cy.giLogOut()
+  })
 })

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -43,3 +43,19 @@ Cypress.Commands.add('giLogOut', () => {
 
   cy.getByDT('welcomeHome').should('contain', 'Welcome to GroupIncome')
 })
+
+Cypress.Commands.add('giAcceptGroupInvite', (groupName) => {
+  cy.getByDT('mailboxLink').click()
+  cy.getByDT('inboxMessage').click()
+
+  cy.getByDT('message').invoke('text').then(text => {
+    const urlAt = text.indexOf('http://')
+    const url = text.substr(urlAt)
+
+    assert.isOk(url, 'url is found')
+
+    cy.visit(url)
+    cy.getByDT('acceptLink').click()
+    cy.getByDT('groupName').should('contain', groupName)
+  })
+})


### PR DESCRIPTION
Related to #613 and #560.

In order to implement Delete Group functionality, we need to create members/groups an accept invitations over and over again first. Having a Cypress test does that for us in seconds and save us a lot of time during development.

I thought it would be better to push it right away to master.

Note: Inbox link is visible again, otherwise Cypress can't click on it.