### PR TITLE
Add additional tests to Login and Signup and improve a11y

### DIFF
--- a/frontend/assets/style/components/_forms.scss
+++ b/frontend/assets/style/components/_forms.scss
@@ -14,6 +14,7 @@ form {
 }
 
 .field {
+  display: block;
   max-width: 100%;
   width: 100%;
   margin-bottom: 1rem;

--- a/frontend/views/components/Forms/Password.vue
+++ b/frontend/views/components/Forms/Password.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
-.field
-  i18n.label(tag='label' v-if='label') {{ label }}
+label.field
+  .label(v-if='label') {{ label }}
   .input-combo
     input.input(
       :type='isLock ? "password" : "text"'

--- a/frontend/views/components/Modal/ModalClose.vue
+++ b/frontend/views/components/Modal/ModalClose.vue
@@ -2,7 +2,8 @@
   button.c-modal-close(
     :class='{ "back-on-mobile": backOnMobile }'
     @click.self='$emit("close")'
-    aria-label='close'
+    :aria-label='L("close modal")'
+    data-test='closeModal'
   )
     i.icon-chevron-left(aria-hidden='true')
 </template>

--- a/frontend/views/containers/modals/Login.vue
+++ b/frontend/views/containers/modals/Login.vue
@@ -10,9 +10,8 @@
       data-test='login'
       @submit.prevent='login'
     )
-      .field
-        i18n.label(tag='label') Username
-
+      label.field
+        i18n.label Username
         input.input#loginName(
           :class='{error: $v.form.name.$error}'
           name='name'
@@ -26,6 +25,7 @@
         i18n.error(
           v-show='$v.form.name.$error'
           tag='p'
+          data-test='badUsername'
         ) Username cannot contain spaces
 
       form-password(
@@ -36,10 +36,9 @@
         @input='(newPassword) => {password = newPassword}'
       )
 
-      a.link(@click='forgotPassword')
-        i18n Forgot your password?
+      i18n.link(tag='a' @click='forgotPassword') Forgot your password?
 
-      p.error(v-if='form.response') {{ form.response }}
+      p.error(v-if='form.response' data-test='loginError') {{ form.response }}
 
       .buttons.is-centered
         i18n(
@@ -53,6 +52,7 @@
       p
         i18n Not on Group Income yet?&nbsp;
         i18n.link(
+          data-test='goToSignup'
           tag='a'
           @click='showSignUpModal'
         ) Create an account

--- a/frontend/views/containers/modals/SignUp.vue
+++ b/frontend/views/containers/modals/SignUp.vue
@@ -10,9 +10,8 @@
       data-test='signup'
       @submit.prevent='signup'
     )
-      .field
-        i18n.label(tag='label') Username
-
+      label.field
+        i18n.label Username
         input.input#name(
           :class='{error: $v.form.name.$error}'
           name='name'
@@ -21,17 +20,12 @@
           v-focus=''
           data-test='signName'
         )
-
-        p.error(
-          v-if='$v.form.name.$error'
-          data-test='badUsername'
-        )
+        p.error(v-if='$v.form.name.$error' data-test='badUsername')
           i18n(v-if='!$v.form.name.isAvailable') name is unavailable
           i18n(v-if='!$v.form.name.nonWhitespace') cannot contain spaces
 
-      .field
-        i18n.label(tag='label') Email
-
+      label.field
+        i18n.label Email
         input.input#email(
           :class='{error: $v.form.email.$error}'
           name='email'
@@ -40,9 +34,9 @@
           type='email'
           data-test='signEmail'
         )
-
         p.error(v-if='$v.form.email.$error' data-test='badEmail')
-          i18n not an email
+          i18n(v-if='!$v.form.name.email') not an e-mail
+          i18n(v-if='!$v.form.name.isAvailable') e-mail is unavailable
 
       form-password(
         :label='L("Password")'
@@ -64,7 +58,7 @@
     template(slot='footer')
       p
         i18n Already have an account?&nbsp;
-        a.link(@click='showLoginModal')
+        a.link(@click='showLoginModal' data-test='goToLogin')
           i18n Login
 </template>
 
@@ -198,7 +192,11 @@ export default {
       },
       email: {
         required,
-        email
+        email,
+        isAvailable (value) {
+          // TODO - verify if e-mail exists
+          return true
+        }
       }
     }
   }

--- a/test/cypress/integration/signup-and-login.spec.js
+++ b/test/cypress/integration/signup-and-login.spec.js
@@ -55,6 +55,46 @@ describe('SignUp, Profile and Login', () => {
     cy.giLogOut()
   })
 
-  it.skip('user1 must not signup twice', () => {
+  it('cannot login a non existent user', () => {
+    cy.getByDT('loginBtn').click()
+
+    cy.getByDT('loginName').clear().type('non existent')
+    cy.getByDT('badUsername').should('contain', 'cannot contain spaces')
+
+    cy.getByDT('loginName').clear().type('nonexistent')
+    cy.getByDT('password').clear().type('987654321')
+
+    cy.getByDT('loginSubmit').click()
+    cy.getByDT('loginError').should('contain', 'Invalid username or password')
+
+    cy.getByDT('closeModal').click()
+  })
+
+  it('cannot signup existing user1 twice', () => {
+    cy.getByDT('signupBtn').click()
+
+    cy.getByDT('signName').clear().type('new user')
+    cy.getByDT('badUsername').should('contain', 'cannot contain spaces')
+
+    cy.getByDT('signName').clear().type(userName)
+    cy.getByDT('badUsername').should('contain', 'name is unavailable')
+
+    // TODO: When email verification is implemented
+    // cy.getByDT('signEmail').clear().type(`${userName}@email.com`)
+    // cy.getByDT('badUsername').should('contain', 'email is unavailable')
+
+    cy.getByDT('closeModal').click()
+  })
+
+  it('switch directly between login to signup modals', () => {
+    cy.getByDT('loginBtn').click()
+
+    cy.getByDT('goToSignup').click()
+    cy.getByDT('signName').should('exist')
+
+    cy.getByDT('goToLogin').click()
+    cy.getByDT('loginName').should('exist')
+
+    cy.getByDT('closeModal').click()
   })
 })


### PR DESCRIPTION
- Add e2e tests to login and signup flows: 
  - cannot login nonexistent user
  - cannot signup user1 twice
  - switch directly between login to signup modals
- Improve A11Y of both modals and do some i18n scouting.

Closes #580. The only missing tests are related to proposals and that will be addressed at #613