### PR TITLE
Group Settings - implement "save changes".

### DIFF
--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -13,6 +13,7 @@ import * as Errors from '../errors.js'
 import { merge, deepEqualJSONType } from '~/frontend/utils/giLodash.js'
 import { currentMonthTimestamp } from '~/frontend/utils/time.js'
 import { vueFetchInitKV } from '~/frontend/views/utils/misc.js'
+import currencies from '@view-utils/currencies.js'
 
 export const INVITE_INITIAL_CREATOR = 'INVITE_INITIAL_CREATOR'
 export const INVITE_STATUS = {
@@ -311,8 +312,11 @@ DefineContract({
       // OPTIMIZE: Make this custom validation function
       // reusable accross other future validators
       validate: objectMaybeOf({
+        groupName: x => typeof x === 'string',
+        groupPicture: x => typeof x === 'string',
+        sharedValues: x => typeof x === 'string',
         mincomeAmount: x => typeof x === 'number' && x > 0,
-        mincomeCurrency: x => typeof x === 'string'
+        mincomeCurrency: x => Object.keys(currencies).includes(x)
       }),
       process (state, { data }) {
         for (var key in data) {

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -13,7 +13,7 @@ import * as Errors from '../errors.js'
 import { merge, deepEqualJSONType } from '~/frontend/utils/giLodash.js'
 import { currentMonthTimestamp } from '~/frontend/utils/time.js'
 import { vueFetchInitKV } from '~/frontend/views/utils/misc.js'
-import currencies from '@view-utils/currencies.js'
+import currencies from '~/frontend/views/utils/currencies.js'
 
 export const INVITE_INITIAL_CREATOR = 'INVITE_INITIAL_CREATOR'
 export const INVITE_STATUS = {

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -13,7 +13,6 @@ import * as Errors from '../errors.js'
 import { merge, deepEqualJSONType } from '~/frontend/utils/giLodash.js'
 import { currentMonthTimestamp } from '~/frontend/utils/time.js'
 import { vueFetchInitKV } from '~/frontend/views/utils/misc.js'
-import currencies from '~/frontend/views/utils/currencies.js'
 
 export const INVITE_INITIAL_CREATOR = 'INVITE_INITIAL_CREATOR'
 export const INVITE_STATUS = {
@@ -316,7 +315,7 @@ DefineContract({
         groupPicture: x => typeof x === 'string',
         sharedValues: x => typeof x === 'string',
         mincomeAmount: x => typeof x === 'number' && x > 0,
-        mincomeCurrency: x => Object.keys(currencies).includes(x)
+        mincomeCurrency: x => typeof x === 'string'
       }),
       process (state, { data }) {
         for (var key in data) {

--- a/frontend/views/components/AvatarUpload.vue
+++ b/frontend/views/components/AvatarUpload.vue
@@ -4,7 +4,7 @@
     .c-avatar-wrapper
       label.c-avatar-label
         avatar.c-avatar-img(
-          :src='form.picture'
+          :src='avatar'
           ref='picture'
         )
         i18n.link.c-avatar-text Change avatar
@@ -29,9 +29,12 @@ import L from '@view-utils/translations.js'
 export default {
   name: 'AvatarUpload',
   props: {
-    variant: {
+    avatar: {
       type: String,
-      validator: (value) => ['user', 'group'].includes(value),
+      required: true
+    },
+    sbpParams: {
+      type: Object,
       required: true
     }
   },
@@ -40,34 +43,10 @@ export default {
     BannerScoped
   },
   data () {
-    const picture = {
-      user: this.$store.getters.ourUserIdentityContract.attributes.picture,
-      group: this.$store.getters.groupSettings.groupPicture
-    }[this.variant]
-
     return {
-      form: {
-        picture
-      },
       ephemeral: {
         isSubmitting: false
       }
-    }
-  },
-  computed: {
-    sbpParams () {
-      return {
-        user: {
-          selector: 'gi.contracts/identity/setAttributes/create',
-          contractID: this.$store.state.loggedIn.identityContractID,
-          key: 'picture'
-        },
-        group: {
-          selector: 'gi.contracts/group/updateSettings/create',
-          contractID: this.$store.state.currentGroupId,
-          key: 'groupPicture'
-        }
-      }[this.variant]
     }
   },
   methods: {

--- a/frontend/views/components/AvatarUpload.vue
+++ b/frontend/views/components/AvatarUpload.vue
@@ -1,0 +1,165 @@
+<template lang='pug'>
+  // TODO #658
+  form.c-avatar-form(@submit.prevent='')
+    .c-avatar-wrapper
+      label.c-avatar-label
+        avatar.c-avatar-img(
+          :src='form.picture'
+          ref='picture'
+        )
+        i18n.link.c-avatar-text Change avatar
+
+        input.sr-only(
+          type='file'
+          name='picture'
+          accept='image/*'
+          @change='fileChange($event.target.files)'
+          placeholder='http://'
+          data-test='picture'
+        )
+      banner-scoped.c-formMsg(ref='formMsg' data-test='formMsg')
+</template>
+<script>
+import sbp from '~/shared/sbp.js'
+import imageUpload from '@utils/imageUpload.js'
+import Avatar from '@components/Avatar.vue'
+import BannerScoped from '@components/banners/BannerScoped.vue'
+import L from '@view-utils/translations.js'
+
+export default {
+  name: 'AvatarUpload',
+  props: {
+    variant: {
+      type: String,
+      validator: (value) => ['user', 'group'].includes(value),
+      required: true
+    }
+  },
+  components: {
+    Avatar,
+    BannerScoped
+  },
+  data () {
+    const picture = {
+      user: this.$store.getters.ourUserIdentityContract.attributes.picture,
+      group: this.$store.getters.groupSettings.groupPicture
+    }[this.variant]
+
+    return {
+      form: {
+        picture
+      },
+      ephemeral: {
+        isSubmitting: false
+      }
+    }
+  },
+  computed: {
+    sbpParams () {
+      return {
+        user: {
+          selector: 'gi.contracts/identity/setAttributes/create',
+          contractID: this.$store.state.loggedIn.identityContractID,
+          key: 'picture'
+        },
+        group: {
+          selector: 'gi.contracts/group/updateSettings/create',
+          contractID: this.$store.state.currentGroupId,
+          key: 'groupPicture'
+        }
+      }[this.variant]
+    }
+  },
+  methods: {
+    async fileChange (fileList) {
+      if (!fileList.length) return
+      const fileReceived = fileList[0]
+      let picture
+
+      try {
+        picture = await imageUpload(fileReceived)
+      } catch (e) {
+        console.error(e)
+        this.$refs.formMsg.danger(L('Failed to upload avatar. {codeError}', { codeError: e.message }))
+        return false
+      }
+
+      try {
+        const { selector, contractID, key } = this.sbpParams
+        const newPicture = await sbp(selector,
+          { [key]: picture },
+          contractID
+        )
+        await sbp('backend/publishLogEntry', newPicture)
+        this.$refs.picture.setFromBlob(fileReceived)
+        this.$refs.formMsg.success(L('Avatar updated!'))
+      } catch (e) {
+        console.error('Failed to save avatar', e)
+        this.$refs.formMsg.danger(L('Failed to save avatar. {codeError}', { codeError: e.message }))
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@assets/style/_variables.scss";
+
+.c-avatar {
+  &-form {
+    position: relative;
+  }
+
+  &-wrapper {
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    text-align: center;
+
+    @include desktop {
+      align-items: flex-end;
+    }
+  }
+
+  &-label {
+    @include touch {
+      margin-bottom: $spacer*1.5;
+    }
+
+    @include desktop {
+      position: absolute;
+      top: -6.5rem; // -3.5rem;
+      right: 0;
+      align-items: flex-end;
+      margin-bottom: -0.5rem;
+    }
+  }
+
+  &-img {
+    margin: 0 auto;
+    width: 8rem;
+    height: 8rem;
+
+    @include desktop {
+      width: 4.5rem;
+      height: 4.5rem;
+    }
+  }
+
+  &-text {
+    display: inline-block;
+  }
+}
+
+.c-formMsg {
+  width: 100%;
+
+  ::v-deep .c-banner {
+    margin: 0 0 $spacer*1.5;
+
+    @include desktop {
+      margin: 0.5rem 0 $spacer*1.5;
+    }
+  }
+}
+</style>

--- a/frontend/views/components/AvatarUpload.vue
+++ b/frontend/views/components/AvatarUpload.vue
@@ -128,7 +128,7 @@ export default {
 
     @include desktop {
       position: absolute;
-      top: -6.5rem; // -3.5rem;
+      top: -6.5rem;
       right: 0;
       align-items: flex-end;
       margin-bottom: -0.5rem;

--- a/frontend/views/components/AvatarUpload.vue
+++ b/frontend/views/components/AvatarUpload.vue
@@ -15,9 +15,9 @@
           accept='image/*'
           @change='fileChange($event.target.files)'
           placeholder='http://'
-          data-test='picture'
+          data-test='avatar'
         )
-      banner-scoped.c-formMsg(ref='formMsg' data-test='formMsg')
+      banner-scoped.c-formMsg(ref='formMsg' data-test='avatarMsg')
 </template>
 <script>
 import sbp from '~/shared/sbp.js'

--- a/frontend/views/components/Page.vue
+++ b/frontend/views/components/Page.vue
@@ -11,7 +11,7 @@ div(:data-test='pageTestName' :class='$scopedSlots.sidebar ? "p-with-sidebar" : 
 
     p(
       v-if='$scopedSlots.description'
-      class='p-descritpion'
+      class='p-descritpion has-text-small has-text-1'
     )
       slot(name='description')
 
@@ -165,15 +165,12 @@ $pagePaddingDesktop: 5.5rem;
 }
 
 .p-descritpion {
-  font-weight: normal;
-  font-size: $size_5; // 12px
-  line-height: 1rem;
-  color: $text_1;
   display: none;
-  padding-bottom: 3rem;
 
   @include desktop {
     display: block;
+    margin-top: $spacer-xs;
+    padding-bottom: $spacer-md*3;
   }
 }
 
@@ -206,6 +203,7 @@ $pagePaddingDesktop: 5.5rem;
   }
 
   @include desktop {
+    position: fixed;
     transform: translateX(0%);
   }
 

--- a/frontend/views/components/banners/BannerSimple.vue
+++ b/frontend/views/components/banners/BannerSimple.vue
@@ -97,12 +97,12 @@ export default {
 }
 
 .c-icon {
-  margin-top: 0.1875rem; // visually better centered aligned
   font-size: $size_3;
   margin-right: $spacer;
 }
 
 .c-content {
+  margin-top: 0.125rem; // visually better, with 1 or multiple lines
   flex-grow: 1;
 }
 

--- a/frontend/views/components/group-creation-steps/GroupName.vue
+++ b/frontend/views/components/group-creation-steps/GroupName.vue
@@ -3,8 +3,7 @@
   i18n.is-title-4.steps-title(tag='h4') 1. Create a new group
 
   label.avatar(for='groupPicture')
-    //- TODO: set a default placeholder image using a built-in asset
-    avatar(ref='picture')
+    avatar(ref='picture' src='/assets/images/default-group-avatar.png')
     //- we don't need to add any code to trigger the hidden file input field
     //- because we use this label(for='elem') trick:
     //- https://developer.mozilla.org/en-US/docs/Web/API/File/Using_files_from_web_applications#Using_a_label_element_to_trigger_a_hidden_file_input_element

--- a/frontend/views/containers/access/LoginForm.vue
+++ b/frontend/views/containers/access/LoginForm.vue
@@ -59,6 +59,9 @@ export default {
       form: {
         name: null,
         password: null
+      },
+      ephemeral: {
+        isSubmitting: false
       }
     }
   },
@@ -67,6 +70,8 @@ export default {
   },
   methods: {
     async login () {
+      if (this.ephemeral.isSubmitting) { return }
+      this.ephemeral.isSubmitting = true
       try {
         await sbp('gi.actions/user/login', {
           username: this.form.name,
@@ -77,6 +82,7 @@ export default {
         console.error('FormLogin.vue login() error:', e)
         this.$refs.formMsg.danger(e.message)
       }
+      this.ephemeral.isSubmitting = false
     },
     forgotPassword () {
       // TODO: implement forgot password

--- a/frontend/views/containers/access/SignupForm.vue
+++ b/frontend/views/containers/access/SignupForm.vue
@@ -70,16 +70,19 @@ export default {
         name: null,
         password: null,
         email: null
+      },
+      ephemeral: {
+        isSubmitting: false
       }
     }
   },
   methods: {
     async signup () {
       // Prevent autocomplete submission when empty field
-      if (!this.form.name || !this.form.email || !this.form.password) {
+      if (!this.form.name || !this.form.email || !this.form.password || this.ephemeral.isSubmitting) {
         return
       }
-
+      this.ephemeral.isSubmitting = true
       try {
         await sbp('gi.actions/user/signupAndLogin', {
           username: this.form.name,
@@ -91,6 +94,7 @@ export default {
         console.error('Signup.vue submit() error:', e)
         this.$refs.formMsg.danger(e.message)
       }
+      this.ephemeral.isSubmitting = false
     }
   },
   validations: {

--- a/frontend/views/containers/group-settings/GroupDeletionModal.vue
+++ b/frontend/views/containers/group-settings/GroupDeletionModal.vue
@@ -68,7 +68,7 @@ export default {
       'groupSettings'
     ]),
     code () {
-      return `DELETE ${this.groupSettings.groupName.toUpperCase()}`
+      return L('DELETE {GROUP_NAME}', { GROUP_NAME: this.groupSettings.groupName.toUpperCase() })
     }
   },
   methods: {

--- a/frontend/views/containers/group-settings/GroupDeletionModal.vue
+++ b/frontend/views/containers/group-settings/GroupDeletionModal.vue
@@ -1,66 +1,61 @@
 <template lang='pug'>
-  modal-template(class='is-centered' ref='modal')
-    template(slot='title') {{ L('Leave a group') }}
+  modal-template(ref='modal')
+    template(slot='title')
+      i18n Delete group
 
-    form(
-      novalidate
-      ref='form'
-      name='formData'
-      @submit.prevent='submit'
-    )
+    form(novalidate @submit.prevent='submit')
+      i18n.has-text-bold(tag='p') Are you sure you want to delete this group?
+      i18n(
+        tag='p'
+        :args='LTags("strong")'
+      ) All messages exchanged between members will be {strong_} deleted permanently{_strong}.
 
-      i18n.is-title-3(tag='h3') Are you sure you want to delete this group?
+      banner-simple.c-banner(severity='danger')
+        i18n(
+          :args='LTags("strong")'
+        ) This action {strong_}cannot be undone{_strong}.
 
-      i18n(tag='p' html='All messages exchanged between members will be <b>deleted permanently</b>.')
-
-      form(
-        novalidate
-        ref='form'
-        name='formData'
-        data-test='GroupDeletionModal'
-        @submit.prevent='submit'
-      )
-        .field
-          i18n(tag='label' class='label') Type "Delete The Dreamers" below
-
+      form(novalidate @submit.prevent='submit')
+        label.field
+          i18n.label(:args='{ code }') Type "{code}" below
           input.input(
             :class='{error: $v.form.confirmation.$error}'
-            name='confirmation'
+            type='text'
             v-model='form.confirmation'
-            @keyup.enter='submit'
-            @input='$v.form.confirmation.$touch()'
-            placeholder=''
-            data-test='confirmation'
+            @input='debounceField("confirmation")'
+            @blur='updateField("confirmation")'
+            v-error:confirmation=''
           )
 
-          i18n.error(
-            tag='p'
-            v-show='$v.form.confirmation.$error'
-            html='Please enter the sentence "<b>Delete The Dreamers</b>"to confirm that you delete the group'
-          )
+        banner-scoped(ref='formMsg')
 
         .buttons
-          i18n.is-outlined(
-            tag='button'
-            @click='close'
-          ) Cancel
+          i18n.is-outlined(tag='button' @click='close') Cancel
           i18n.is-danger(
             tag='button'
             @click='submit'
             :disabled='$v.form.$invalid'
           ) Delete Group
-
-      template(slot='errors') {{ form.response }}
 </template>
 
 <script>
 import { validationMixin } from 'vuelidate'
+import { mapGetters } from 'vuex'
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import { required } from 'vuelidate/lib/validators'
+import BannerSimple from '@components/banners/BannerSimple.vue'
+import BannerScoped from '@components/banners/BannerScoped.vue'
+import L from '@view-utils/translations.js'
+import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
 export default {
-  name: 'GroupDeletionModalModal',
-  mixins: [validationMixin],
+  name: 'GroupLeaveModal',
+  mixins: [validationMixin, validationsDebouncedMixins],
+  components: {
+    ModalTemplate,
+    BannerSimple,
+    BannerScoped
+  },
   data () {
     return {
       form: {
@@ -68,39 +63,39 @@ export default {
       }
     }
   },
-  validations: {
-    form: {
-      confirmation: {
-        required,
-        checkConfirmation: value => {
-          console.log(value)
-          return value === 'Delete The Dreamers'
-        }
-      }
+  computed: {
+    ...mapGetters([
+      'groupSettings'
+    ]),
+    code () {
+      return `DELETE ${this.groupSettings.groupName.toUpperCase()}`
     }
-  },
-  components: {
-    ModalTemplate
   },
   methods: {
     close () {
       this.$refs.modal.close()
     },
     async submit () {
-      console.error('TODO: implement')
-      this.close()
+      alert('TODO implement this')
+    }
+  },
+  validations: {
+    form: {
+      confirmation: {
+        [L('This field is required')]: required,
+        [L('Does not match')]: function (value) {
+          return value === this.code
+        }
+      }
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-h3 {
-  align-self: start;
-  margin-bottom: 0;
-}
+@import "@assets/style/_variables.scss";
 
-form {
-  margin-top: 2rem;
+.c-banner {
+  margin: $spacer*1.5 0;
 }
 </style>

--- a/frontend/views/containers/group-settings/GroupLeaveModal.vue
+++ b/frontend/views/containers/group-settings/GroupLeaveModal.vue
@@ -1,76 +1,45 @@
 <template lang='pug'>
-  modal-template(class='is-centered' ref='modal')
-    form(
-      novalidate
-      ref='form'
-      name='formData'
-      @submit.prevent='submit'
-    )
-      template(slot='title') {{ L('Leave a group') }}
+  modal-template(ref='modal')
+    template(slot='title')
+      i18n Leave group
 
+    form(novalidate @submit.prevent='submit')
       i18n(
         tag='p'
         :args='LTags("strong")'
       ) If you leave, you will stop having access to the {strong_}group chat{_strong} and {strong_}contributions{_strong}. Re-joining the group is possible, but requires other members to {strong_}vote and reach an agreement{_strong}.
 
-      banner-simple(severity='danger')
+      banner-simple.c-banner(severity='danger')
         i18n(
           :args='LTags("strong")'
         ) This action {strong_}cannot be undone{_strong}.
 
-      form(
-        novalidate
-        ref='form'
-        name='formData'
-        data-test='leaveGroup'
-        @submit.prevent='submit'
-      )
-        .field
-          i18n.label(tag='label') Username
-
-          input.input#loginName(
-            :class='{error: $v.form.name.$error}'
-            name='name'
-            v-model='form.name'
-            @keyup.enter='submit'
-            @input='$v.form.name.$touch()'
-            placeholder='username'
-            ref='username'
-            autofocus
-            data-test='loginName'
+      form(novalidate @submit.prevent='submit')
+        label.field
+          i18n.label Username
+          input.input(
+            :class='{error: $v.form.username.$error}'
+            type='text'
+            v-model='form.username'
+            @input='debounceField("username")'
+            @blur='updateField("username")'
+            v-error:username=''
           )
-          i18n.error(
-            tag='p'
-            v-show='$v.form.name.$error'
-          ) username cannot contain spaces
 
-        password-form(
-          :label='L("Password")'
-          :value='form'
-          :v='$v'
-          @enter='submit'
-          @input='(Password) => {password = Password}'
-          data-test='loginPassword'
-        )
+        password-form(:label='L("Password")' :$v='$v')
 
-        .field
-          i18n.label(tag='label') Type "Leave The Dreamers" below
-
+        label.field
+          i18n.label(:args='{ code }') Type "{code}" below
           input.input(
             :class='{error: $v.form.confirmation.$error}'
-            name='confirmation'
+            type='text'
             v-model='form.confirmation'
-            @keyup.enter='submit'
-            @input='$v.form.confirmation.$touch()'
-            placeholder=''
-            data-test='confirmation'
+            @input='debounceField("confirmation")'
+            @blur='updateField("confirmation")'
+            v-error:confirmation=''
           )
 
-          i18n.error(
-            tag='p'
-            v-show='$v.form.confirmation.$error'
-            html='Please enter the sentence "<b>Leave The Dreamers</b>" to confirm that you leave the group'
-          )
+        banner-scoped(ref='formMsg')
 
         .buttons
           i18n.is-outlined(tag='button' @click='close') Cancel
@@ -79,82 +48,80 @@
             @click='submit'
             :disabled='$v.form.$invalid'
           ) Leave Group
-
-      template(slot='errors') {{ form.response }}
 </template>
 
 <script>
 import { validationMixin } from 'vuelidate'
+import { mapGetters } from 'vuex'
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import PasswordForm from '@containers/access/PasswordForm.vue'
 import { required } from 'vuelidate/lib/validators'
 import BannerSimple from '@components/banners/BannerSimple.vue'
+import BannerScoped from '@components/banners/BannerScoped.vue'
 import L from '@view-utils/translations.js'
+import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
 export default {
   name: 'GroupLeaveModal',
-  mixins: [validationMixin],
+  mixins: [validationMixin, validationsDebouncedMixins],
+  components: {
+    ModalTemplate,
+    PasswordForm,
+    BannerSimple,
+    BannerScoped
+  },
   data () {
     return {
       form: {
-        name: null,
+        username: null,
         password: null,
         confirmation: null
       }
     }
   },
-  validations: {
-    form: {
-      name: {
-        required
-      },
-      password: {
-        required
-      },
-      confirmation: {
-        required,
-        checkConfirmation: value => {
-          console.log(value)
-          return value === L('Leave The Dreamers')
-        }
-      }
+  computed: {
+    ...mapGetters([
+      'groupSettings',
+      'ourUsername'
+    ]),
+    code () {
+      return `LEAVE ${this.groupSettings.groupName.toUpperCase()}`
     }
-  },
-  components: {
-    ModalTemplate,
-    PasswordForm,
-    BannerSimple
   },
   methods: {
     close () {
       this.$refs.modal.close()
     },
     async submit () {
-      console.error('TODO: implement')
-      this.close()
+      alert('TODO implement this')
+    }
+  },
+  validations: {
+    form: {
+      username: {
+        [L('This field is required')]: required,
+        [L('Your username is different')]: function (value) {
+          return value === this.ourUsername
+        }
+      },
+      password: {
+        [L('This field is required')]: required
+      },
+      confirmation: {
+        [L('This field is required')]: required,
+        [L('Does not match')]: function (value) {
+          return value === this.code
+        }
+      }
     }
   }
 }
 </script>
 
 <style lang="scss" scoped>
-.modal-card-body {
-  padding-top: 0;
-}
+@import "@assets/style/_variables.scss";
 
-.message.is-danger {
-  width: 100%;
-  padding: 1rem;
-  margin-top: 1rem;
-  margin-bottom: 2rem;
-  align-items: center;
-
-  i {
-    padding-right: 1rem;
-  }
-}
-
-.media {
-  display: flex;
+.c-banner {
+  margin: $spacer*1.5 0;
 }
 </style>

--- a/frontend/views/containers/group-settings/GroupLeaveModal.vue
+++ b/frontend/views/containers/group-settings/GroupLeaveModal.vue
@@ -52,6 +52,7 @@
 
 <script>
 import { validationMixin } from 'vuelidate'
+import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 import { mapGetters } from 'vuex'
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import PasswordForm from '@containers/access/PasswordForm.vue'
@@ -59,7 +60,6 @@ import { required } from 'vuelidate/lib/validators'
 import BannerSimple from '@components/banners/BannerSimple.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import L from '@view-utils/translations.js'
-import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
 export default {
   name: 'GroupLeaveModal',

--- a/frontend/views/containers/group-settings/GroupLeaveModal.vue
+++ b/frontend/views/containers/group-settings/GroupLeaveModal.vue
@@ -85,7 +85,7 @@ export default {
       'ourUsername'
     ]),
     code () {
-      return `LEAVE ${this.groupSettings.groupName.toUpperCase()}`
+      return L('LEAVE {GROUP_NAME}', { GROUP_NAME: this.groupSettings.groupName.toUpperCase() })
     }
   },
   methods: {

--- a/frontend/views/containers/group-settings/InvitationsTable.vue
+++ b/frontend/views/containers/group-settings/InvitationsTable.vue
@@ -88,12 +88,15 @@ page-section.c-section(:title='L("Invite links")')
 
   i18n.c-invite-footer(
     tag='p'
-    :args='{ r1: "<router-link class=\'link\' to=\'/invite\'>", r2: "</router-link>"}'
+    @click='handleInviteClick'
     compile
+    :args='{ r1: `<button class="link js-btnInvite">`, r2: "</button>"}'
   ) To generate a new link, you need to {r1}propose adding a new member{r2} to your group.
 </template>
 
 <script>
+import sbp from '~/shared/sbp.js'
+import { OPEN_MODAL } from '@utils/events.js'
 import { MenuParent, MenuTrigger, MenuContent, MenuItem } from '@components/menu/index.js'
 import PageSection from '@components/PageSection.vue'
 import Tooltip from '@components/Tooltip.vue'
@@ -195,6 +198,11 @@ export default {
           }),
           expiryInfo: isAllInviteUsed ? '' : this.readableExpiryInfo(expiryTime)
         }
+      }
+    },
+    handleInviteClick (e) {
+      if (e.target.classList.contains('js-btnInvite')) {
+        sbp('okTurtles.events/emit', OPEN_MODAL, 'AddMembers')
       }
     }
   },
@@ -426,8 +434,8 @@ export default {
     background-color: $white;
     z-index: 2;
     border: {
-      left: 1px solid $text_0;
-      right: 1px solid $text_0;
+      left: 1px solid $primary_0;
+      right: 1px solid $primary_0;
     }
     box-shadow: 0 2px 0 2px $primary_1;
   }

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -3,7 +3,7 @@
     span.c-username @{{ ourUsername }}
 
     avatar-upload(
-      :avatar='$store.getters.ourUserIdentityContract.attributes.picture'
+      :avatar='attributes.picture'
       :sbpParams='sbpParams'
     )
 

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -229,7 +229,7 @@ export default {
   &-img {
     width: 8rem;
     height: 8rem;
-    margin-bottom: $spacer-sm;
+    /* margin-bottom: $spacer-sm; */
 
     @include desktop {
       width: 4.5rem;

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -2,7 +2,10 @@
   .settings-container
     span.c-username @{{ ourUsername }}
 
-    avatar-upload(variant='user')
+    avatar-upload(
+      :avatar='$store.getters.ourUserIdentityContract.attributes.picture'
+      :sbpParams='sbpParams'
+    )
 
     section.card
       form(@submit.prevent='saveProfile')
@@ -119,6 +122,13 @@ export default {
     ]),
     attributes () {
       return this.$store.getters.ourUserIdentityContract.attributes || {}
+    },
+    sbpParams () {
+      return {
+        selector: 'gi.contracts/identity/setAttributes/create',
+        contractID: this.$store.state.loggedIn.identityContractID,
+        key: 'picture'
+      }
     }
   },
   methods: {

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -90,8 +90,8 @@ export default {
   name: 'UserProfile',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
-    BannerScoped,
-    AvatarUpload
+    AvatarUpload,
+    BannerScoped
   },
   data () {
     // create a copy of the attributes to avoid any Vue.js reactivity weirdness

--- a/frontend/views/pages/DesignSystem.vue
+++ b/frontend/views/pages/DesignSystem.vue
@@ -1,6 +1,5 @@
 <template lang='pug'>
 page(
-  mainClass='full-width'
   pageTestName='designSystemPage'
   pageTestHeaderName='designSystemTitle'
   class='p-design-system'
@@ -1105,11 +1104,11 @@ export default {
       const top = e.target.scrollTop
       let last = 0
       this.articles.forEach((el, index) => {
-        if (top > (el.top)) {
-          el.link.classList.add('active')
+        if (top > (el.top + window.innerHeight - 40)) { // 30 - space between each card.
+          el.link.classList.add('scrolled')
           last = index
         } else {
-          el.link.classList.remove('active')
+          el.link.classList.remove('scrolled')
         }
         el.link.classList.remove('last')
       })
@@ -1290,12 +1289,13 @@ table {
   display: flex;
   flex-direction: column;
 
-  ::v-deep .active {
-    color: $general_0;
+  ::v-deep .scrolled {
+    opacity: 0.4;
     text-decoration: line-through;
   }
 
   ::v-deep .last {
+    opacity: 1;
     text-decoration: underline;
     color: $primary_0;
   }

--- a/frontend/views/pages/DesignSystem.vue
+++ b/frontend/views/pages/DesignSystem.vue
@@ -526,11 +526,10 @@ page(
             pre banner-simple(severity='info')
           td
             banner-simple(severity='info')
-              | This is an&nbsp;
-              strong information message
+              | This is a&nbsp;
+              strong short message
               |  with a&nbsp;
-              a.link(href='/') link
-              | . This message can grow in width or height, as needed.
+              a.link(href='/') link.
 
       h4.is-title-4 With title
       table

--- a/frontend/views/pages/GroupDashboard.vue
+++ b/frontend/views/pages/GroupDashboard.vue
@@ -4,7 +4,7 @@ page(pageTestName='dashboard' pageTestHeaderName='groupName' v-if='groupSettings
 
   add-income-details-widget(v-if='!hasIncomeDetails')
 
-  div(v-else)
+  template(v-else)
     start-inviting-widget(v-if='groupMembersCount === 1')
 
     contributions-overview-widget(v-if='canDisplayGraph')

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -87,7 +87,7 @@ page.c-page
 
     banner-simple(severity='info' v-else)
       i18n(
-        :args='{ count: membersLeft, groupName: groupSettings.groupNname, ...LTags("b")}'
+        :args='{ count: membersLeft, groupName: groupSettings.groupName, ...LTags("b")}'
       ) You can only delete a group when all the other members have left. {groupName} still has {b_}{count} other members{_b}.
 </template>
 

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -3,23 +3,48 @@ page.c-page
   template(#title='') {{ L('Group Settings') }}
   template(#description='') {{ L('Changes to these settings will be visible to all group members') }}
 
+  form.c-form-avatar(@submit.prevent='')
+    .c-avatar
+      label.c-avatar-field
+        avatar.c-avatar-img(
+          :src='form.groupPicture'
+          ref='picture'
+        )
+        i18n.link.c-avatar-text Change avatar
+
+        input.sr-only(
+          type='file'
+          name='groupPicture'
+          accept='image/*'
+          @change='fileChange($event.target.files)'
+          placeholder='http://'
+          data-test='groupPicture'
+        )
+      // TODO #658
+      banner-scoped.c-bannerAvatarMsg(ref='bannerPictureMsg' data-test='bannerPictureMsg')
+
   page-section
-    form
+    form(@submit.prevent='saveSettings')
       label.field
         i18n.label Group name
         input.input(
-          name='groupName'
           type='text'
+          :class='{error: $v.form.groupName.$error}'
           v-model='form.groupName'
-          data-test='groupName'
+          @input='debounceField("groupName")'
+          @blur='updateField("groupName")'
+          v-error:groupName=''
         )
 
       label.field
         i18n.label About the group
         textarea.textarea(
-          name='sharedValues'
           maxlength='500'
-          :value='form.sharedValues'
+          :class='{error: $v.form.sharedValues.$error}'
+          v-model='form.sharedValues'
+          @input='debounceField("sharedValues")'
+          @blur='updateField("sharedValues")'
+          v-error:sharedValues=''
         )
 
       label.field
@@ -27,13 +52,13 @@ page.c-page
         .select-wrapper.c-currency-select
           select(
             name='mincomeCurrency'
-            :value='form.mincomeCurrency'
+            v-model='form.mincomeCurrency'
           )
             option(
               v-for='(currency, code) in currencies'
               :value='code'
               :key='code'
-            ) {{ currency.symbol }}
+            ) {{ currency.symbolWithCode }}
 
         i18n.helper This is the currency that will be displayed for every member of the group, across the platform.
 
@@ -42,8 +67,6 @@ page.c-page
       .buttons
         i18n.is-success(
           tag='button'
-          ref='save'
-          @click='save'
           :disabled='$v.form.$invalid'
           data-test='saveBtn'
         ) Save changes
@@ -67,7 +90,7 @@ page.c-page
   page-section(:title='L("Delete Group")')
     i18n.has-text-1(tag='p') This will delete all the data associated with this group permanently.
 
-    .buttons
+    .buttons(v-if='membersLeft === 0')
       i18n.is-danger.is-outlined(
         tag='button'
         ref='delete'
@@ -75,21 +98,24 @@ page.c-page
         data-test='deleteBtn'
       ) Delete group
 
-    banner-simple(severity='info')
+    banner-simple(severity='info' v-else)
       i18n(
-        :args='{ count: groupMembersCount - 1, groupName: groupSettings.groupNname, ...LTags("b")}'
+        :args='{ count: membersLeft, groupName: groupSettings.groupNname, ...LTags("b")}'
       ) You can only delete a group when all the other members have left. {groupName} still has {b_}{count} other members{_b}.
 </template>
 
 <script>
 import sbp from '~/shared/sbp.js'
-import { mapGetters } from 'vuex'
-import { OPEN_MODAL } from '@utils/events.js'
 import { validationMixin } from 'vuelidate'
+import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
+import { mapState, mapGetters } from 'vuex'
+import { OPEN_MODAL } from '@utils/events.js'
 import { required } from 'vuelidate/lib/validators'
 import currencies from '@view-utils/currencies.js'
+import imageUpload from '@utils/imageUpload.js'
 import Page from '@components/Page.vue'
 import PageSection from '@components/PageSection.vue'
+import Avatar from '@components/Avatar.vue'
 import InvitationsTable from '@containers/group-settings/InvitationsTable.vue'
 import BannerSimple from '@components/banners/BannerSimple.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
@@ -97,52 +123,105 @@ import L from '@view-utils/translations.js'
 
 export default {
   name: 'GroupSettings',
-  mixins: [validationMixin],
+  mixins: [validationMixin, validationsDebouncedMixins],
   components: {
     Page,
     PageSection,
     InvitationsTable,
+    Avatar,
     BannerSimple,
     BannerScoped
   },
   data () {
-    const { groupName, sharedValues, mincomeCurrency } = this.$store.getters.groupSettings
+    const { groupName, groupPicture, sharedValues, mincomeCurrency } = this.$store.getters.groupSettings
     return {
-      currencies,
       form: {
-        groupName: groupName,
-        sharedValues: sharedValues,
-        mincomeCurrency: mincomeCurrency
+        groupName,
+        groupPicture,
+        sharedValues,
+        mincomeCurrency
+      },
+      ephemeral: {
+        isSubmitting: false
       }
     }
   },
   computed: {
+    ...mapState([
+      'currentGroupId'
+    ]),
     ...mapGetters([
       'groupSettings',
       'groupMembersCount'
-    ])
+    ]),
+    membersLeft () {
+      return this.groupMembersCount - 1
+    },
+    currencies () {
+      return currencies
+    }
   },
   methods: {
     openProposal (component) {
       sbp('okTurtles.events/emit', OPEN_MODAL, component)
     },
-    update (e) {
-      // TODO update value
-      console.log('Update', e)
+    async fileChange (fileList) {
+      if (!fileList.length) return
+      const fileReceived = fileList[0]
+      let picture
+
+      try {
+        picture = await imageUpload(fileReceived)
+      } catch (e) {
+        console.error(e)
+        this.$refs.bannerPictureMsg.danger(L('Failed to upload avatar. {codeError}', { codeError: e.message }))
+        return false
+      }
+
+      try {
+        await this.setAttributes({ groupPicture: picture })
+        this.$refs.picture.setFromBlob(fileReceived)
+        this.$refs.bannerPictureMsg.success(L('Avatar updated!'))
+      } catch (e) {
+        console.error('Failed to save avatar', e)
+        this.$refs.bannerPictureMsg.danger(L('Failed to save avatar. {codeError}', { codeError: e.message }))
+      }
     },
-    save (e) {
-      // TODO save form
-      // ::::::::::: CONTINUE HERE - handle disable status
-      console.log('Save', e)
+    async saveSettings (e) {
+      if (this.ephemeral.isSubmitting) { return }
+      this.ephemeral.isSubmitting = true
+      const attrs = {}
+
+      for (const key in this.form) {
+        if (this.form[key] !== this.groupSettings[key]) {
+          attrs[key] = this.form[key]
+        }
+      }
+
+      try {
+        const updatedAttrs = await this.setAttributes(attrs)
+        await sbp('backend/publishLogEntry', updatedAttrs)
+        this.$refs.formMsg.success(L('Your changes were saved!'))
+      } catch (e) {
+        this.$refs.formMsg.danger(L('Failed to update group settings. {codeError}', { codeError: e.message }))
+      }
+      this.ephemeral.isSubmitting = false
+    },
+    async setAttributes (attrs) {
+      const settings = await sbp('gi.contracts/group/updateSettings/create',
+        attrs,
+        this.currentGroupId
+      )
+      await sbp('backend/publishLogEntry', settings)
     }
   },
   validations: {
     form: {
       groupName: {
-        [L('A name is required.')]: required
+        [L('This field is required')]: required
       },
       sharedValues: {
-        [L('A group without description?')]: required
+        [L('This field is required')]: required
       }
     }
   }
@@ -154,6 +233,65 @@ export default {
 
 .c-page ::v-deep .p-main {
   max-width: 37rem;
+}
+
+.c-form-avatar {
+  position: relative;
+}
+
+.c-avatar-field {
+  @include touch {
+    margin-bottom: $spacer*1.5;
+  }
+
+  @include desktop {
+    position: absolute;
+    top: -6.5rem; // -3.5rem;
+    right: 0;
+    align-items: flex-end;
+  }
+}
+
+.c-avatar {
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  text-align: center;
+
+  @include desktop {
+    align-items: flex-end;
+
+    label {
+      margin-bottom: -0.5rem; /* temporary until #658 */
+    }
+  }
+
+  &-img {
+    width: 8rem;
+    height: 8rem;
+    /* margin-bottom: $spacer-sm; */
+
+    @include desktop {
+      width: 4.5rem;
+      height: 4.5rem;
+    }
+  }
+
+  &-text {
+    display: inline-block;
+  }
+}
+
+.c-bannerAvatarMsg {
+  width: 100%;
+
+  ::v-deep .c-banner {
+    margin: 0 0 $spacer*1.5;
+
+    @include desktop {
+      margin: 0.5rem 0 $spacer*1.5;
+    }
+  }
 }
 
 .c-currency-select {

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -3,7 +3,10 @@ page.c-page
   template(#title='') {{ L('Group Settings') }}
   template(#description='') {{ L('Changes to these settings will be visible to all group members') }}
 
-  avatar-upload(variant='group')
+  avatar-upload(
+    :avatar='$store.getters.groupSettings.groupPicture'
+    :sbpParams='sbpParams'
+  )
 
   page-section
     form(@submit.prevent='saveSettings')
@@ -141,6 +144,13 @@ export default {
     },
     currencies () {
       return currencies
+    },
+    sbpParams () {
+      return {
+        selector: 'gi.contracts/group/updateSettings/create',
+        contractID: this.$store.state.currentGroupId,
+        key: 'groupPicture'
+      }
     }
   },
   methods: {

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -16,6 +16,7 @@ page.c-page
           @input='debounceField("groupName")'
           @blur='updateField("groupName")'
           v-error:groupName=''
+          data-test='groupName'
         )
 
       label.field
@@ -27,6 +28,7 @@ page.c-page
           @input='debounceField("sharedValues")'
           @blur='updateField("sharedValues")'
           v-error:sharedValues=''
+          data-test='sharedValues'
         )
 
       label.field
@@ -44,7 +46,7 @@ page.c-page
 
         i18n.helper This is the currency that will be displayed for every member of the group, across the platform.
 
-      banner-scoped(ref='formMsg' data-test='profileMsg')
+      banner-scoped(ref='formMsg' data-test='formMsg')
 
       .buttons
         i18n.is-success(

--- a/test/cypress/integration/group-settings.spec.js
+++ b/test/cypress/integration/group-settings.spec.js
@@ -1,13 +1,15 @@
 describe('Changing Group Settings', () => {
   const userId = Math.floor(Math.random() * 10000)
+  const groupName = 'Dreamers'
   const groupMincome = 750
   const groupNewMincome = groupMincome + 100
+  const sharedValues = 'One dream at the time.'
 
   it('user1 creates a new group', () => {
     cy.visit('/')
     cy.giSignup(`user1-${userId}`, { bypassUI: true })
 
-    cy.giCreateGroup('Dreamers', { mincome: groupMincome })
+    cy.giCreateGroup(groupName, { mincome: groupMincome, sharedValues })
   })
 
   it('user1 changes the group minimum income (increase it $100)', () => {
@@ -27,6 +29,34 @@ describe('Changing Group Settings', () => {
     cy.getByDT('groupMincome').within(() => {
       cy.getByDT('minIncome').should('contain', `$${groupNewMincome}`)
     })
+  })
+
+  it('user1 changes avatar and profile settings', () => {
+    const groupPicture = 'imageTest.png' // at fixtures/imageTest
+    const newGroupName = 'Turtles'
+    const newSharedValues = 'One step at the time.'
+
+    cy.getByDT('groupSettingsLink').click()
+
+    cy.fixture(groupPicture, 'base64').then(fileContent => {
+      cy.get('[data-test="avatar"]').upload({ fileContent, fileName: groupPicture, mimeType: 'image/png' }, { subjectType: 'input' })
+    })
+
+    cy.getByDT('avatarMsg').should('contain', 'Avatar updated!')
+
+    cy.getByDT('groupName').should('have.value', groupName)
+    cy.getByDT('groupName').clear().type(newGroupName)
+
+    cy.getByDT('sharedValues').should('have.value', sharedValues)
+    cy.getByDT('sharedValues').clear().type(newSharedValues)
+
+    cy.getByDT('saveBtn', 'button').click()
+    cy.getByDT('formMsg').should('contain', 'Your changes were saved!')
+
+    // Go to dashboard and verify new values:
+    cy.getByDT('dashboard').click()
+    cy.getByDT('groupName').should('contain', newGroupName)
+    cy.getByDT('sharedValues').should('contain', newSharedValues)
 
     cy.giLogout()
   })

--- a/test/cypress/integration/signup-and-login.js
+++ b/test/cypress/integration/signup-and-login.js
@@ -24,10 +24,10 @@ describe('Signup, Profile and Login', () => {
     cy.getByDT('settingsBtn').click()
 
     cy.fixture(profilePicture, 'base64').then(fileContent => {
-      cy.get('[data-test="profilePicture"]').upload({ fileContent, fileName: profilePicture, mimeType: 'image/png' }, { subjectType: 'input' })
+      cy.get('[data-test="avatar"]').upload({ fileContent, fileName: profilePicture, mimeType: 'image/png' }, { subjectType: 'input' })
     })
 
-    cy.getByDT('pictureMsg').should('contain', 'Picture updated!')
+    cy.getByDT('avatarMsg').should('contain', 'Avatar updated!')
 
     cy.getByDT('displayName').clear().type('John Bot')
     cy.getByDT('bio').clear().type('Born in a test case')

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -133,14 +133,14 @@ Cypress.Commands.add('giSetDisplayName', (name) => {
 
 Cypress.Commands.add('giCreateGroup', (name, {
   image = 'imageTest.png',
-  values = 'Testing group values',
+  sharedValues = 'Testing group values',
   mincome = 200,
   bypassUI = false
 } = {}) => {
   if (bypassUI) {
     cyBypassUI('group_create', {
       name,
-      sharedValues: values,
+      sharedValues,
       mincomeAmount: mincome,
       mincomeCurrency: 'USD',
       thresholdChange: 0.8,
@@ -162,7 +162,7 @@ Cypress.Commands.add('giCreateGroup', (name, {
 
   cy.getByDT('nextBtn').click()
 
-  cy.get('textarea[name="sharedValues"]').type(values)
+  cy.get('textarea[name="sharedValues"]').type(sharedValues)
   cy.getByDT('nextBtn').click()
 
   cy.get('input[name="mincomeAmount"]').type(mincome)


### PR DESCRIPTION
Related to #792.

![image](https://user-images.githubusercontent.com/14869087/73544293-c60bc300-4430-11ea-8ac8-1a689c9e1150.png)

- Implement pixel perfect the "Group Settings" page, including the modals to leave/delete the group.
- Implement logic to update group settings. (profile, name, about and currency). Keep in mind that #658 wasn't done yet.
- `AvatarUpload` component created - it centralizes the layout and upload logic for both user and group profiles.
- Added necessary Cypress tests.

### scout improvements:
- "Invite links" card: the link "propose adding a new member" is now working correctly.
- Secondary/right sidebar is fixed when scrolling. (it wasn't for some reason!)
- `Banner` component - now it looks pretty when it has 1 or multiple lines. Before it was "broken" when it had just one line.