### PR TITLE
Fix NavigationDuplicated Error upon logout

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -106,7 +106,7 @@ async function startApp () {
       })
       sbp('okTurtles.events/on', LOGOUT, () => {
         this.ephemeral.finishedLogin = 'no'
-        router.push({ path: '/' }).catch(console.error)
+        router.currentRoute.path !== '/' && router.push({ path: '/' }).catch(console.error)
       })
     },
     computed: {


### PR DESCRIPTION
related to #686 

- problem
Upon logout, `NavigationDuplicated` error occurs because it tries to navigate to the same route.
- solution
Make it navigate to the route only when the current route is not the same as the destination.