### PR TITLE
fix Close sidebars when a new page has been loaded

### DIFF
--- a/frontend/views/containers/sidebar/Navigation.vue
+++ b/frontend/views/containers/sidebar/Navigation.vue
@@ -110,6 +110,14 @@ export default {
       }
     }
   },
+  watch: {
+    $route (to, from) {
+      const isDifferentPage = from.path !== to.path
+      if (this.ephemeral.isActive && isDifferentPage) {
+        this.ephemeral.isActive = false
+      }
+    }
+  },
   computed: {
     ...mapGetters([
       'groupsByName',


### PR DESCRIPTION
Closes #666 

The condition implemented is simple: close the sidebar when the main URL path changes (not including query, this is, it ignores if it's a modal, as asked by @mmbotelho).

---

> @mmbotelho 
> Note: This also happens on the dashboard's right-hand sidebar (on the link to edit the group's description)

@mmbotelho I didn't understand this. If I click to edit the group's description, the page changes and that page doesn't have a sidebar, so... what am I missing here? 🤔 

