### PR TITLE
Fix groupMembers count on sidebar

### DIFF
--- a/.Gruntfile.babel.js
+++ b/.Gruntfile.babel.js
@@ -253,16 +253,11 @@ module.exports = (grunt) => {
     const cypress = require('cypress')
     const done = this.async()
     const command = grunt.option('browser') === 'debug' ? 'open' : 'run'
-    const disableVideo = process.argv.indexOf('--disable-video') > -1
 
-    console.log('disableVideo', disableVideo, process.argv)
     // https://docs.cypress.io/guides/guides/module-api.html
     const options = {
       run: {
-        headed: grunt.option('browser') === true,
-        config: {
-          video: !disableVideo
-        }
+        headed: grunt.option('browser') === true
       },
       open: {
         // add cypress.open() options here

--- a/.Gruntfile.babel.js
+++ b/.Gruntfile.babel.js
@@ -253,10 +253,16 @@ module.exports = (grunt) => {
     const cypress = require('cypress')
     const done = this.async()
     const command = grunt.option('browser') === 'debug' ? 'open' : 'run'
+    const disableVideo = process.argv.indexOf('--disable-video') > -1
+
+    console.log('disableVideo', disableVideo, process.argv)
     // https://docs.cypress.io/guides/guides/module-api.html
     const options = {
       run: {
-        headed: grunt.option('browser') === true
+        headed: grunt.option('browser') === true,
+        config: {
+          video: !disableVideo
+        }
       },
       open: {
         // add cypress.open() options here

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ cache:
 install:
   - npm ci
 script:
-  - npm test
+  - npm test -- --disable-video

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ cache:
 install:
   - npm ci
 script:
-  - npm test -- --disable-video
+  - npm test

--- a/cypress.json
+++ b/cypress.json
@@ -8,5 +8,5 @@
   "screenshotsFolder": "test/cypress/screenshots",
   "supportFile": "test/cypress/support",
   "videosFolder": "test/cypress/videos",
-  "videoUploadOnPasses": false
+  "video": false
 }

--- a/cypress.json
+++ b/cypress.json
@@ -7,5 +7,6 @@
   "pluginsFile": "test/cypress/plugins",
   "screenshotsFolder": "test/cypress/screenshots",
   "supportFile": "test/cypress/support",
-  "videosFolder": "test/cypress/videos"
+  "videosFolder": "test/cypress/videos",
+  "videoUploadOnPasses": false
 }

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -246,7 +246,7 @@ DefineContract({
         const meta = message.meta()
         // TODO: per #257 this will have to be encompassed in a recoverable transaction
         // however per #610 that might be handled in handleEvent (?), or per #356 might not be needed
-        if (data.username === rootState.loggedIn.username) {
+        if (meta.username === rootState.loggedIn.username) {
           // we're the person who just accepted the group invite
           // so subscribe to founder's IdentityContract & everyone else's
           for (const name of Object.keys(groupState.profiles)) {

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -242,7 +242,6 @@ DefineContract({
       async sideEffect (message) {
         const rootState = sbp('state/vuex/state')
         const groupState = rootState[message.contractID()]
-        const data = message.data()
         const meta = message.meta()
         // TODO: per #257 this will have to be encompassed in a recoverable transaction
         // however per #610 that might be handled in handleEvent (?), or per #356 might not be needed
@@ -254,7 +253,6 @@ DefineContract({
             await sbp('state/vuex/dispatch', 'syncContractWithServer', groupState.profiles[name].contractID)
           }
         } else {
-          console.log('pass aqui?', meta.identityContractID)
           // we're an existing member of the group getting notified that a
           // new member has joined, so subscribe to their identity contract
           await sbp('state/vuex/dispatch', 'syncContractWithServer', meta.identityContractID)

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -254,6 +254,7 @@ DefineContract({
             await sbp('state/vuex/dispatch', 'syncContractWithServer', groupState.profiles[name].contractID)
           }
         } else {
+          console.log('pass aqui?', meta.identityContractID)
           // we're an existing member of the group getting notified that a
           // new member has joined, so subscribe to their identity contract
           await sbp('state/vuex/dispatch', 'syncContractWithServer', meta.identityContractID)

--- a/frontend/views/components/StartInviting.vue
+++ b/frontend/views/components/StartInviting.vue
@@ -9,10 +9,6 @@ section.card.c-card
         tag='button'
         @click='openModal'
       ) Add members
-      router-link.button(
-        to='/invite'
-        data-test='inviteButton'
-      ) {{ L('Invite members') }}
 </template>
 
 <script>

--- a/frontend/views/containers/sidebar/GroupMembers.vue
+++ b/frontend/views/containers/sidebar/GroupMembers.vue
@@ -88,9 +88,6 @@ export default {
     Tooltip,
     UserImage
   },
-  mounted () {
-    console.log(this.groupMembers)
-  },
   methods: {
     invite () {
       this.$router.push({ path: '/invite' })

--- a/frontend/views/containers/sidebar/GroupMembers.vue
+++ b/frontend/views/containers/sidebar/GroupMembers.vue
@@ -16,7 +16,7 @@
     // TODO: remove v-if in v-for loop and reorder list member by active user limited to 10
     li.c-group-member(
       v-for='(member, username, index) in groupMembers'
-      v-if='index < 10 && member && username !== currentUserName'
+      v-if='index < 10 && member'
       :class='member.pending && "is-pending"'
       :key='username'
       data-test='member'
@@ -91,6 +91,9 @@ export default {
     MenuItem,
     Tooltip,
     UserImage
+  },
+  mounted () {
+    console.log(this.groupMembers)
   },
   methods: {
     invite () {

--- a/frontend/views/containers/sidebar/GroupMembers.vue
+++ b/frontend/views/containers/sidebar/GroupMembers.vue
@@ -105,7 +105,7 @@ export default {
       return this.$store.state.loggedIn.username
     },
     firstTenMembers () {
-      const usernames = Object.keys(this.groupMembers).slice(0, 9)
+      const usernames = Object.keys(this.groupMembers).slice(0, 10)
 
       return usernames.reduce((acc, cur) => ({
         ...acc,

--- a/frontend/views/containers/sidebar/GroupMembers.vue
+++ b/frontend/views/containers/sidebar/GroupMembers.vue
@@ -12,14 +12,10 @@
       i18n Add
 
   ul.c-group-list
-    // TODO: Check why removing member condition can fail here
-    // TODO: remove v-if in v-for loop and reorder list member by active user limited to 10
     li.c-group-member(
-      v-for='(member, username, index) in groupMembers'
-      v-if='index < 10 && member'
+      v-for='(member, username, index) in firstTenMembers'
       :class='member.pending && "is-pending"'
       :key='username'
-      data-test='member'
     )
       user-image(:username='username')
 
@@ -110,6 +106,14 @@ export default {
     ]),
     currentUserName () {
       return this.$store.state.loggedIn.username
+    },
+    firstTenMembers () {
+      const usernames = Object.keys(this.groupMembers).slice(0, 9)
+
+      return usernames.reduce((acc, cur) => ({
+        ...acc,
+        [cur]: this.groupMembers[cur]
+      }), {})
     }
   }
 }

--- a/frontend/views/pages/GroupDashboard.vue
+++ b/frontend/views/pages/GroupDashboard.vue
@@ -22,7 +22,7 @@ page(pageTestName='dashboard' pageTestHeaderName='groupName' v-if='groupSettings
 
   template(#sidebar='')
     groups-min-income
-    group-members(v-if='groupMembersCount > 1')
+    group-members
     group-purpose
 </template>
 

--- a/test/cypress/integration/group-creation-and-invite.spec.js
+++ b/test/cypress/integration/group-creation-and-invite.spec.js
@@ -95,15 +95,24 @@ describe('Group Creation and Inviting Members', () => {
     cy.giLogOut()
   })
 
+  function assertGroupMembersCount (count) {
+    // OPTIMIZE: We could also verify the username of each member...
+    cy.getByDT('groupMembers').find('ul')
+      .children()
+      .should('have.length', count)
+  }
+
   it('user2 accepts the invite', () => {
     cy.giLogin(`user2-${userId}`)
     cy.giAcceptGroupInvite(groupName)
+    assertGroupMembersCount(2)
     cy.giLogOut()
   })
 
   it('user3 accepts the invite', () => {
     cy.giLogin(`user3-${userId}`)
     cy.giAcceptGroupInvite(groupName)
+    assertGroupMembersCount(3)
     cy.giLogOut()
   })
 })


### PR DESCRIPTION
Thanks to @greg for the pair programming and patience on this one!
- Added a cypress test to cover this issue in the future.
- Removed "Invite Members" from dashboard widget because now we always show the group members on the sidebar.

Bonus: Disable cypress video recording on cypress, this way the run is faster. We still have video recordings when running the tests locally.

Closes #648, #647 