### PR TITLE
Make the modal ignore NavigationDuplicated error when updating the query string

### DIFF
--- a/.Gruntfile.babel.js
+++ b/.Gruntfile.babel.js
@@ -315,6 +315,7 @@ module.exports = (grunt) => {
           resolve: ['.vue', '.js', '.svg'],
           vue: path.resolve('./node_modules/vue/dist/vue.common.js'),
           '~': path.resolve('./'),
+          '@controller': path.resolve('./frontend/controller'),
           '@model': path.resolve('./frontend/model'),
           '@utils': path.resolve('./frontend/utils'),
           '@views': path.resolve('./frontend/views'),

--- a/frontend/controller/utils/misc.js
+++ b/frontend/controller/utils/misc.js
@@ -6,3 +6,7 @@ export function handleFetchResult (type: string) {
     return r[type]()
   }
 }
+
+export function logExceptNavigationDuplicated (err: Error) {
+  err.name !== 'NavigationDuplicated' && console.error(err)
+}

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -5,6 +5,7 @@ import '~/shared/domains/okTurtles/data.js'
 import '~/shared/domains/okTurtles/events.js'
 import './controller/namespace.js'
 import router from './controller/router.js'
+import { logExceptNavigationDuplicated } from './controller/utils/misc.js'
 import { createWebSocket } from './controller/backend.js'
 import store from './model/state.js'
 import { SETTING_CURRENT_USER } from './model/database.js'
@@ -85,7 +86,7 @@ async function startApp () {
     store // make this and all child components aware of the new store
   }).$mount('#app')
 
-  sbp('okTurtles.events/on', LOGOUT, () => router.push({ path: '/' }))
+  sbp('okTurtles.events/on', LOGOUT, () => router.push({ path: '/' }).catch(logExceptNavigationDuplicated))
 }
 
 startApp()

--- a/frontend/views/components/Modal/Modal.vue
+++ b/frontend/views/components/Modal/Modal.vue
@@ -6,6 +6,7 @@
 <script>
 import sbp from '~/shared/sbp.js'
 import { OPEN_MODAL, REPLACE_MODAL, CLOSE_MODAL } from '@utils/events.js'
+import { logExceptNavigationDuplicated } from '@controller/utils/misc.js'
 
 export default {
   name: 'Modal',
@@ -72,9 +73,9 @@ export default {
     },
     updateUrl () {
       if (this.content) {
-        this.$router.push({ query: { modal: this.content, subcontent: this.activeSubcontent() } }).catch(console.error)
+        this.$router.push({ query: { modal: this.content, subcontent: this.activeSubcontent() } }).catch(logExceptNavigationDuplicated)
       } else {
-        this.$router.push({ query: null }).catch(console.error)
+        this.$router.push({ query: null }).catch(logExceptNavigationDuplicated)
       }
     },
     openModal (componentName) {


### PR DESCRIPTION
related to #686 .

according to the discussion on this thread(https://github.com/vuejs/vue-router/issues/2872#issuecomment-519073998), NavigationDuplicated error that is thrown when updating a query string is an expected behavior and is safe to ignore.
