### PR TITLE
Rename actions/user to actions/identity

### DIFF
--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -5,7 +5,7 @@ import L from '@view-utils/translations.js'
 // import { CONTRACT_IS_SYNCING } from '@utils/events.js'
 
 export default sbp('sbp/selectors/register', {
-  'gi.actions/user/create': async function ({
+  'gi.actions/identity/create': async function ({
     username,
     email,
     password
@@ -16,7 +16,7 @@ export default sbp('sbp/selectors/register', {
     if (oldSettings) {
       // TODO: prompt to ask user before deleting and overwriting an existing user
       //       https://github.com/okTurtles/group-income-simple/issues/599
-      console.warn(`deleting settings for pre-existing user ${username}!`, oldSettings)
+      console.warn(`deleting settings for pre-existing identity ${username}!`, oldSettings)
       await sbp('gi.db/settings/delete', username)
     }
     // proceed with creation
@@ -46,7 +46,7 @@ export default sbp('sbp/selectors/register', {
 
     return [userID, mailboxID]
   },
-  'gi.actions/user/signup': async function ({
+  'gi.actions/identity/signup': async function ({
     username,
     email,
     password // TODO - implement
@@ -54,7 +54,7 @@ export default sbp('sbp/selectors/register', {
     sync = true
   } = {}) {
     try {
-      const [userID, mailboxID] = await sbp('gi.actions/user/create', { username, email, password })
+      const [userID, mailboxID] = await sbp('gi.actions/identity/create', { username, email, password })
 
       await sbp('namespace/register', username, userID)
 
@@ -63,12 +63,12 @@ export default sbp('sbp/selectors/register', {
       }
       return [userID, mailboxID]
     } catch (e) {
-      await sbp('gi.actions/user/logout') // TODO: should this be here?
-      console.error('gi.actions/user/signup failed!', e)
+      await sbp('gi.actions/identity/logout') // TODO: should this be here?
+      console.error('gi.actions/identity/signup failed!', e)
       throw new GIErrorUIRuntimeError(L('Failed to signup: {codeError}', { codeError: e.message }))
     }
   },
-  'gi.actions/user/login': async function ({
+  'gi.actions/identity/login': async function ({
     username,
     password
   }, {
@@ -91,20 +91,20 @@ export default sbp('sbp/selectors/register', {
 
       return userId
     } catch (e) {
-      console.error('gi.actions/user/login failed!', e)
+      console.error('gi.actions/identity/login failed!', e)
       throw new GIErrorUIRuntimeError(L('Failed to login: {codeError}', { codeError: e.message }))
     }
   },
-  'gi.actions/user/signupAndLogin': async function (signupParams) {
-    const contractIDs = await sbp('gi.actions/user/signup', signupParams, { sync: true })
-    await sbp('gi.actions/user/login', signupParams, { sync: true })
+  'gi.actions/identity/signupAndLogin': async function (signupParams) {
+    const contractIDs = await sbp('gi.actions/identity/signup', signupParams, { sync: true })
+    await sbp('gi.actions/identity/login', signupParams, { sync: true })
     return contractIDs
   },
-  'gi.actions/user/logout': async function () {
+  'gi.actions/identity/logout': async function () {
     // TODO: move the logout vuex action code into this function (see #804)
     await sbp('state/vuex/dispatch', 'logout')
   },
-  'gi.actions/user/updateSettings': async function (settings, contractID) {
+  'gi.actions/identity/updateSettings': async function (settings, contractID) {
     const msg = await sbp('gi.contracts/identity/updateSettings/create', settings, contractID)
     await sbp('backend/publishLogEntry', msg)
   }

--- a/frontend/controller/actions/index.js
+++ b/frontend/controller/actions/index.js
@@ -1,3 +1,3 @@
 export { default as contract } from './contract.js'
 export { default as group } from './group.js'
-export { default as user } from './user.js'
+export { default as identity } from './identity.js'

--- a/frontend/views/containers/access/LoginForm.vue
+++ b/frontend/views/containers/access/LoginForm.vue
@@ -70,7 +70,7 @@ export default {
       try {
         this.$refs.formMsg.clean()
 
-        await sbp('gi.actions/user/login', {
+        await sbp('gi.actions/identity/login', {
           username: this.form.username,
           password: this.form.password
         })

--- a/frontend/views/containers/access/SignupForm.vue
+++ b/frontend/views/containers/access/SignupForm.vue
@@ -75,7 +75,7 @@ export default {
         return
       }
       try {
-        await sbp('gi.actions/user/signupAndLogin', {
+        await sbp('gi.actions/identity/signupAndLogin', {
           username: this.form.username,
           email: this.form.email,
           password: this.form.password

--- a/frontend/views/pages/BypassUI.vue
+++ b/frontend/views/pages/BypassUI.vue
@@ -92,7 +92,7 @@ export default {
             const username = this.$store.getters.ourUsername
             // QUESTION: Maybe we should do this validation inside sbp action...
             if (username) { throw Error(`You're signed as '${username}'. Logout first and re-run the tests.`) }
-            await sbp('gi.actions/user/signupAndLogin', params)
+            await sbp('gi.actions/identity/signupAndLogin', params)
           },
           finalize: () => {
             // Bug vue/no-side-effects-in-computed-properties
@@ -104,7 +104,7 @@ export default {
           actionFn: async (params) => {
             const username = this.$store.getters.ourUsername
             if (username) { throw Error(`You're loggedin as '${username}'. Logout first and re-run the tests.`) }
-            await sbp('gi.actions/user/login', params)
+            await sbp('gi.actions/identity/login', params)
           },
           finalize: () => {
             this.$router.push({ path: '/app' }) // eslint-disable-line


### PR DESCRIPTION
Related to #848 

> > Another thing I noticed is how we say "identity contract" and "user contract" and they mean the same thing. We actually have 2 files: contracts/identity.js(gi.contracts/identity/*) and actions/user.js (gi.actions/user/*)
> > Which one should we stick with? Perhaps identity because most of the code uses it.
> 
> Yeah agreed... feel free to do that in another PR

