### PR TITLE
Create "group_join" cypress bypassUI action

### DIFF
--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -96,11 +96,14 @@ export default sbp('sbp/selectors/register', {
   },
   'gi.actions/group/join': async function ({ groupId, inviteSecret }) {
     try {
+      // post acceptance event to the group contract
       const acceptance = await sbp('gi.contracts/group/inviteAccept/create',
         { inviteSecret },
         groupId
       )
+      // let the group know we've accepted their invite
       await sbp('backend/publishLogEntry', acceptance)
+      // sync the group's contract state
       await sbp('state/enqueueContractSync', groupId)
       return groupId
     } catch (e) {
@@ -110,6 +113,7 @@ export default sbp('sbp/selectors/register', {
   },
   'gi.actions/group/joinAndSwitch': async function (joinParams) {
     const groupId = await sbp('gi.actions/group/join', joinParams)
+    // after joining, we can set the current group
     sbp('gi.actions/group/switch', groupId)
     return groupId
   },

--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -94,6 +94,25 @@ export default sbp('sbp/selectors/register', {
     sbp('gi.actions/group/switch', groupID)
     return groupID
   },
+  'gi.actions/group/join': async function ({ groupId, inviteSecret }) {
+    try {
+      const acceptance = await sbp('gi.contracts/group/inviteAccept/create',
+        { inviteSecret },
+        groupId
+      )
+      await sbp('backend/publishLogEntry', acceptance)
+      await sbp('state/enqueueContractSync', groupId)
+      return groupId
+    } catch (e) {
+      console.error('gi.actions/group/join failed!', e)
+      throw new GIErrorUIRuntimeError(L('Failed to join the group: {codeError}', { codeError: e.message }))
+    }
+  },
+  'gi.actions/group/joinAndSwitch': async function (joinParams) {
+    const groupId = await sbp('gi.actions/group/join', joinParams)
+    sbp('gi.actions/group/switch', groupId)
+    return groupId
+  },
   'gi.actions/group/switch': function (groupId) {
     sbp('state/vuex/commit', 'setCurrentGroupId', groupId)
   }

--- a/frontend/views/pages/BypassUI.vue
+++ b/frontend/views/pages/BypassUI.vue
@@ -112,9 +112,7 @@ export default {
         },
         'group_create': {
           actionFn: async (params) => {
-            await sbp('gi.actions/group/createAndSwitch', params, () => {
-              return true
-            })
+            await sbp('gi.actions/group/createAndSwitch', params)
           },
           finalize: () => {
             this.$router.push({ path: '/dashboard' }) // eslint-disable-line

--- a/frontend/views/pages/BypassUI.vue
+++ b/frontend/views/pages/BypassUI.vue
@@ -119,6 +119,14 @@ export default {
           finalize: () => {
             this.$router.push({ path: '/dashboard' }) // eslint-disable-line
           }
+        },
+        'group_join': {
+          actionFn: async (params) => {
+            await sbp('gi.actions/group/joinAndSwitch', params)
+          },
+          finalize: () => {
+            this.$router.push({ path: '/dashboard' }) // eslint-disable-line
+          }
         }
       }
     }

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -227,27 +227,39 @@ Cypress.Commands.add('giAcceptGroupInvite', (invitationLink, {
   actionBeforeLogout,
   bypassUI
 }) => {
-  cy.visit(invitationLink)
-
-  if (isLoggedIn) {
-    cy.getByDT('welcomeGroup').should('contain', `Welcome to ${groupName}!`)
+  if (bypassUI) {
+    if (!isLoggedIn) {
+      cy.giSignup(username, { bypassUI: true })
+    }
+    const params = new URLSearchParams(new URL(invitationLink).search)
+    const groupId = params.get('groupId')
+    const inviteSecret = params.get('secret')
+    cyBypassUI('group_join', { groupId, inviteSecret })
   } else {
-    cy.getByDT('groupName').should('contain', groupName)
-    const inviteMessage = inviteCreator
-      ? `${inviteCreator} invited you to join their group!`
-      : 'You were invited to join'
-    cy.getByDT('invitationMessage').should('contain', inviteMessage)
-    cy.giSignup(username, { isInvitation: true, groupName })
-  }
+    cy.visit(invitationLink)
 
-  cy.getByDT('toDashboardBtn').click()
-  cy.url().should('eq', 'http://localhost:8000/app/dashboard')
+    if (isLoggedIn) {
+      cy.getByDT('welcomeGroup').should('contain', `Welcome to ${groupName}!`)
+    } else {
+      cy.getByDT('groupName').should('contain', groupName)
+      const inviteMessage = inviteCreator
+        ? `${inviteCreator} invited you to join their group!`
+        : 'You were invited to join'
+      cy.getByDT('invitationMessage').should('contain', inviteMessage)
+      cy.giSignup(username, { isInvitation: true, groupName })
+    }
+
+    cy.getByDT('toDashboardBtn').click()
+    cy.url().should('eq', 'http://localhost:8000/app/dashboard')
+  }
 
   if (displayName) {
     cy.giSetDisplayName(displayName)
   }
 
-  if (actionBeforeLogout) actionBeforeLogout()
+  if (actionBeforeLogout) {
+    actionBeforeLogout()
+  }
   cy.giLogout()
 })
 


### PR DESCRIPTION
Closes #814 

Add option `bypassUI` to cypress command `cy.giAcceptGroupInvite()`.

This is a command used 18 times on our tests. `bypassUI` was enabled everywhere expect on `group-proposals.spec` (4 times) so we make sure that the "join group" flow works properly.

#### Test speed comparison before and now)
![Group 96](https://user-images.githubusercontent.com/14869087/74609331-134e8c80-50e1-11ea-8833-5b8a861d72e2.png)
- Before: 102s
- Now: 85s
- Diff: 16s faster (~4/5 of the time).

Note 1: These tests were run locally on my machine, the values may be different compared to your machine.

Note 2: Initially I thought about also add option `bypassUI` to `cy.setDisplayName()` but then I noticed it was only used 4 times and it's a quick flow (compared to login or join a group). So I think for now it's not worth the effort. But if you disagree, let me know and I can do it too.

## Update:
On our Cypress dashboard, compared to our last 2 builds, the current build is **~1min faster!** 🚀 

![image](https://user-images.githubusercontent.com/14869087/74609631-b6a0a100-50e3-11ea-9f3e-a675af8f6bbe.png)

