### PR TITLE
New LTags convenience function for localization + misc fixes

### DIFF
--- a/.Gruntfile.babel.js
+++ b/.Gruntfile.babel.js
@@ -317,7 +317,7 @@ module.exports = (grunt) => {
         alias({
           // https://vuejs.org/v2/guide/installation.html#Standalone-vs-Runtime-only-Build
           resolve: ['.vue', '.js', '.svg'],
-          vue: path.resolve('./node_modules/vue/dist/vue.common.js'),
+          vue: path.resolve('./node_modules/vue/dist/vue.esm.js'),
           '~': path.resolve('./'),
           '@controller': path.resolve('./frontend/controller'),
           '@model': path.resolve('./frontend/model'),
@@ -373,7 +373,10 @@ module.exports = (grunt) => {
         // VuePlugin(),
         flow({ all: true }),
         commonjs({
-          // include: 'node_modules/**'
+          // NOTE: uncommenting this saves ~1 second off build process
+          //       while making it a massive pain to deal with dependencies
+          //       and causing "ReferenceError: require is not defined"
+          // include: /(node_modules\/(blakejs|multihashes|tweetnacl|localforage|@babel|vue.+).*|primus\.js$)/,
           namedExports: {
             'node_modules/vuelidate/lib/validators/index.js': ['required', 'between', 'email', 'minLength', 'requiredIf']
           },

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -243,10 +243,12 @@ const getters = {
   },
   groupMincomeFormatted (state, getters) {
     const settings = getters.groupSettings
-    return currencies[settings.mincomeCurrency].displayWithCurrency(settings.mincomeAmount)
+    const currency = currencies[settings.mincomeCurrency]
+    return currency && currency.displayWithCurrency(settings.mincomeAmount)
   },
   groupMincomeSymbolWithCode (state, getters) {
-    return currencies[getters.groupSettings.mincomeCurrency].symbolWithCode
+    const currency = currencies[getters.groupSettings.mincomeCurrency]
+    return currency && currency.symbolWithCode
   },
   colors (state) {
     return Colors[state.theme]

--- a/frontend/views/containers/proposals/ProposalTemplate.vue
+++ b/frontend/views/containers/proposals/ProposalTemplate.vue
@@ -75,8 +75,14 @@
     template(slot='footer' v-if='!isConfirmation && rule')
       .c-footer
         i.icon-vote-yea
-        i18n(v-if='groupShouldPropose' html='According to your voting rules, <strong>{value} out of {total} members</strong> will have to agree with this.' :args='rule')
-        i18n(v-else html='Your group has less than 3 members, so <strong>this change will be immediate</strong> (no voting required).')
+        i18n(
+          v-if='groupShouldPropose'
+          :args='{ ...rule, ...LTags("strong") }'
+        ) According to your voting rules, {strong_}{value} out of {total} members{_strong} will have to agree with this.
+        i18n(
+          v-else
+          :args='LTags("strong")'
+        ) Your group has less than 3 members, so {strong_}this change will be immediate{_strong} (no voting required).
 </template>
 
 <script>

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -62,7 +62,10 @@ page(pageTestName='dashboard' pageTestHeaderName='groupName' v-if='groupSettings
       ) Save changes
 
   page-section(:title='L("Leave Group")')
-    i18n(tag='p' html='This means you will stop having access to the <b>group chat</b> (including direct messages to other group members) and <b>contributions</b>. Re-joining the group is possible, but requires other members to vote and reach an agreement.')
+    i18n(
+      tag='p'
+      :args='LTags("b")'
+    ) This means you will stop having access to the {b_}group chat{_b} (including direct messages to other group members) and {b_}contributions{_b}. Re-joining the group is possible, but requires other members to vote and reach an agreement.
 
     i18n.is-danger.is-outlined(
       tag='button'

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -15,6 +15,18 @@ i18next.use(XHR).init({
 })
 
 Vue.prototype.L = L
+Vue.prototype.LTags = LTags
+
+export function LTags (...tags) {
+  const o = {
+    'br_': '<br/>'
+  }
+  for (const tag of tags) {
+    o[`${tag}_`] = `<${tag}>`
+    o[`_${tag}`] = `</${tag}>`
+  }
+  return o
+}
 
 export default function L (
   key: string,
@@ -65,7 +77,7 @@ Vue.component('i18n', {
       })
     } else {
       if (!context.data.domProps) context.data.domProps = {}
-      context.data.domProps.innerText = translation
+      context.data.domProps.innerHTML = translation
       return h(context.props.tag, context.data)
     }
   }


### PR DESCRIPTION
### New `LTags` function!

Instead of having to repeatedly write HTML opening/closing tags in `:args`, you can now simply name them:

```pug
// INSTEAD OF:

i18n(
  v-if='groupShouldPropose'
  html=''
  :args='{ ...rule, s1: "<strong>", s2: "</strong>" }'
) According to your voting rules, {s1}{value} out of {total} members{s2} will have to agree with this.
i18n(
  v-else
  :args='{ s1: "<strong">, s2: "</strong>" }'
) Your group has less than 3 members, so {s1}this change will be immediate{s2} (no voting required).

// DO:

i18n(
  v-if='groupShouldPropose'
  html=''
  :args='{ ...rule, ...LTags("strong") }'
) According to your voting rules, {strong_}{value} out of {total} members{_strong} will have to agree with this.
i18n(
  v-else
  :args='LTags("strong")'
) Your group has less than 3 members, so {strong_}this change will be immediate{_strong} (no voting required).
```

You can pass in a list of tags to `LTags`, like so: `LTags("strong", "em")`

NOTE: By default `LTags` also includes `{br_}` for the `<br/>` tag (which doesn't have a closing tag).

Note that this is **only useful for tags that have no properties!**

### Misc fixes

- Include `vue.esm.js` instead of `vue.common.js`
- Fix exceptions in console for `groupMincomeFormatted` and `groupMincomeSymbolWithCode`
- Boyscoutting for `html` usage
- i18n now again supports basic HTML without having to call `Vue.compile`