### PR TITLE
basic PayGroup payment sending + state/groupContractSafeGetters + more

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -6,7 +6,9 @@ import sbp from '~/shared/sbp.js'
 import { GIMessage } from '~/shared/GIMessage.js'
 import { blake32Hash } from '~/shared/functions.js'
 import { SERVER_INSTANCE } from './instance-keys.js'
+import chalk from 'chalk'
 import './database.js'
+
 const Boom = require('@hapi/boom')
 const Joi = require('@hapi/joi')
 
@@ -33,7 +35,12 @@ route.POST('/event', {
     await sbp('backend/server/handleEntry', entry)
     return entry.hash()
   } catch (err) {
-    logger(err)
+    if (err.name === 'ErrorDBBadPreviousHEAD') {
+      console.error(chalk.bold.yellow('ErrorDBBadPreviousHEAD'), err)
+      return Boom.conflict(err.message)
+    } else {
+      logger(err)
+    }
     return err
   }
 })

--- a/frontend/controller/backend.js
+++ b/frontend/controller/backend.js
@@ -96,7 +96,7 @@ sbp('okTurtles.events/on', CONTRACTS_MODIFIED, async (contracts) => {
 })
 
 sbp('sbp/selectors/register', {
-  'backend/publishLogEntry': async (entry: GIMessage, { maxAttempts = 1 } = {}) => {
+  'backend/publishLogEntry': async (entry: GIMessage, { maxAttempts = 2 } = {}) => {
     const action = CONTRACT_REGEX.exec(entry.type())[1]
     var attempt = 1
     // auto resend after short random delay
@@ -119,7 +119,7 @@ sbp('sbp/selectors/register', {
           throw new Error(`publishLogEntry: ${r.status} - ${r.statusText}. attempt ${attempt}`)
         }
         // create new entry
-        const randDelay = randomIntFromRange(500, 2000)
+        const randDelay = randomIntFromRange(0, 1500)
         console.warn(`publishLogEntry: attempt ${attempt} of ${maxAttempts} failed. Waiting ${randDelay} msec before resending ${action}`)
         attempt += 1
         await delay(randDelay) // wait half a second before sending it again

--- a/frontend/controller/namespace.js
+++ b/frontend/controller/namespace.js
@@ -18,7 +18,7 @@ sbp('sbp/selectors/register', {
     // TODO: should `name` be encodeURI'd?
     return fetch(`${process.env.API_URL}/name/${name}`).then((r: Object) => {
       if (!r.ok) {
-        console.debug(`namespace/lookup: ${r.status} (${typeof r.status}))`, r)
+        console.warn(`namespace/lookup: ${r.status}`, r)
         if (r.status !== 404) {
           throw new Error(`${r.status}: ${r.statusText}`)
         }

--- a/frontend/model/contracts/Contract.js
+++ b/frontend/model/contracts/Contract.js
@@ -6,9 +6,7 @@ import { GIMessage } from '~/shared/GIMessage.js'
 // this must not be exported, but instead accessed through 'actionWhitelisted'
 const whitelistedSelectors = {}
 
-// can be useful for extracting the name of the contract or action, for example:
-// const contractName = CONTRACT_REGEX.exec(selector)[1]
-export const CONTRACT_REGEX = /^[\w.]+\/([^/]+)\/(?:([^/]+)\/)?process$/
+export const CONTRACT_REGEX = /^(([\w.]+)\/([^/]+)\/(?:([^/]+)\/)?)process$/
 
 // TODO: define a flow type for contracts
 export function DefineContract (contract: Object) {

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -30,6 +30,7 @@ var store // this is set and made the default export at the bottom of the file.
 // we have it declared here to make it accessible in mutations
 // 'state' is the Vuex state object, and it can only store JSON-like data
 var dropAllMessagesUntilRefresh = false
+var attemptToReprocessMessageID
 const contractIsSyncing: {[string]: boolean} = {}
 
 const initialState = {
@@ -38,7 +39,6 @@ const initialState = {
   pending: [], // contractIDs we've just published but haven't received back yet
   loggedIn: false, // false | { username: string, identityContractID: string }
   theme: 'blue',
-  paymentsByMonth: {},
   reducedMotion: false,
   fontSize: 1
 }
@@ -94,16 +94,14 @@ sbp('sbp/selectors/register', {
       'state/vuex/dispatch', 'handleEvent', event
     ])
   },
-  // use 'contractSafeGetters' from within a contract to avoid code duplication,
+  // use 'groupContractSafeGetters' from within a contract to avoid code duplication,
   // but be careful to only use getters that restrict themselves to the
   // contract's state, and do not access state outside the contract.
   // For example, if the getter you use tries to access `state.loggedIn`,
-  // that will break the `latestContractState` function, so DO NOT
-  // USE getters that access state outside of the contract from within
-  // the contract!
-  // The only place that is OK is in the contract's `sideEffect` function,
-  // and ONLY if the sideEffect does not modify the contract's state.
-  'state/contractSafeGetters': function (state: Object) {
+  // that will break the `latestContractState` function.
+  // It is only safe to access state outside of the contract in a contract action's
+  // `sideEffect` function (as long as it doesn't modify contract state)
+  'state/groupContractSafeGetters': function (state: Object) {
     var lastAccessedGetter
     const stateProxy = new Proxy({}, {
       get: function (obj, prop) {
@@ -116,7 +114,10 @@ sbp('sbp/selectors/register', {
     const gettersProxy = new Proxy({}, {
       get: function (obj, prop) {
         lastAccessedGetter = prop
-        return getters[prop](stateProxy, gettersProxy)
+        // this is a bit of a hack, and in the future we might
+        // instead register getters on the vuex module and somehow
+        // pass them to the contract process function, but this works for now
+        return prop === 'currentGroupState' ? stateProxy : getters[prop](stateProxy, gettersProxy)
       }
     })
     return gettersProxy
@@ -212,6 +213,15 @@ const mutations = {
 }
 // https://vuex.vuejs.org/en/getters.html
 // https://vuex.vuejs.org/en/modules.html
+//
+// !!  IMPORTANT  !!
+//
+// To make it simple to use *SOME* of these getters (the ones related to
+// group contract state) via 'state/groupContractSafeGetters', prefer using
+// 'getters' to access state instead of 'state'.
+//
+// For example, instead of: state[state.currentGroupId]
+//     Use getters instead: getters.currentGroupState
 const getters = {
   currentGroupState (state) {
     return state[state.currentGroupId] || {} // avoid "undefined" vue errors at inoportune times
@@ -239,36 +249,37 @@ const getters = {
   },
   // list of group names and contractIDs
   groupsByName (state) {
-    const { contracts } = store.state
+    const contracts = state.contracts
     // The code below was originally Object.entries(...) but changed to .keys()
     // due to the same flow issue as https://github.com/facebook/flow/issues/5838
-    return Object.keys(contracts)
+    return Object.keys(contracts || {})
       .filter(contractID => contracts[contractID].type === 'group' && state[contractID].settings)
       .map(contractID => ({ groupName: state[contractID].settings.groupName, contractID }))
   },
-  memberProfile (state) {
-    return (username) => {
-      var profile = state[state.currentGroupId].profiles[username]
-      return profile && state[profile.contractID] && {
-        contractID: profile.contractID,
-        globalProfile: state[profile.contractID].attributes,
-        groupProfile: profile.groupProfile
-      }
+  groupProfile (state, getters) {
+    return username => {
+      const profiles = getters.currentGroupState.profiles
+      return profiles && profiles[username]
     }
   },
-  groupMembers (state, getters) {
-    const groupId = state.currentGroupId
-    return groupId && state[groupId] && Object.keys(state[groupId].profiles || {}).reduce(
+  globalProfile (state, getters) {
+    return username => {
+      const groupProfile = getters.groupProfile(username)
+      const identityState = groupProfile && state[groupProfile.contractID]
+      return identityState && identityState.attributes
+    }
+  },
+  groupProfiles (state, getters) {
+    return Object.keys(getters.currentGroupState.profiles || {}).reduce(
       (result, username) => {
-        result[username] = getters.memberProfile(username, groupId)
+        result[username] = getters.groupProfile(username)
         return result
       },
       {}
     )
   },
-  groupMembersByUsername (state) {
-    var profiles = state.currentGroupId && state[state.currentGroupId] && state[state.currentGroupId].profiles
-    return Object.keys(profiles || {})
+  groupMembersByUsername (state, getters) {
+    return Object.keys(getters.currentGroupState.profiles || {})
   },
   groupMembersCount (state, getters) {
     return getters.groupMembersByUsername.length
@@ -289,23 +300,23 @@ const getters = {
     return currency && currency.symbolWithCode
   },
   groupIncomeDistribution (state, getters) {
-    const groupMembers = getters.groupMembers
+    const groupProfiles = getters.groupProfiles
     const mincomeAmount = getters.groupMincomeAmount
     const currentIncomeDistribution = []
-    for (const username in groupMembers) {
-      const member = groupMembers[username]
-      const incomeDetailsType = member && member.groupProfile.incomeDetailsType
+    for (const username in groupProfiles) {
+      const profile = groupProfiles[username]
+      const incomeDetailsType = profile && profile.incomeDetailsType
       if (incomeDetailsType) {
         const adjustment = incomeDetailsType === 'incomeAmount' ? 0 : mincomeAmount
-        const adjustedAmount = adjustment + member.groupProfile[incomeDetailsType]
+        const adjustedAmount = adjustment + profile[incomeDetailsType]
         currentIncomeDistribution.push({ name: username, amount: adjustedAmount })
       }
     }
     return incomeDistribution(currentIncomeDistribution, mincomeAmount)
   },
   thisMonthsPayments (state, getters) {
-    const payments = getters.currentGroupState.paymentsByMonth
-    return payments && payments[currentMonthTimestamp()]
+    const payments = getters.currentGroupState.userPaymentsByMonth
+    return (payments && payments[currentMonthTimestamp()]) || {}
   },
   colors (state) {
     return Colors[state.theme]
@@ -429,6 +440,11 @@ const actions = {
       handleEvent.processMutation(message)
       // process any side-effects (these must never result in any mutation to this contract state)
       await handleEvent.processSideEffects(message)
+
+      if (attemptToReprocessMessageID === message.hash()) {
+        console.warn(`Successfully re-processed ${attemptToReprocessMessageID}!`)
+        attemptToReprocessMessageID = null
+      }
     } catch (e) {
       // For details about the rationale for how error handling works here see these links:
       // https://gitlab.okturtles.org/okturtles/group-income-simple/snippets/9
@@ -467,7 +483,19 @@ const actions = {
         dropAllMessagesUntilRefresh = true
       }
       if (banUser) {
-        await handleEvent.autoBanSenderOfMessage(message, e)
+        if (contractIsSyncing[contractID]) {
+          console.warn(`handleEvent: skipping autoBanSenderOfMessage since we're syncing ${contractID}`)
+        } else {
+          // NOTE: this random delay is here for multiple reasons:
+          const randomDelay = _.randomIntFromRange(0, 1000)
+          // 1. to avoid backend throwing 'bad previousHEAD' error
+          // https://github.com/okTurtles/group-income-simple/issues/608
+          // 2. because we need to make sure that if a proposal has been cast by someone,
+          // then we are likely to find it in store.state, so we have this random delay
+          // here a the top, before we iterate store.state[groupID].proposals, and
+          // 3. to avoid weird errors like 'TypeError: "state[(intermediate value)] is undefined"'
+          setTimeout(() => handleEvent.autoBanSenderOfMessage(message, e), randomDelay)
+        }
       }
     }
   }
@@ -487,6 +515,21 @@ const handleEvent = {
       return await sbp('gi.db/log/addEntry', message)
     } catch (e) {
       if (e instanceof ErrorDBBadPreviousHEAD) {
+        // sometimes we simply miss messages, it's not clear why, but it happens
+        // in rare cases. So we attempt to re-sync this contract once
+        if (!attemptToReprocessMessageID) {
+          // keep track of what message we're trying to reprocess
+          // so that if we're able to fix ourselves we can go back to normal
+          attemptToReprocessMessageID = message.hash()
+          console.warn(`addMessageToDB: going to attempt to resync ${message.contractID()} to re-process ${message.type()} / ${message.hash()}`)
+          setTimeout(() => {
+            // re-enable message processing
+            dropAllMessagesUntilRefresh = false
+            sbp('state/enqueueContractSync', message.contractID())
+          }, 1000)
+        } else {
+          console.error(`addMessageToDB: already attempted to re-process ${attemptToReprocessMessageID} ${message.type()}, will not attempt again!`)
+        }
         // the server should never send us a bad previousHEAD (because)
         // it verifies that before adding it to its db. So if we receive
         // this error it means somehow we're getting valid messages out of order
@@ -508,7 +551,7 @@ const handleEvent = {
       const hash = message.hash()
       const data = message.data()
       const meta = message.meta()
-      const type = CONTRACT_REGEX.exec(selector)[1]
+      const type = CONTRACT_REGEX.exec(selector)[3]
       if (!type) {
         throw new GIErrorIgnoreAndBanIfGroup(`bad selector '${selector}' for message ${hash}`)
       }
@@ -576,7 +619,7 @@ const handleEvent = {
       // TODO: set state machine critical error state
     }
   },
-  async autoBanSenderOfMessage (message: GIMessage, error: Object) {
+  async autoBanSenderOfMessage (message: GIMessage, error: Object, attempt = 1) {
     const contractID = message.contractID()
     try {
       // If we just joined, we're likely witnessing an old error that was handled
@@ -586,23 +629,15 @@ const handleEvent = {
       // TODO: we should still autoban them after the sync is finished
       //       if the proposal is still open. See #731
       if (contractIsSyncing[contractID]) {
-        console.debug(`skipping autoBanSenderOfMessage since we're syncing ${contractID}`)
+        console.warn(`skipping autoBanSenderOfMessage since we're syncing ${contractID}`)
         return // don't do anything, assume the existing users handled this event
       }
-      // NOTE: this random delay is here for multiple reasons:
-      //       1. to avoid backend throwing 'bad previousHEAD' error
-      //       https://github.com/okTurtles/group-income-simple/issues/608
-      await _.delay(_.randomIntFromRange(1, 2000))
-      //       2. because we need to make sure that if a proposal has been cast by someone,
-      //       then we are likely to find it in store.state, so we have this random delay
-      //       here a the top, before we iterate store.state[groupID].proposals, and
-      //       3. to avoid weird errors like 'TypeError: "state[(intermediate value)] is undefined"'
       const username = message.meta().username
       if (message.type().indexOf('gi.contracts/group/') !== 0) {
         console.warn(`autoBanSenderOfMessage: removing & unsubscribing from ${username} contractID: ${contractID}`)
         store.commit('removeContract', contractID)
       }
-      if (username && store.getters.memberProfile(username)) {
+      if (username && store.getters.groupProfile(username)) {
         console.warn(`autoBanSenderOfMessage: autobanning ${username}`)
         const groupID = store.state.currentGroupId
         var proposal
@@ -610,7 +645,10 @@ const handleEvent = {
         // find existing proposal if it exists
         for (const hash in store.state[groupID].proposals) {
           const prop = store.state[groupID].proposals[hash]
-          if (prop.status === STATUS_OPEN && prop.data.proposalType === PROPOSAL_REMOVE_MEMBER && prop.data.proposalData.member === username) {
+          if (prop.status === STATUS_OPEN &&
+            prop.data.proposalType === PROPOSAL_REMOVE_MEMBER &&
+            prop.data.proposalData.member === username
+          ) {
             proposal = prop
             proposalHash = hash
             break
@@ -623,23 +661,32 @@ const handleEvent = {
               { proposalHash, vote: VOTE_FOR },
               groupID
             )
-            await sbp('backend/publishLogEntry', vote)
+            await sbp('backend/publishLogEntry', vote, { maxAttempts: 3 })
           }
         } else {
           // create our proposal to ban the user
-          proposal = await sbp('gi.contracts/group/proposal/create',
-            {
-              proposalType: PROPOSAL_REMOVE_MEMBER,
-              proposalData: {
-                member: username,
-                reason: L("Automated ban because they're sending malformed messages resulting in: {error}", { error: error.message })
-              },
-              votingRule: store.getters.groupSettings.proposals[PROPOSAL_REMOVE_MEMBER].rule,
-              expires_date_ms: Date.now() + store.getters.groupSettings.proposals[PROPOSAL_REMOVE_MEMBER].expires_ms
+          proposal = await sbp('gi.contracts/group/proposal/create', {
+            proposalType: PROPOSAL_REMOVE_MEMBER,
+            proposalData: {
+              member: username,
+              reason: L("Automated ban because they're sending malformed messages resulting in: {error}", { error: error.message })
             },
-            groupID
-          )
-          await sbp('backend/publishLogEntry', proposal)
+            votingRule: store.getters.groupSettings.proposals[PROPOSAL_REMOVE_MEMBER].rule,
+            expires_date_ms: Date.now() + store.getters.groupSettings.proposals[PROPOSAL_REMOVE_MEMBER].expires_ms
+          }, groupID)
+          try {
+            await sbp('backend/publishLogEntry', proposal)
+          } catch (e) {
+            if (attempt > 2) {
+              console.error(`autoBanSenderOfMessage: max attempts reached. Error ${e.message} attempting to ban ${username}`, message, e)
+            } else {
+              const randDelay = _.randomIntFromRange(500, 1000)
+              console.warn(`autoBanSenderOfMessage: ${e.message} attempting to ban ${username}, retrying in ${randDelay} ms...`, e)
+              setTimeout(() => {
+                handleEvent.autoBanSenderOfMessage(message, error, attempt + 1)
+              }, randDelay)
+            }
+          }
         }
       }
     } catch (e) {

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -487,7 +487,7 @@ const actions = {
           console.warn(`handleEvent: skipping autoBanSenderOfMessage since we're syncing ${contractID}`)
         } else {
           // NOTE: this random delay is here for multiple reasons:
-          const randomDelay = _.randomIntFromRange(0, 1000)
+          const randomDelay = _.randomIntFromRange(0, 1500)
           // 1. to avoid backend throwing 'bad previousHEAD' error
           // https://github.com/okTurtles/group-income-simple/issues/608
           // 2. because we need to make sure that if a proposal has been cast by someone,
@@ -675,12 +675,12 @@ const handleEvent = {
             expires_date_ms: Date.now() + store.getters.groupSettings.proposals[PROPOSAL_REMOVE_MEMBER].expires_ms
           }, groupID)
           try {
-            await sbp('backend/publishLogEntry', proposal)
+            await sbp('backend/publishLogEntry', proposal, { maxAttempts: 1 })
           } catch (e) {
             if (attempt > 2) {
               console.error(`autoBanSenderOfMessage: max attempts reached. Error ${e.message} attempting to ban ${username}`, message, e)
             } else {
-              const randDelay = _.randomIntFromRange(500, 1000)
+              const randDelay = _.randomIntFromRange(0, 1500)
               console.warn(`autoBanSenderOfMessage: ${e.message} attempting to ban ${username}, retrying in ${randDelay} ms...`, e)
               setTimeout(() => {
                 handleEvent.autoBanSenderOfMessage(message, error, attempt + 1)

--- a/frontend/views/containers/UserImage.vue
+++ b/frontend/views/containers/UserImage.vue
@@ -32,10 +32,10 @@ export default {
   },
   computed: {
     profile () {
-      return this.$store.getters.memberProfile(this.username)
+      return this.$store.getters.globalProfile(this.username)
     },
     pictureURL () {
-      return this.profile ? this.profile.globalProfile.picture : this.ephemeral.url
+      return this.profile ? this.profile.picture : this.ephemeral.url
     }
   },
   data () {

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -108,23 +108,24 @@ export default {
   },
   computed: {
     ...mapGetters([
-      'groupMembers',
       'groupSettings',
-      'memberProfile',
+      'groupProfile',
+      'groupProfiles',
       'groupMincomeFormatted',
       'groupMincomeSymbolWithCode',
-      'ourUsername',
-      'groupMembersByUsername'
+      'ourUsername'
     ]),
     memberGroupProfile () {
-      const profile = this.memberProfile(this.ourUsername) || {}
-      return profile.groupProfile || {}
+      return this.groupProfile(this.ourUsername) || {}
     },
     needsIncome () {
       return this.form.incomeDetailsType === 'incomeAmount'
     },
     whoIsPledging () {
-      return this.groupMembersByUsername.filter(username => this.groupMembers[username].groupProfile.incomeDetailsType === 'pledgeAmount' && username !== this.ourUsername)
+      const groupProfiles = this.groupProfiles
+      return Object.keys(groupProfiles).filter(username => {
+        return groupProfiles[username].incomeDetailsType === 'pledgeAmount' && username !== this.ourUsername
+      })
     }
   },
   created () {

--- a/frontend/views/containers/sidebar/GroupMembers.vue
+++ b/frontend/views/containers/sidebar/GroupMembers.vue
@@ -97,11 +97,11 @@ export default {
   },
   computed: {
     ...mapGetters([
-      'groupMembers',
+      'groupProfiles',
       'groupMembersCount'
     ]),
     firstTenMembers () {
-      const profiles = this.groupMembers
+      const profiles = this.groupProfiles
       const usernames = Object.keys(profiles).slice(0, 10)
       return usernames.reduce((acc, username) => {
         // Prevent displaying users without a synced contract.

--- a/frontend/views/pages/Contributions.vue
+++ b/frontend/views/pages/Contributions.vue
@@ -2,7 +2,7 @@
 page(pageTestName='contributionsPage' pageTestHeaderName='contributionsTitle')
   template(#title='') {{ L('Contributions') }}
 
-  // v-if='memberProfile(ourUsername).groupProfile.incomeDetailsKey'
+  // v-if='groupProfile(ourUsername).incomeDetailsKey'
   callout-card(
     :isCard='true'
     :title='L("Add your income details")'
@@ -221,7 +221,7 @@ export default {
   computed: {
     ...mapGetters([
       'groupSettings',
-      'memberProfile',
+      'groupProfile',
       'groupMincomeFormatted',
       'ourUsername'
     ]),
@@ -233,11 +233,11 @@ export default {
     }
   },
   beforeMount () {
-    const profile = this.memberProfile(this.ourUsername) || {}
-    const incomeDetailsType = profile.groupProfile && profile.groupProfile.incomeDetailsType
+    const profile = this.groupProfile(this.ourUsername) || {}
+    const incomeDetailsType = profile.incomeDetailsType
     if (incomeDetailsType) {
       this.form.incomeDetailsType = incomeDetailsType
-      this.form[incomeDetailsType] = profile.groupProfile[incomeDetailsType]
+      this.form[incomeDetailsType] = profile[incomeDetailsType]
     }
   },
   methods: {

--- a/frontend/views/pages/PayGroup.vue
+++ b/frontend/views/pages/PayGroup.vue
@@ -5,9 +5,7 @@ page(
 )
   template(#title='') {{ L('Pay Group') }}
 
-  template(#sidebar=''
-    v-if='hasPayments'
-  )
+  template(#sidebar='' v-if='hasPayments')
     .c-summary-item(
       v-for='(item, index) in paymentSummary'
       :key='index'
@@ -21,6 +19,7 @@ page(
       p(:class='{"has-text-success": item.max === item.value}')
         i.icon-check(v-if='item.max === item.value')
         .has-text-1 {{ item.label }}
+
   .c-container-empty(v-if='!hasPayments')
     svg-contributions.c-svg
 
@@ -52,7 +51,7 @@ page(
                 user: `<b>${username}</b>` \
               }'
             ) {total} to {user}
-            i18n(:class='paymentStatusClass()')
+            //- i18n(:class='paymentStatusClass()')
             //- i18n.has-text-1(
             //-   v-if='statusIsPending(payment)'
             //-   :args='{ username }'
@@ -74,7 +73,7 @@ page(
             tag='button'
             key='send'
             v-if='statusIsToPay(username)'
-            @click='markAsPayed(username)'
+            @click='markAsPayed(username, payment)'
           ) Mark as sent
           i18n.button.is-small.is-outlined(
             tag='button'
@@ -135,7 +134,7 @@ page(
 
 <script>
 import sbp from '~/shared/sbp.js'
-import { mapGetters, mapState } from 'vuex'
+import { mapGetters } from 'vuex'
 import Page from '@pages/Page.vue'
 import Avatar from '@components/Avatar.vue'
 import UserImage from '@containers/UserImage.vue'
@@ -195,40 +194,34 @@ export default {
     }
   },
   computed: {
-    ...mapState([
-      'paymentsByMonth'
-    ]),
     ...mapGetters([
+      'currentGroupState',
       'groupIncomeDistribution',
-      'groupMembers',
+      'groupProfiles',
       'groupSettings',
       'ourUsername',
-      'memberProfile',
       'thisMonthsPayments'
     ]),
     currency () {
       return currencies[this.groupSettings.mincomeCurrency]
     },
     paymentsDistribution () {
-      return {}
-      /*
-      if (Object.keys(this.thisMonthsPayments).length > 0) {
-
-      } else {
-        return this.groupIncomeDistribution.filter(p => p.from === this.ourUsername)
-          .reduce((acc, payment) => {
-            acc[payment.to] = {
-              amount: +this.currency.displayWithoutCurrency(payment.amount),
-              amountPretty: this.currency.displayWithCurrency(payment.amount)
-            }
-            return acc
-          }, {})
-      }
-      */
+      // TODO: make sure we create a new month if month roll's over
+      //       perhaps send a message to do that
+      const distribution = this.thisMonthsPayments.frozenDistribution || this.groupIncomeDistribution
+      // const distribution = this.groupIncomeDistribution
+      return distribution.filter(p => p.from === this.ourUsername)
+        .reduce((acc, payment) => {
+          acc[payment.to] = {
+            amount: +this.currency.displayWithoutCurrency(payment.amount),
+            amountPretty: this.currency.displayWithCurrency(payment.amount)
+          }
+          return acc
+        }, {})
     },
     // old stuff (to be deleted) follows
     hasPayments () {
-      return this.fakeStore.usersToPay.length > 0
+      return Object.keys(this.paymentsDistribution).length > 0
     },
     paymentStatus () {
       const { usersToPay } = this.fakeStore
@@ -281,14 +274,21 @@ export default {
     }
   },
   methods: {
-    statusIsToPay (username) {
-      return !this.thisMonthsPayments[username]
+    statusIsToPay (toUser) {
+      const payments = this.thisMonthsPayments.payments
+      const ourPayments = payments && payments[this.ourUsername]
+      return !payments || !ourPayments || !ourPayments[toUser]
     },
     statusIsSent (user) {
       return ['completed', 'pending'].includes(user.status)
     },
-    statusIsPending (user) {
-      return user.status === 'pending'
+    statusIsPending (toUser) {
+      const payments = this.thisMonthsPayments.payments
+      const ourPayments = payments && payments[this.ourUsername]
+      const paymentHash = ourPayments && ourPayments[toUser]
+      // const payment = paymentHash && this.currentGroupState.payments[paymentHash]
+      // console.warn({ ourUser: this.ourUsername, toUser, payments, ourPayments, paymentHash, payment })
+      return paymentHash && this.currentGroupState.payments[paymentHash].data.status === 'pending'
     },
     statusIsRejected (user) {
       return user.status === 'rejected'
@@ -299,10 +299,20 @@ export default {
     getUserFirstName (name) {
       return name.split(' ')[0]
     },
-    markAsPayed (user) {
-      console.log('TODO - mark as payed')
-      // Raw Logic
-      user.status = 'pending'
+    async markAsPayed (toUser, payment) {
+      try {
+        const paymentMessage = await sbp('gi.contracts/group/payment/create', {
+          toUser,
+          amount: payment.amount,
+          currency: this.currency.symbol,
+          txid: String(Math.random()),
+          status: 'pending',
+          paymentType: 'manual'
+        }, this.$store.state.currentGroupId)
+        await sbp('backend/publishLogEntry', paymentMessage)
+      } catch (e) {
+        console.error(e)
+      }
     },
     cancelPayment (user) {
       console.log('TODO - cancel payment')

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -1,8 +1,9 @@
-import i18next from 'i18next'
-import XHR from 'i18next-xhr-backend'
+// import i18next from 'i18next'
+// import XHR from 'i18next-xhr-backend'
 import Vue from 'vue'
 import template from '~/frontend/utils/stringTemplate.js'
 
+/*
 i18next.use(XHR).init({
   load: 'languageOnly',
   fallbackLng: 'en',
@@ -13,6 +14,7 @@ i18next.use(XHR).init({
 }, (err) => {
   if (err) console.error('i18next setup error:', err)
 })
+*/
 
 Vue.prototype.L = L
 Vue.prototype.LTags = LTags
@@ -63,7 +65,11 @@ export default function L (
   // TODO: see also using i18next's interpolation and formatting
   //       https://www.i18next.com/translation-function/formatting
   //       https://www.i18next.com/translation-function/interpolation
-  return template(i18next.t(key, options), args)
+  // return template(i18next.t(key, options), args)
+  // BUG/TODO: i18next is broken, and we should get rid of it anyway
+  // doing L("Automated ban because they're sending malformed messages resulting in: {error}", { error: 'error.message' })
+  // results in output: " error.message"
+  return template(key, args)
 }
 
 Vue.component('i18n', {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1115,6 +1115,7 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
       "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
       }
@@ -6869,22 +6870,6 @@
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
     },
-    "i18next": {
-      "version": "17.0.4",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-17.0.4.tgz",
-      "integrity": "sha512-+lwmv3FT8Sv/HwVPjkR6rtEFhgOqt9L/CTehzyxvL/NdkeUYbFZJfE57MsBToB6LFWg3d0sZJIVgYqCpWzUyLQ==",
-      "requires": {
-        "@babel/runtime": "^7.3.1"
-      }
-    },
-    "i18next-xhr-backend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-3.0.0.tgz",
-      "integrity": "sha512-Pi/X91Zk2nEqdEHTV+FG6VeMHRcMcPKRsYW/A0wlaCfKsoJc3TI7A75Tqse/d5LVGN2Ymzx0FT+R+gLag9Eb2g==",
-      "requires": {
-        "@babel/runtime": "^7.4.5"
-      }
-    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -9244,7 +9229,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -10781,7 +10767,8 @@
     "regenerator-runtime": {
       "version": "0.13.3",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.1",

--- a/package.json
+++ b/package.json
@@ -100,8 +100,6 @@
     "blakejs": "1.1.0",
     "buffer": "5.2.1",
     "form-data": "2.5.0",
-    "i18next": "17.0.4",
-    "i18next-xhr-backend": "3.0.0",
     "localforage": "1.7.3",
     "multihashes": "0.4.14",
     "nacl-blob": "2.0.2",

--- a/test/backend.js
+++ b/test/backend.js
@@ -114,7 +114,7 @@ describe('Full walkthrough', function () {
       }
     })
   }
-  function createPaymentTo (to, amount, parentHash, currency = 'USD') {
+  function createPaymentTo (to, amount, contractID, currency = 'USD') {
     return sbp('gi.contracts/group/payment/create',
       {
         toUser: to.data().attributes.name,
@@ -124,7 +124,7 @@ describe('Full walkthrough', function () {
         status: PAYMENT_PENDING,
         paymentType: PAYMENT_TYPE_MANUAL
       },
-      parentHash
+      contractID
     )
   }
 
@@ -259,7 +259,7 @@ describe('Full walkthrough', function () {
       await postEntry(await createPaymentTo(users.bob, 100, groups.group1.hash()))
     })
 
-    it('Should fail with wrong parentHash', async function () {
+    it('Should fail with wrong contractID', async function () {
       try {
         var p = await createPaymentTo(users.bob, 100, '')
         await postEntry(p)


### PR DESCRIPTION
+ can send payments in PayGroup
+ 'state/groupContractSafeGetters' makes it safe to use getters in group contract
+ handled a bunch of random previousHEAD related sync errors
+ Closes #608 - will retry publishLogEntry on autoban
+ groupMembers is now groupProfiles, and globalProfile is separated out to its own getter
+ fix error with L function not localizing string by no longer importing i18next