### PR TITLE
Optimize/delete redundant cypress tests

### DIFF
--- a/test/cypress/integration/group-creation-and-invite.spec.js
+++ b/test/cypress/integration/group-creation-and-invite.spec.js
@@ -2,11 +2,8 @@ describe('Group Creation and Inviting Members', () => {
   const userId = Math.floor(Math.random() * 10000)
   const groupName = 'Dreamers'
 
-  it('successfully loads the homepage', function () {
-    cy.visit('/')
-  })
-
   it('register user1, user2 and user3', () => {
+    cy.visit('/')
     cy.giSignUp(`user1-${userId}`)
     cy.giLogOut()
     cy.giSignUp(`user2-${userId}`)
@@ -15,18 +12,12 @@ describe('Group Creation and Inviting Members', () => {
     cy.giLogOut()
   })
 
-  it('user1 logins back and creates a group', () => {
+  it('user1 logins back and invites user2 and user3 to his group', () => {
     cy.giLogin(`user1-${userId}`)
 
-    cy.giCreateGroup(groupName, {
-      income: 400
-    })
-    cy.getByDT('profileName').should('contain', `user1-${userId}`)
-
+    cy.giCreateGroup(groupName, { income: 400 })
     cy.getByDT('welcomeGroup').should('contain', `Welcome ${groupName}!`)
-  })
 
-  it('user1 starts inviting user2 and user3 to the group', () => {
     cy.getByDT('inviteButton').click()
 
     cy.getByDT('invitee').within(() => {
@@ -42,21 +33,16 @@ describe('Group Creation and Inviting Members', () => {
       cy.getByDT('add', 'button').click()
       cy.getByDT('feedbackMsg').should('contain', 'Ready to be invited!')
     })
-  })
 
-  it('user1 removes user3 from invitation list and cancels process', () => {
+    cy.log('user1 removes user3 from invitation list and cancels process')
     cy.getByDT('invitee').eq(1).within(() => {
       cy.getByDT('remove').click()
     })
-
     cy.getByDT('invitee').should('have.length', 1)
-
     cy.getByDT('closeModal').click()
-  })
 
-  it('user1 decides to actually invite user2 and user3 to the group', () => {
+    cy.log('user1 decides to actually invite user2 and user3 to the group')
     cy.giInviteMember([`user2-${userId}`, `user3-${userId}`])
-
     cy.giLogOut()
   })
 
@@ -67,14 +53,12 @@ describe('Group Creation and Inviting Members', () => {
       .should('have.length', count)
   }
 
-  it('user2 accepts the invite', () => {
+  it('both user2 and user 3 accept the invitation', () => {
     cy.giLogin(`user2-${userId}`)
     cy.giAcceptGroupInvite(groupName)
     assertGroupMembersCount(2)
     cy.giLogOut()
-  })
 
-  it('user3 accepts the invite', () => {
     cy.giLogin(`user3-${userId}`)
     cy.giAcceptGroupInvite(groupName)
     assertGroupMembersCount(3)

--- a/test/cypress/integration/group-proposals.spec.js
+++ b/test/cypress/integration/group-proposals.spec.js
@@ -13,11 +13,8 @@ function getProposalBoxes () {
 }
 
 describe('Proposals - Add members', () => {
-  it('successfully loads the homepage', function () {
-    cy.visit('/')
-  })
-
   it('register 6 users and logout each one', () => {
+    cy.visit('/')
     for (var i = 1; i <= 6; i++) {
       cy.giSignUp(`user${i}-${userId}`)
       cy.giLogOut()
@@ -35,13 +32,11 @@ describe('Proposals - Add members', () => {
     cy.getByDT('welcomeGroup').should('contain', `Welcome ${groupName}!`)
   })
 
-  it('user1 invites user2 and user3 to the group', () => {
+  it('user1 invites user2 and user3 to the group and they accept', () => {
     cy.giInviteMember([`user2-${userId}`, `user3-${userId}`])
 
     cy.giLogOut()
-  })
 
-  it('user2 and user3 accept their invites', () => {
     cy.giLogin(`user2-${userId}`)
     cy.giAcceptGroupInvite(groupName)
     cy.giLogOut()
@@ -51,15 +46,13 @@ describe('Proposals - Add members', () => {
     cy.giLogOut()
   })
 
-  it('user1 proposes to add user4 and user5 together to the group', () => {
+  it('user1 proposes to add user4 and user5 together to the group and user2 proposes to add user6 to the group', () => {
     cy.giLogin(`user1-${userId}`)
 
     cy.giInviteMember([`user4-${userId}`, `user5-${userId}`], { isProposal: true })
 
     cy.giLogOut()
-  })
 
-  it('user2 proposes to add user6 to the group', () => {
     cy.giLogin(`user2-${userId}`)
 
     cy.giInviteMember(`user6-${userId}`, { isProposal: true })

--- a/test/cypress/integration/group-settings.spec.js
+++ b/test/cypress/integration/group-settings.spec.js
@@ -3,11 +3,8 @@ describe('Changing Group Settings', () => {
   const groupMincome = 750
   const groupNewIncome = groupMincome + 100
 
-  it('successfully loads the homepage', function () {
-    cy.visit('/')
-  })
-
   it('user1 registers and creates a new group', () => {
+    cy.visit('/')
     cy.giSignUp(`user1-${userId}`)
 
     cy.giCreateGroup('Dreamers', {

--- a/test/cypress/integration/signup-and-login.spec.js
+++ b/test/cypress/integration/signup-and-login.spec.js
@@ -5,15 +5,9 @@ describe('SignUp, Profile and Login', () => {
   const userId = Math.floor(Math.random() * 10000)
   const username = `user1-${userId}`
 
-  it('successfully loads homepage', () => {
+  it('user1 signups and creates a group', () => {
     cy.visit('/')
-  })
-
-  it('sign up new user1', () => {
     cy.giSignUp(username)
-  })
-
-  it('user1 creates a group', () => {
     cy.giCreateGroup('Dreamers 2')
     cy.getByDT('profileName').should('contain', username)
   })
@@ -48,21 +42,11 @@ describe('SignUp, Profile and Login', () => {
 
     cy.getByDT('profileDisplayName').should('contain', 'I am a bot')
     cy.getByDT('profileName').should('contain', username)
-  })
-
-  it('user1 logout and login again', () => {
-    cy.giLogOut()
-    cy.giLogin(username)
-  })
-
-  it('user1 logout one last time', () => {
-    // NOTE: Logout a last time so when tests restart they start
-    // from starting point. TODO - find a better way to do this
-    /// https://stackoverflow.com/questions/50711829/cypress-browser-state-maintains-log-in-how-do-i-stop-this-from-occurring
     cy.giLogOut()
   })
 
-  it('cannot login a non existent user', () => {
+  it('prevent incorrect logins/signup actions', () => {
+    cy.log('- Connot login a non existent user')
     cy.getByDT('loginBtn').click()
 
     cy.getByDT('loginName').clear().type('non existent')
@@ -75,9 +59,8 @@ describe('SignUp, Profile and Login', () => {
     cy.getByDT('loginError').should('contain', 'Invalid username or password')
 
     cy.getByDT('closeModal').click()
-  })
 
-  it('cannot signup existing user1 twice', () => {
+    cy.log('- Cannot signup existing user twice')
     cy.getByDT('signupBtn').click()
 
     cy.getByDT('signName').clear().type('new user')
@@ -91,9 +74,8 @@ describe('SignUp, Profile and Login', () => {
     // cy.getByDT('badUsername').should('contain', 'email is unavailable')
 
     cy.getByDT('closeModal').click()
-  })
 
-  it('switch directly between login to signup modals', () => {
+    cy.log('- Switch between login to signup modals')
     cy.getByDT('loginBtn').click()
 
     cy.getByDT('goToSignup').click()

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -16,21 +16,7 @@ Cypress.Commands.add('getByDT', (element, otherSelector = '') => {
 
 // NOTE: We can go a step further and not use UI to do repetitive tasks.
 // https://docs.cypress.io/guides/getting-started/testing-your-app.html#Fully-test-the-login-flow-%E2%80%93-but-only-once
-
-function doubleCheckIsLoggedOut () {
-  // Fix #706
-  cy.getByDT('app').then(($app) => {
-    // wait for Vue to mount everything
-    cy.wait(250) // eslint-disable-line
-    if ($app.find('[data-test="loginBtn"]').length === 0) {
-      cy.giLogOut()
-    }
-  })
-}
-
 Cypress.Commands.add('giSignUp', (userName, password = '123456789') => {
-  doubleCheckIsLoggedOut()
-
   cy.getByDT('signupBtn').click()
   cy.getByDT('signName').clear().type(userName)
   cy.getByDT('signEmail').clear().type(`${userName}@email.com`)
@@ -42,8 +28,6 @@ Cypress.Commands.add('giSignUp', (userName, password = '123456789') => {
 })
 
 Cypress.Commands.add('giLogin', (userName, password = '123456789') => {
-  doubleCheckIsLoggedOut()
-
   cy.getByDT('loginBtn').click()
   cy.getByDT('loginName').clear().type(userName)
   cy.getByDT('password').clear().type(password)

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -15,9 +15,19 @@
 
 import './commands.js'
 
-// Abort tests on first fail
+// Abort all tests specs on first fail
+
+before(function () {
+  cy.getCookie('FAILED_TEST').then(cookie => {
+    if (cookie && typeof cookie === 'object' && cookie.value === 'true') {
+      Cypress.runner.stop()
+    }
+  })
+})
+
 afterEach(function () {
   if (this.currentTest.state === 'failed') {
+    cy.setCookie('FAILED_TEST', 'true')
     Cypress.runner.stop()
   }
 })


### PR DESCRIPTION
Our Cypress tests limit per 2 weeks is 500 tests. So I reviewed all tests and merged those that are redundant/too small. Reduced the number from 32 to 17. So we can run 2x more tests :D