### PR TITLE
Fix the double Login-Modal redirection bug upon refresh

### DIFF
--- a/frontend/views/components/Modal/Modal.vue
+++ b/frontend/views/components/Modal/Modal.vue
@@ -24,7 +24,7 @@ export default {
     window.addEventListener('keyup', this.handleKeyUp)
   },
   mounted () {
-    !this.$route.query.next && this.initializeModals()
+    this.initializeModals()
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', OPEN_MODAL)
@@ -66,6 +66,11 @@ export default {
       return this.subcontent[this.subcontent.length - 1]
     },
     initializeModals () {
+      if (this.$route.query.next) {
+        this.openModal('LoginModal')
+        return
+      }
+
       const modal = this.$route.query.modal
       if (modal) this.openModal(modal)
       const subcontent = this.$route.query.subcontent

--- a/frontend/views/components/Modal/Modal.vue
+++ b/frontend/views/components/Modal/Modal.vue
@@ -25,6 +25,8 @@ export default {
   },
   mounted () {
     this.initializeModals()
+    console.log('- content: ', this.content)
+    console.log('- subcontent: ', this.subcontent)
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', OPEN_MODAL)

--- a/frontend/views/components/Modal/Modal.vue
+++ b/frontend/views/components/Modal/Modal.vue
@@ -24,7 +24,7 @@ export default {
     window.addEventListener('keyup', this.handleKeyUp)
   },
   mounted () {
-    this.initializeModals()
+    !this.$route.query.next && this.initializeModals()
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', OPEN_MODAL)

--- a/frontend/views/components/Modal/Modal.vue
+++ b/frontend/views/components/Modal/Modal.vue
@@ -24,7 +24,7 @@ export default {
     window.addEventListener('keyup', this.handleKeyUp)
   },
   mounted () {
-    !this.$route.query.next && this.initializeModals()
+    this.initializeModals()
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', OPEN_MODAL)
@@ -87,6 +87,8 @@ export default {
       }
     },
     openModal (componentName) {
+      // Don't open the same kind of modal twice.
+      if (this.content === componentName) return
       // Record active element
       this.lastFocus = document.activeElement
       if (this.content) {

--- a/frontend/views/components/Modal/Modal.vue
+++ b/frontend/views/components/Modal/Modal.vue
@@ -25,8 +25,6 @@ export default {
   },
   mounted () {
     this.initializeModals()
-    console.log('- content: ', this.content)
-    console.log('- subcontent: ', this.subcontent)
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', OPEN_MODAL)

--- a/frontend/views/components/Modal/Modal.vue
+++ b/frontend/views/components/Modal/Modal.vue
@@ -24,7 +24,7 @@ export default {
     window.addEventListener('keyup', this.handleKeyUp)
   },
   mounted () {
-    this.initializeModals()
+    !this.$route.query.next && this.initializeModals()
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', OPEN_MODAL)
@@ -66,11 +66,6 @@ export default {
       return this.subcontent[this.subcontent.length - 1]
     },
     initializeModals () {
-      if (this.$route.query.next) {
-        this.openModal('LoginModal')
-        return
-      }
-
       const modal = this.$route.query.modal
       if (modal) this.openModal(modal)
       const subcontent = this.$route.query.subcontent

--- a/frontend/views/pages/Home.vue
+++ b/frontend/views/pages/Home.vue
@@ -77,6 +77,11 @@ export default {
     SvgJoinGroup,
     SvgCreateGroup
   },
+  mounted () {
+    if (this.$route.query.next) {
+      this.openModal('LoginModal')
+    }
+  },
   methods: {
     openModal (mode) {
       sbp('okTurtles.events/emit', OPEN_MODAL, mode)

--- a/frontend/views/pages/Home.vue
+++ b/frontend/views/pages/Home.vue
@@ -77,11 +77,6 @@ export default {
     SvgJoinGroup,
     SvgCreateGroup
   },
-  mounted () {
-    if (this.$route.query.next) {
-      this.openModal('LoginModal')
-    }
-  },
   methods: {
     openModal (mode) {
       sbp('okTurtles.events/emit', OPEN_MODAL, mode)


### PR DESCRIPTION
closes #702 

* Reason for the bug
the `next` query string added by the `loginGuard` [ [here ](https://github.com/okTurtles/group-income-simple/blob/master/frontend/views/components/Modal/Modal.vue#L27)] triggers the modal to open in `Home.vue` [ [here ](https://github.com/okTurtles/group-income-simple/blob/master/frontend/views/pages/Home.vue#L82)]
before the modal initialization procedure happens [here](https://github.com/okTurtles/group-income-simple/blob/master/frontend/views/components/Modal/Modal.vue#L27) in `Modal.vue`.
That apparently causes a weird (sort of a) chain reaction of calling `openModal()` method.

* A possible solution I suggest on this PR
move the **"if the query string has next specified then open Login Modal" ** logic from `Home.vue` into the initialization function in `Modal.vue`.

Hope this solution makes sense to you guys, @pieer and @taoeffect .

