### PR TITLE
Contributing Requirement Rule #8 Updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,13 @@ This contribution policy will evolve over time. For now it is based on a slightl
 
 1. A PR **SHOULD** be a minimal and accurate answer to exactly one identified and agreed problem.
 2. A PR **SHOULD** follow [the boy scout rule](https://github.com/okTurtles/group-income-simple/issues/383#issuecomment-383381863): leave the code cleaner than you found it when the refactor effort is not too big.
-3. A PR **MUST NOT** include non-trivial code from other projects unless the Contributor is the original author of that code.
+3. A PR **MAY NOT** include non-trivial code from other projects unless the Contributor is the original author of that code.
 4. A PR **MUST** pass all tests on at least the principle target platform.
 5. A PR **MUST** include new tests for any new functionality introduced.
 6. A PR **SHOULD** avoid "callback-hell" style and instead prefer "async/await" style.
 7. A PR **MUST** follow the requirements spelled out in this project's [Style Guide](docs/Style-Guide.md).
-8. A PR **MUST** receive approval from at least one long-term contributor before being merged. Contributors **MUST NOT** review their own PRs, **MUST NOT** push commits to someone else's PR, and **SHOULD NOT** merge their own PRs.
+8. A PR **MUST** receive approval from at least one long-term contributor before being merged. Contributors **MAY NOT** review their own PRs, **MUST NOT** push commits to someone else's PR, and **SHOULD NOT** merge their own PRs.
+9. A PR **MAY NOT** be merged if there exist unaddressed concerns from a current maintainer (via the Github "request changes" review feature). Contributors are encouraged to discuss the requested changes, and may even argue against them if there are strong reasons to do so. However, maintainers have veto power over all PRs.
 
 ## How to submit an issue
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,12 @@ This contribution policy will evolve over time. For now it is based on a slightl
 
 1. A PR **SHOULD** be a minimal and accurate answer to exactly one identified and agreed problem.
 2. A PR **SHOULD** follow [the boy scout rule](https://github.com/okTurtles/group-income-simple/issues/383#issuecomment-383381863): leave the code cleaner than you found it when the refactor effort is not too big.
-3. A PR **SHALL NOT** include non-trivial code from other projects unless the Contributor is the original author of that code.
+3. A PR **MUST NOT** include non-trivial code from other projects unless the Contributor is the original author of that code.
 4. A PR **MUST** pass all tests on at least the principle target platform.
 5. A PR **MUST** include new tests for any new functionality introduced.
 6. A PR **SHOULD** avoid "callback-hell" style and instead prefer "async/await" style.
 7. A PR **MUST** follow the requirements spelled out in this project's [Style Guide](docs/Style-Guide.md).
-8. A PR **MUST** receive approval from at least one reviewer (existing, long-term contributor) before being merged. *Reviewers may not review their own PRs, and may not push commits to someone else's PR.*
+8. A PR **MUST** receive approval from at least one long-term contributor before being merged. Contributors **MUST NOT** review their own PRs, **MUST NOT** push commits to someone else's PR, and **SHOULD NOT** merge their own PRs.
 
 ## How to submit an issue
 


### PR DESCRIPTION
Updated language to make it clear that PRs should be merged by someone other than the author of the PR.

There can be rare exceptions to this rule, under special circumstances. For example:

- During a hackathon organized by okTurtles Foundation, when everyone is in the same room and a trivial change is made and approved by hackathon attendees, then for efficiency purposes the PR may be merged by the PR author if it has received approval from another contributor
- A trivial documentation change has been submitted and approved
- Trivial changes in general (that do not affect any significant functionality), where for some reason there is imminent time pressure, and at least one approval from a long-term contributor (other than the PR author) has been received