### PR TITLE
Replaced 'state/groupContractSafeGetters' with new getter support in DefineContract!

### DIFF
--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -44,7 +44,7 @@ export default sbp('sbp/selectors/register', {
 
     try {
       const initialInvite = createInvite({ quantity: 60, creator: INVITE_INITIAL_CREATOR })
-      const entry = sbp('gi.contracts/group/create', {
+      const entry = await sbp('gi.contracts/group/create', {
         invites: {
           [initialInvite.inviteSecret]: initialInvite
         },

--- a/frontend/controller/actions/user.js
+++ b/frontend/controller/actions/user.js
@@ -20,7 +20,7 @@ export default sbp('sbp/selectors/register', {
       await sbp('gi.db/settings/delete', username)
     }
     // proceed with creation
-    const user = sbp('gi.contracts/identity/create', {
+    const user = await sbp('gi.contracts/identity/create', {
       // authorizations: [Events.CanModifyAuths.dummyAuth()],
       attributes: {
         name: username,
@@ -28,7 +28,7 @@ export default sbp('sbp/selectors/register', {
         picture: `${window.location.origin}/assets/images/default-avatar.png`
       }
     })
-    const mailbox = sbp('gi.contracts/mailbox/create', {
+    const mailbox = await sbp('gi.contracts/mailbox/create', {
       // authorizations: [Events.CanModifyAuths.dummyAuth(user.hash())]
     })
     await sbp('backend/publishLogEntry', user)

--- a/frontend/controller/backend.js
+++ b/frontend/controller/backend.js
@@ -8,7 +8,7 @@ import { CONTRACTS_MODIFIED } from '~/frontend/utils/events.js'
 import { intersection, difference, delay, randomIntFromRange } from '~/frontend/utils/giLodash.js'
 import pubsub from './utils/pubsub.js'
 import { handleFetchResult } from './utils/misc.js'
-import { CONTRACT_REGEX } from '~/frontend/model/contracts/Contract.js'
+import { ACTION_REGEX } from '~/frontend/model/contracts/Contract.js'
 
 // temporary identity for signing
 // const nacl = require('tweetnacl')
@@ -97,7 +97,7 @@ sbp('okTurtles.events/on', CONTRACTS_MODIFIED, async (contracts) => {
 
 sbp('sbp/selectors/register', {
   'backend/publishLogEntry': async (entry: GIMessage, { maxAttempts = 2 } = {}) => {
-    const action = CONTRACT_REGEX.exec(entry.type())[1]
+    const action = ACTION_REGEX.exec(entry.type())[1]
     var attempt = 1
     // auto resend after short random delay
     // https://github.com/okTurtles/group-income-simple/issues/608

--- a/frontend/model/contracts/Contract.js
+++ b/frontend/model/contracts/Contract.js
@@ -6,23 +6,22 @@ import { GIMessage } from '~/shared/GIMessage.js'
 // this must not be exported, but instead accessed through 'actionWhitelisted'
 const whitelistedSelectors = {}
 
-export const CONTRACT_REGEX = /^(([\w.]+)\/([^/]+)\/(?:([^/]+)\/)?)process$/
+export const IS_CONSTRUCTOR = /^[\w.]+\/[^/]+\/(create|process)$/
+export const ACTION_REGEX = /^(([\w.]+)\/([^/]+)\/(?:([^/]+)\/)?)process$/
+// ACTION_REGEX.exec('gi.contracts/group/payment/process')
+// 0 => 'gi.contracts/group/payment/process'
+// 1 => 'gi.contracts/group/payment/'
+// 2 => 'gi.contracts'
+// 3 => 'group'
+// 4 => 'payment'
 
 // TODO: define a flow type for contracts
 export function DefineContract (contract: Object) {
-  const meta = contract.metadata || { validate () {}, create: () => ({}) }
-  whitelistedSelectors[`${contract.name}/process`] = true
+  const metadata = contract.metadata || { validate () {}, create: () => ({}) }
   sbp('sbp/selectors/register', {
-    [`${contract.name}/create`]: function (data) {
-      const metadata = meta.create()
-      meta.validate(metadata)
-      contract.contract.validate(data, { state: null, meta: metadata })
-      return GIMessage.create(null, null, undefined, `${contract.name}/process`, data, metadata)
-    },
-    [`${contract.name}/process`]: function (state, message) {
-      meta.validate(message.meta)
-      contract.contract.validate(message.data, { state, meta: message.meta })
-      contract.contract.process(state, message)
+    // expose getters for Vuex integration
+    [`${contract.name}/getters`]: function () {
+      return contract.getters
     }
   })
   for (const action in contract.actions) {
@@ -31,21 +30,25 @@ export function DefineContract (contract: Object) {
     }
     whitelistedSelectors[`${action}/process`] = true
     sbp('sbp/selectors/register', {
-      [`${action}/create`]: async function (data, contractID) {
-        if (!contractID) {
-          throw new Error(`A contractID as 2nd parameter is required when calling '${action}/create'`)
+      [`${action}/create`]: async function (data: Object, contractID: string = null) {
+        var previousHEAD = null
+        var state = null
+        if (contractID) {
+          state = contract.state(contractID)
+          previousHEAD = await sbp('backend/latestHash', contractID)
+        } else if (!IS_CONSTRUCTOR.test(`${action}/create`)) {
+          throw new Error(`contractID required when calling '${action}/create'`)
         }
-        const metadata = meta.create()
-        // TODO: this is hackish and not library friendly, fix in #749
-        const state = sbp('state/vuex/state')[contractID]
-        meta.validate(metadata)
-        contract.actions[action].validate(data, { state, meta: metadata })
-        const previousHEAD = await sbp('backend/latestHash', contractID)
-        return GIMessage.create(contractID, previousHEAD, undefined, `${action}/process`, data, metadata)
+        const meta = metadata.create()
+        metadata.validate(meta)
+        contract.actions[action].validate(data, { state, meta })
+        return GIMessage.create(contractID, previousHEAD, undefined, `${action}/process`, data, meta)
       },
-      [`${action}/process`]: function (state, message) {
-        meta.validate(message.meta)
-        contract.actions[action].validate(message.data, { state, meta: message.meta })
+      [`${action}/process`]: function (state: Object, message: Object) {
+        const { meta, data, contractID } = message
+        state = state || contract.state(contractID)
+        metadata.validate(meta)
+        contract.actions[action].validate(data, { state, meta })
         contract.actions[action].process(state, message)
       },
       // if this is undefined sbp will not register it

--- a/frontend/model/contracts/identity.js
+++ b/frontend/model/contracts/identity.js
@@ -19,7 +19,7 @@ DefineContract({
           picture: string
         })
       }),
-      process (state, { data }) {
+      process ({ data }, { state }) {
         for (const key in data) {
           Vue.set(state, key, data[key])
         }
@@ -27,7 +27,7 @@ DefineContract({
     },
     'gi.contracts/identity/setAttributes': {
       validate: object,
-      process (state, { data }) {
+      process ({ data }, { state }) {
         for (var key in data) {
           Vue.set(state.attributes, key, data[key])
         }
@@ -35,7 +35,7 @@ DefineContract({
     },
     'gi.contracts/identity/deleteAttributes': {
       validate: arrayOf(string),
-      process (state, { data }) {
+      process ({ data }, { state }) {
         for (var attribute of data) {
           Vue.delete(state.attributes, attribute)
         }

--- a/frontend/model/contracts/identity.js
+++ b/frontend/model/contracts/identity.js
@@ -1,26 +1,30 @@
 'use strict'
 
+import sbp from '~/shared/sbp.js'
 import Vue from 'vue'
 import { DefineContract } from './Contract.js'
 import { objectOf, objectMaybeOf, arrayOf, string, object } from '~/frontend/utils/flowTyper.js'
 
 DefineContract({
   name: 'gi.contracts/identity',
-  contract: {
-    validate: objectOf({
-      attributes: objectMaybeOf({
-        name: string,
-        email: string,
-        picture: string
-      })
-    }),
-    process (state, { data }) {
-      for (const key in data) {
-        Vue.set(state, key, data[key])
-      }
-    }
+  state (contractID) {
+    return sbp('state/vuex/state')[contractID]
   },
   actions: {
+    'gi.contracts/identity': {
+      validate: objectOf({
+        attributes: objectMaybeOf({
+          name: string,
+          email: string,
+          picture: string
+        })
+      }),
+      process (state, { data }) {
+        for (const key in data) {
+          Vue.set(state, key, data[key])
+        }
+      }
+    },
     'gi.contracts/identity/setAttributes': {
       validate: object,
       process (state, { data }) {

--- a/frontend/model/contracts/mailbox.js
+++ b/frontend/model/contracts/mailbox.js
@@ -29,7 +29,7 @@ DefineContract({
   actions: {
     'gi.contracts/mailbox': {
       validate: object, // TODO: define this
-      process (state, { data }) {
+      process ({ data }, { state }) {
         for (const key in data) {
           Vue.set(state, key, data[key])
         }
@@ -44,15 +44,15 @@ DefineContract({
         message: optional(string),
         headers: optional(object)
       }),
-      process (state, { data, meta, hash }) {
-        state.messages.push({ data, meta, hash })
+      process (message, { state }) {
+        state.messages.push(message)
       }
     },
     'gi.contracts/mailbox/authorizeSender': {
       validate: objectOf({
         sender: string
       }),
-      process (state, { data }) {
+      process ({ data }, { state }) {
         // TODO: replace this via OP_KEY_*?
         throw new Error('unimplemented!')
       }

--- a/frontend/model/contracts/mailbox.js
+++ b/frontend/model/contracts/mailbox.js
@@ -1,5 +1,6 @@
 'use strict'
 
+import sbp from '~/shared/sbp.js'
 import Vue from 'vue'
 import { DefineContract } from './Contract.js'
 import { objectOf, string, object, unionOf, literalOf, optional } from '~/frontend/utils/flowTyper.js'
@@ -11,15 +12,6 @@ export const messageType = unionOf(...[TYPE_MESSAGE, TYPE_FRIEND_REQ].map(k => l
 
 DefineContract({
   name: 'gi.contracts/mailbox',
-  contract: {
-    validate: object, // TODO: define this
-    process (state, { data }) {
-      for (const key in data) {
-        Vue.set(state, key, data[key])
-      }
-      Vue.set(state, 'messages', [])
-    }
-  },
   metadata: {
     // TODO: why is this missing the from username..?
     validate: objectOf({
@@ -31,7 +23,19 @@ DefineContract({
       }
     }
   },
+  state (contractID) {
+    return sbp('state/vuex/state')[contractID]
+  },
   actions: {
+    'gi.contracts/mailbox': {
+      validate: object, // TODO: define this
+      process (state, { data }) {
+        for (const key in data) {
+          Vue.set(state, key, data[key])
+        }
+        Vue.set(state, 'messages', [])
+      }
+    },
     'gi.contracts/mailbox/postMessage': {
       validate: objectOf({
         messageType: messageType,

--- a/frontend/model/contracts/voting/proposals.js
+++ b/frontend/model/contracts/voting/proposals.js
@@ -73,10 +73,10 @@ const proposals = {
       const proposal = state.proposals[data.proposalHash]
       proposal.payload = data.passPayload
       proposal.status = STATUS_PASSED
-      sbp('gi.contracts/group/invite/process', state, {
-        meta: proposal.meta,
-        data: data.passPayload
-      })
+      // NOTE: if invite/process requires more than just data+meta
+      //       this code will need to be updated...
+      const message = { meta: proposal.meta, data: data.passPayload }
+      sbp('gi.contracts/group/invite/process', message, state)
       sbp('okTurtles.events/emit', PROPOSAL_RESULT, state, VOTE_FOR, data)
       // TODO: for now, generate the link and send it to the user's inbox
       //       however, we cannot send GIMessages in any way from here
@@ -142,11 +142,13 @@ const proposals = {
       const proposal = state.proposals[data.proposalHash]
       proposal.status = STATUS_PASSED
       const { setting, proposedValue } = proposal.data.proposalData
-
-      sbp('gi.contracts/group/updateSettings/process', state, {
+      // NOTE: if updateSettings ever needs more ethana just meta+data
+      //       this code will need to be updated
+      const message = {
         meta: proposal.meta,
         data: { [setting]: proposedValue }
-      })
+      }
+      sbp('gi.contracts/group/updateSettings/process', message, state)
     },
     [VOTE_AGAINST]: voteAgainst
   },

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -7,8 +7,7 @@ import sbp from '~/shared/sbp.js'
 import Vue from 'vue'
 import Vuex from 'vuex'
 import L from '~/frontend/views/utils/translations.js'
-import currencies from '~/frontend/views/utils/currencies.js'
-import incomeDistribution from '~/frontend/utils/distribution/mincome-proportional.js'
+// import incomeDistribution from '~/frontend/utils/distribution/mincome-proportional.js'
 import { GIMessage } from '~/shared/GIMessage.js'
 import { SETTING_CURRENT_USER } from './database.js'
 import { ErrorDBBadPreviousHEAD, ErrorDBConnection } from '~/shared/domains/gi/db.js'
@@ -18,7 +17,6 @@ import { GIErrorUnrecoverable, GIErrorIgnoreAndBanIfGroup, GIErrorDropAndReproce
 import { STATUS_OPEN, PROPOSAL_REMOVE_MEMBER } from './contracts/voting/proposals.js'
 import { VOTE_FOR } from '~/frontend/model/contracts/voting/rules.js'
 import { actionWhitelisted, ACTION_REGEX } from '~/frontend/model/contracts/Contract.js'
-import { currentMonthTimestamp } from '~/frontend/utils/time.js'
 import * as _ from '~/frontend/utils/giLodash.js'
 import * as EVENTS from '~/frontend/utils/events.js'
 import './contracts/group.js'
@@ -64,7 +62,7 @@ sbp('sbp/selectors/register', {
       const stateCopy = _.cloneDeep(state)
       try {
         const message = { data: e.data(), meta: e.meta(), hash: e.hash(), contractID }
-        guardedSBP(e.type(), state, message)
+        guardedSBP(e.type(), message, state)
       } catch (err) {
         if (!(err instanceof GIErrorUnrecoverable)) {
           console.warn(`latestContractState: ignoring mutation ${e.hash()}|${e.type()} because of ${err.name}`)
@@ -95,34 +93,6 @@ sbp('sbp/selectors/register', {
       'state/vuex/dispatch', 'handleEvent', event
     ])
   },
-  // use 'groupContractSafeGetters' from within a contract to avoid code duplication,
-  // but be careful to only use getters that restrict themselves to the
-  // contract's state, and do not access state outside the contract.
-  // For example, if the getter you use tries to access `state.loggedIn`,
-  // that will break the `latestContractState` function.
-  // It is only safe to access state outside of the contract in a contract action's
-  // `sideEffect` function (as long as it doesn't modify contract state)
-  'state/groupContractSafeGetters': function (state: Object) {
-    var lastAccessedGetter
-    const stateProxy = new Proxy({}, {
-      get: function (obj, prop) {
-        if (!(prop in state)) {
-          throw new Error(`attempt to access state outside of contract state via getters.${lastAccessedGetter}. Property doesn't exist: state.${prop}`)
-        }
-        return state[prop]
-      }
-    })
-    const gettersProxy = new Proxy({}, {
-      get: function (obj, prop) {
-        lastAccessedGetter = prop
-        // this is a bit of a hack, and in the future we might
-        // instead register getters on the vuex module and somehow
-        // pass them to the contract process function, but this works for now
-        return prop === 'currentGroupState' ? stateProxy : getters[prop](stateProxy, gettersProxy)
-      }
-    })
-    return gettersProxy
-  },
   'state/vuex/state': () => store.state,
   'state/vuex/commit': (id, payload) => store.commit(id, payload),
   'state/vuex/dispatch': (...args) => store.dispatch(...args)
@@ -139,7 +109,7 @@ const mutations = {
     state.currentGroupId = null
   },
   processMessage (state, { selector, message }) {
-    guardedSBP(selector, state, message)
+    guardedSBP(selector, message, state)
   },
   registerContract (state, { contractID, type }) {
     const firstTimeRegistering = !state[contractID]
@@ -215,21 +185,32 @@ const mutations = {
 }
 // https://vuex.vuejs.org/en/getters.html
 // https://vuex.vuejs.org/en/modules.html
-//
-// !!  IMPORTANT  !!
-//
-// To make it simple to use *SOME* of these getters (the ones related to
-// group contract state) via 'state/groupContractSafeGetters', prefer using
-// 'getters' to access state instead of 'state'.
-//
-// For example, instead of: state[state.currentGroupId]
-//     Use getters instead: getters.currentGroupState
 const getters = {
+  // !!  IMPORTANT  !!
+  //
+  // For getters that get data from only contract state, write them
+  // under the 'getters' key of the object passed to DefineContract.
+  // See for example: frontend/model/contracts/group.js
+  //
+  // For convenience, we've defined the same getter, `currentGroupState`,
+  // twice, so that we can reuse the same getter definitions both here with Vuex,
+  // and inside of the contracts (e.g. in group.js).
+  //
+  // The one here is based off the value of `state.currentGroupId` — a user
+  // preference that does not exist in the group contract state.
+  //
+  // The getters in DefineContract are designed to be compatible with Vuex!
+  // When they're used in the context of DefineContract, their 'state' always refers
+  // to the state of the contract whose messages are being processed, regardless
+  // of what group we're in. That is why the definition of 'currentGroupState' in
+  // group.js simply returns the state.
+  //
+  // Since the getter functions are compatible between Vuex and our contract chain
+  // library, we can simply import them here, while excluding the getter for
+  // `currentGroupState`, and redefining it here based on the Vuex rootState.
+  ..._.omit(sbp('gi.contracts/group/getters'), ['currentGroupState']),
   currentGroupState (state) {
     return state[state.currentGroupId] || {} // avoid "undefined" vue errors at inoportune times
-  },
-  groupSettings (state, getters) {
-    return getters.currentGroupState.settings || {}
   },
   mailboxContract (state, getters) {
     const contract = getters.ourUserIdentityContract
@@ -260,6 +241,9 @@ const getters = {
   ourUserIdentityContract (state) {
     return (state.loggedIn && state[state.loggedIn.identityContractID]) || {}
   },
+  // NOTE: since this getter is written using `getters.ourUsername`, which is based
+  //       on vuexState.loggedIn (a user preference), we cannot use this getter
+  //       into group.js
   ourContributionSummary (state, getters) {
     const groupProfiles = getters.groupProfiles
     const ourUsername = getters.ourUsername
@@ -335,67 +319,12 @@ const getters = {
       .filter(contractID => contracts[contractID].type === 'group' && state[contractID].settings)
       .map(contractID => ({ groupName: state[contractID].settings.groupName, contractID }))
   },
-  groupProfile (state, getters) {
-    return username => {
-      const profiles = getters.currentGroupState.profiles
-      return profiles && profiles[username]
-    }
-  },
   globalProfile (state, getters) {
     return username => {
       const groupProfile = getters.groupProfile(username)
       const identityState = groupProfile && state[groupProfile.contractID]
       return identityState && identityState.attributes
     }
-  },
-  groupProfiles (state, getters) {
-    return Object.keys(getters.currentGroupState.profiles || {}).reduce(
-      (result, username) => {
-        result[username] = getters.groupProfile(username)
-        return result
-      },
-      {}
-    )
-  },
-  groupMembersByUsername (state, getters) {
-    return Object.keys(getters.currentGroupState.profiles || {})
-  },
-  groupMembersCount (state, getters) {
-    return getters.groupMembersByUsername.length
-  },
-  groupShouldPropose (state, getters) {
-    return getters.groupMembersCount >= 3
-  },
-  groupMincomeAmount (state, getters) {
-    return getters.groupSettings.mincomeAmount
-  },
-  groupMincomeFormatted (state, getters) {
-    const settings = getters.groupSettings
-    const currency = currencies[settings.mincomeCurrency]
-    return currency && currency.displayWithCurrency(settings.mincomeAmount)
-  },
-  groupMincomeSymbolWithCode (state, getters) {
-    const currency = currencies[getters.groupSettings.mincomeCurrency]
-    return currency && currency.symbolWithCode
-  },
-  groupIncomeDistribution (state, getters) {
-    const groupProfiles = getters.groupProfiles
-    const mincomeAmount = getters.groupMincomeAmount
-    const currentIncomeDistribution = []
-    for (const username in groupProfiles) {
-      const profile = groupProfiles[username]
-      const incomeDetailsType = profile && profile.incomeDetailsType
-      if (incomeDetailsType) {
-        const adjustment = incomeDetailsType === 'incomeAmount' ? 0 : mincomeAmount
-        const adjustedAmount = adjustment + profile[incomeDetailsType]
-        currentIncomeDistribution.push({ name: username, amount: adjustedAmount })
-      }
-    }
-    return incomeDistribution(currentIncomeDistribution, mincomeAmount)
-  },
-  thisMonthsPayments (state, getters) {
-    const payments = getters.currentGroupState.userPaymentsByMonth
-    return (payments && payments[currentMonthTimestamp()]) || {}
   },
   colors (state) {
     return Colors[state.theme]
@@ -660,9 +589,12 @@ const handleEvent = {
       const contractID = message.contractID()
       const selector = message.type()
       const hash = message.hash()
+      const data = message.data()
+      const meta = message.meta()
+      const mutation = { data, meta, hash, contractID }
       // this selector is created by Contract.js
       if (sbp('sbp/selectors/fn', `${selector}/sideEffect`)) {
-        await sbp(`${selector}/sideEffect`, message)
+        await sbp(`${selector}/sideEffect`, mutation)
       }
       // let any listening components know that we've received, processed, and stored the event
       sbp('okTurtles.events/emit', hash, contractID, message)

--- a/frontend/utils/giLodash.js
+++ b/frontend/utils/giLodash.js
@@ -9,9 +9,19 @@ export function mapValues (obj: Object, fn: Function, o: Object = {}) {
   return o
 }
 
-export function pick (o: Object, props: Array<*>) {
+export function pick (o: Object, props: [string]) {
   var x = {}
   for (const k of props) { x[k] = o[k] }
+  return x
+}
+
+export function omit (o: Object, props: [string]) {
+  var x = {}
+  for (const k in o) {
+    if (!props.includes(k)) {
+      x[k] = o[k]
+    }
+  }
   return x
 }
 

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -59,8 +59,8 @@ sbp('sbp/selectors/overwrite', {
     }
     sbp(
       e.type(),
-      vuexState[contractID],
-      { data: e.data(), meta: e.meta(), hash: e.hash(), contractID }
+      { data: e.data(), meta: e.meta(), hash: e.hash(), contractID },
+      vuexState[contractID]
     )
     sbp('okTurtles.events/emit', e.hash(), e)
   },
@@ -234,7 +234,7 @@ describe('Full walkthrough', function () {
       var state = {}
       for (const e of events) {
         const message = { data: e.data(), meta: e.meta(), hash: e.hash(), contractID: bobsContractId }
-        sbp(e.type(), state, message)
+        sbp(e.type(), message, state)
       }
       console.log(bold.red('FINAL STATE:'), state)
       // 3. get bob's mailbox contractID from his identity contract attributes


### PR DESCRIPTION
This PR partially addresses #749 and #804.

- Contracts can now have Vuex-compatible getters defined on them! They can only access state that's inside of a contract (no outside state like `state.loggedIn.username`. This means we can get rid of `'state/groupContractSafeGetters'` finally and re-use getter definitions across our contract chains and Vuex!
- `validate` functions now have access to contract state, getters, and message metadata!
- The `state` and `message` parameters to `[action]/process` have been swapped! If you call `process` directly (as for example, some code in `proposals.js` did), make sure to update it or things will break! This PR makes these changes for two `[VOTE_FOR]` calls to `process` functions.
- Note that the contract chain constructor, formally defined in the `contract` property of the object passed to `DefineContract`, has been moved into the `actions` property, and is defined by naming the action the same as the contract name.
- Contract `sideEffect` functions are now passed in more data, like the contract's state, just like the `process` and `validate` functions
- Now `validate`, `process`, and `sideEffect` contract functions all take their parameters in the same way, with the "main data thing" being passed in as the first parameter, and all "optional supporting things" being passed in an object as the second parameter