### PR TITLE
#788 Standardized scoped message

### DIFF
--- a/docs/Style-Guide.md
+++ b/docs/Style-Guide.md
@@ -160,6 +160,7 @@ banner-scoped(ref='formMsg')
 ```
 
 ```js
+import L, { LError } from '@view-utils/translations.js'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 
 submit () {
@@ -167,9 +168,7 @@ submit () {
   this.$refs.formMsg.success(L('Changes saved!'))
 
   // If something wen't wrong... Try to be more specific whenever possible.
-  this.$refs.formMsg.danger(L('Failed to upload the group picture, please try again. {codeError}', {
-    codeError: error.message
-  }))
+  this.$refs.formMsg.danger(L('Failed to upload the group picture. {reportError}', LError(error)))
 }
 ```
 

--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -16,7 +16,7 @@ import { GIErrorUIRuntimeError } from '@model/errors.js'
 
 import imageUpload from '@utils/imageUpload.js'
 import { merge } from '@utils/giLodash.js'
-import L from '@view-utils/translations.js'
+import L, { LError } from '@view-utils/translations.js'
 
 export default sbp('sbp/selectors/register', {
   'gi.actions/group/create': async function ({
@@ -122,10 +122,12 @@ export default sbp('sbp/selectors/register', {
   },
   'gi.actions/group/updateSettings': async function (settings, groupId) {
     try {
+      this.dumbError.forced = 123 // DELETE THIS BEFORE MERGE
       const message = await sbp('gi.contracts/group/updateSettings/create', settings, groupId)
       await sbp('backend/publishLogEntry', message)
     } catch (e) {
-      throw new GIErrorUIRuntimeError(L('Failed to update group settings. {codeError}', { codeError: e.message }))
+      console.error('gi.actions/group/updateSettings failed!', e)
+      throw new GIErrorUIRuntimeError(L('Failed to update group settings. {reportError}', LError(e)))
     }
   },
   'gi.actions/group/removeMember': async function (params, groupID) {

--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -122,7 +122,6 @@ export default sbp('sbp/selectors/register', {
   },
   'gi.actions/group/updateSettings': async function (settings, groupId) {
     try {
-      this.dumbError.forced = 123 // DELETE THIS BEFORE MERGE
       const message = await sbp('gi.contracts/group/updateSettings/create', settings, groupId)
       await sbp('backend/publishLogEntry', message)
     } catch (e) {

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1,8 +1,6 @@
 import sbp from '~/shared/sbp.js'
 import { GIErrorUIRuntimeError } from '@model/errors.js'
-import L from '@view-utils/translations.js'
-
-// import { CONTRACT_IS_SYNCING } from '@utils/events.js'
+import L, { LError } from '@view-utils/translations.js'
 
 export default sbp('sbp/selectors/register', {
   'gi.actions/identity/create': async function ({
@@ -65,7 +63,7 @@ export default sbp('sbp/selectors/register', {
     } catch (e) {
       await sbp('gi.actions/identity/logout') // TODO: should this be here?
       console.error('gi.actions/identity/signup failed!', e)
-      throw new GIErrorUIRuntimeError(L('Failed to signup: {codeError}', { codeError: e.message }))
+      throw new GIErrorUIRuntimeError(L('Failed to signup: {reportError}', LError(e)))
     }
   },
   'gi.actions/identity/login': async function ({
@@ -92,7 +90,7 @@ export default sbp('sbp/selectors/register', {
       return userId
     } catch (e) {
       console.error('gi.actions/identity/login failed!', e)
-      throw new GIErrorUIRuntimeError(L('Failed to login: {codeError}', { codeError: e.message }))
+      throw new GIErrorUIRuntimeError(L('Failed to login: {reportError}', LError(e)))
     }
   },
   'gi.actions/identity/signupAndLogin': async function (signupParams) {

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -298,7 +298,7 @@ DefineContract({
           }
 
           if (deepEqualJSONType(omit(prop.data.proposalData, 'reason'), dataToCompare)) {
-            throw new TypeError(L('There is an identical open proposal'))
+            throw new Errors.GIErrorUIRuntimeError(L('There is an identical open proposal.'))
           }
         }
       },

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -298,7 +298,7 @@ DefineContract({
           }
 
           if (deepEqualJSONType(omit(prop.data.proposalData, 'reason'), dataToCompare)) {
-            throw new TypeError(L('There is an identical open proposal.'))
+            throw new TypeError(L('There is an identical open proposal'))
           }
         }
       },

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -298,7 +298,7 @@ DefineContract({
           }
 
           if (deepEqualJSONType(omit(prop.data.proposalData, 'reason'), dataToCompare)) {
-            throw new Errors.GIErrorUIRuntimeError(L('There is an identical open proposal.'))
+            throw new TypeError(L('There is an identical open proposal.'))
           }
         }
       },

--- a/frontend/views/components/AvatarUpload.vue
+++ b/frontend/views/components/AvatarUpload.vue
@@ -25,7 +25,7 @@ import sbp from '~/shared/sbp.js'
 import imageUpload from '@utils/imageUpload.js'
 import Avatar from '@components/Avatar.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
-import L from '@view-utils/translations.js'
+import L, { LError } from '@view-utils/translations.js'
 
 export default {
   name: 'AvatarUpload',
@@ -49,8 +49,8 @@ export default {
       try {
         picture = await imageUpload(fileReceived)
       } catch (e) {
-        console.error(e)
-        this.$refs.formMsg.danger(L('Failed to upload avatar. {codeError}', { codeError: e.message }))
+        console.error('AvatarUpload imageUpload() error:', e)
+        this.$refs.formMsg.danger(L('Failed to upload avatar. {reportError}', LError(e)))
         return false
       }
 
@@ -64,8 +64,8 @@ export default {
         this.$refs.picture.setFromBlob(fileReceived)
         this.$refs.formMsg.success(L('Avatar updated!'))
       } catch (e) {
-        console.error('Failed to save avatar', e)
-        this.$refs.formMsg.danger(L('Failed to save avatar. {codeError}', { codeError: e.message }))
+        console.error('AvatarUpload fileChange() error:', e)
+        this.$refs.formMsg.danger(L('Failed to save avatar. {reportError}', LError(e)))
       }
     }
   }

--- a/frontend/views/components/banners/BannerScoped.vue
+++ b/frontend/views/components/banners/BannerScoped.vue
@@ -72,7 +72,7 @@ export default {
     clean () {
       this.updateBanner('', '')
     },
-    danger (text, opts) {
+    danger (text, opts = {}) {
       this.updateBanner(text, 'danger')
       if (opts.error) { this.ephemeral.error = opts.error }
     },

--- a/frontend/views/components/banners/BannerScoped.vue
+++ b/frontend/views/components/banners/BannerScoped.vue
@@ -3,7 +3,7 @@
     .c-container(v-if='ephemeral.text')
       banner-simple(class='c-banner' :severity='ephemeral.severity')
         .c-inner
-          .c-inner-text(:data-test='dataTest' role='alert' v-html="ephemeral.text")
+          .c-inner-text(:data-test='dataTest' role='alert' v-html='ephemeral.text')
           button.is-icon-small.c-button(
             type='button'
             :class='`is-${ephemeral.severity}`'
@@ -84,9 +84,7 @@ export default {
   }
 }
 
-$severities:
-  "success" $success_0 $success_1,
-  "danger" $danger_0 $danger_1;
+$severities: "success" $success_0 $success_1, "danger" $danger_0 $danger_1;
 
 .c-button {
   transition: box-shadow 150ms ease-in;

--- a/frontend/views/components/banners/BannerScoped.vue
+++ b/frontend/views/components/banners/BannerScoped.vue
@@ -3,10 +3,7 @@
     .c-container(v-if='ephemeral.text')
       banner-simple(class='c-banner' :severity='ephemeral.severity')
         .c-inner
-          .c-inner-text(:data-test='dataTest' role='alert' @click='handleMsgClick')
-            | {{ ephemeral.text }}
-            |
-            span(v-if='ephemeral.error' v-html='linkToErrorReport')
+          .c-inner-text(:data-test='dataTest' role='alert' v-html="ephemeral.text")
           button.is-icon-small.c-button(
             type='button'
             :class='`is-${ephemeral.severity}`'
@@ -17,9 +14,6 @@
 </template>
 
 <script>
-import sbp from '~/shared/sbp.js'
-import { OPEN_MODAL } from '@utils/events.js'
-import L from '@view-utils/translations.js'
 import BannerSimple from '@components/banners/BannerSimple.vue'
 import TransitionExpand from '@components/TransitionExpand.vue'
 
@@ -38,43 +32,17 @@ export default {
   data: () => ({
     ephemeral: {
       text: null,
-      severity: null,
-      error: null
+      severity: null
     }
   }),
-  computed: {
-    linkToErrorReport () {
-      return L('Please check the {b1}error logs{b2} for more info.', {
-        'b1': '<button class="link js-btnError">',
-        'b2': '</button>'
-      })
-    }
-  },
   methods: {
-    handleMsgClick (e) {
-      if (this.ephemeral.error && e.target.classList.contains('js-btnError')) {
-        sbp('okTurtles.events/emit', OPEN_MODAL, 'UserSettingsModal',
-          { // custom props
-            tabProps: {
-              'application-logs': {
-                referalError: this.ephemeral.error
-              }
-            }
-          },
-          { // custom url query
-            section: 'application-logs'
-          }
-        )
-      }
-    },
     // To be used by parent. Example:
     // this.$refs.BannerScoped.success(L('Changes saved!'))
     clean () {
       this.updateBanner('', '')
     },
-    danger (text, opts = {}) {
+    danger (text) {
       this.updateBanner(text, 'danger')
-      if (opts.error) { this.ephemeral.error = opts.error }
     },
     success (text) {
       this.updateBanner(text, 'success')
@@ -82,7 +50,6 @@ export default {
     updateBanner (text, severity) {
       this.ephemeral.text = text
       this.ephemeral.severity = severity
-      this.ephemeral.error = null
     }
   }
 }

--- a/frontend/views/components/banners/BannerSimple.vue
+++ b/frontend/views/components/banners/BannerSimple.vue
@@ -47,7 +47,7 @@ export default {
     color: currentColor;
   }
 
-  ::v-deep a.link {
+  ::v-deep .link {
     font-weight: 400;
     color: currentColor;
     border-bottom-color: currentColor;

--- a/frontend/views/components/modal/Modal.vue
+++ b/frontend/views/components/modal/Modal.vue
@@ -15,7 +15,6 @@ export default {
       subcontent: [], // Collection of modal on top of modals
       subContentProps: {}, // Custom props passed down to the sub modal
       replacement: null, // Replace the modal once the first one is close without updating the url
-      customQuery: {}, // Custom queries passed down to modal
       lastFocus: null // Record element that open the modal
     }
   },
@@ -83,32 +82,19 @@ export default {
           query: {
             ...this.$route.query,
             modal: this.content,
-            subcontent: this.activeSubcontent(),
-            ...this.customQuery
+            subcontent: this.activeSubcontent()
           }
         }).catch(console.error)
       } else if (this.$route.query.modal) {
         const query = { ...this.$route.query }
         delete query['modal']
         delete query['subcontent']
-        for (const queryKey in this.customQuery) {
-          delete query[queryKey]
-        }
-        this.customQuery = {}
         this.$router.push({ query }).catch(console.error)
       }
     },
-    openModal (componentName, componentProps = {}, customQuery = {}) {
-      if (this.content === componentName) {
-        // Don't open the same kind of modal twice.
-        if (this.componentProps === componentProps) return
-        // Otherwise update its content...
-        this.lastFocus = document.activeElement
-        this.contentProps = componentProps
-        this.customQuery = customQuery
-        this.updateUrl()
-        return // TODO dry this
-      }
+    openModal (componentName, componentProps = {}) {
+      // Don't open the same kind of modal twice.
+      if (this.content === componentName) return
       // Record active element
       this.lastFocus = document.activeElement
       if (this.content) {
@@ -118,7 +104,6 @@ export default {
         this.content = componentName
         this.contentProps = componentProps
       }
-      this.customQuery = customQuery
       this.updateUrl()
     },
     unloadModal () {

--- a/frontend/views/components/tabs/TabItems.vue
+++ b/frontend/views/components/tabs/TabItems.vue
@@ -17,25 +17,22 @@
 <script>
 export default {
   name: 'TabItem',
-
   data () {
     return {
       isActive: false,
       transitionName: null
     }
   },
-
   methods: {
+    // Used by parent TabWrapper.vue
     changeTab (isActive, transitionName) {
       this.transitionName = transitionName
       this.isActive = isActive
     }
   },
-
   created () {
     this.$parent.tabItems.push(this)
   },
-
   beforeDestroy () {
     const index = this.$parent.tabItems.indexOf(this)
     if (index >= 0) {

--- a/frontend/views/components/tabs/TabWrapper.vue
+++ b/frontend/views/components/tabs/TabWrapper.vue
@@ -37,19 +37,17 @@ export default {
   name: 'TabWrapper',
 
   props: {
-    value: Number,
-    tabNav: Array
+    tabNav: Array,
+    defaultTab: String // initial tab name
   },
-
   data () {
     return {
-      activeTab: this.value || 0,
+      activeTab: 0, // this.value || 0,
       tabItems: [],
       open: true,
       title: this.tabNav[0].links[0].title || ''
     }
   },
-
   computed: {
     ...mapGetters([
       'isDarkTheme'
@@ -116,12 +114,12 @@ export default {
       }
     }
   },
-
   mounted () {
-    if (this.$route.query.section) {
+    const defaultTab = this.$route.query.section || this.defaultTab
+    if (defaultTab) {
       this.tabNav.forEach(item => {
         item.links.forEach(link => {
-          if (this.$route.query.section === link.url) {
+          if (defaultTab === link.url) {
             this.activeTab = link.index
             this.title = link.title
           }

--- a/frontend/views/components/tabs/TabWrapper.vue
+++ b/frontend/views/components/tabs/TabWrapper.vue
@@ -35,14 +35,13 @@ import sbp from '~/shared/sbp.js'
 
 export default {
   name: 'TabWrapper',
-
   props: {
     tabNav: Array,
     defaultTab: String // initial tab name
   },
   data () {
     return {
-      activeTab: 0, // this.value || 0,
+      activeTab: 0,
       tabItems: [],
       open: true,
       title: this.tabNav[0].links[0].title || ''
@@ -53,7 +52,6 @@ export default {
       'isDarkTheme'
     ])
   },
-
   watch: {
     /**
      * When v-model is changed set the new active tab.

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -81,7 +81,7 @@ import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 import TransitionExpand from '@components/TransitionExpand.vue'
-import L from '@view-utils/translations.js'
+import L, { LError } from '@view-utils/translations.js'
 
 export default {
   name: 'IncomeDetails',
@@ -202,8 +202,8 @@ export default {
         await sbp('backend/publishLogEntry', groupProfileUpdate)
         this.closeModal()
       } catch (e) {
-        console.error('Failed to update income details', e)
-        this.$refs.formMsg.danger(L('Failed to update income details, please try again. {codeError}', { codeError: e.message }))
+        console.error('IncomeDetails submit() error:', e)
+        this.$refs.formMsg.danger(L('Failed to update income details. {reportError}', LError(e)))
       }
     }
   },

--- a/frontend/views/containers/group-settings/GroupLeaveModal.vue
+++ b/frontend/views/containers/group-settings/GroupLeaveModal.vue
@@ -105,7 +105,7 @@ export default {
       try {
         await sbp('gi.actions/group/removeOurselves', this.currentGroupId)
       } catch (e) {
-        console.error('Failed to remove ourselves', e)
+        console.error('GroupLeaveModal submit() error:', e)
         this.$refs.formMsg.danger(e.message)
       }
     }

--- a/frontend/views/containers/proposals/AddMembers.vue
+++ b/frontend/views/containers/proposals/AddMembers.vue
@@ -8,22 +8,27 @@
     variant='addMember'
     @submit='submit'
   )
-    fieldset(v-if='ephemeral.currentStep === 0' key='0' ref='fieldset')
+    fieldset.c-fieldset(
+      v-if='ephemeral.currentStep === 0'
+      ref='fieldset'
+      :class='{"is-shifted": ephemeral.invitesCount.length > 1}'
+    )
       i18n.label(tag='legend') Full name
-      label.field.c-fields-item(
+      .field.c-fields-item(
         v-for='(member, index) in ephemeral.invitesCount'
         :key='`member-${index}`'
         data-test='invitee'
       )
         i18n.label.sr-only Invitee name
-        .input-shifted
+        .inputgroup
           input.input(
             type='text'
+            :aria-label='L("Full name")'
             v-model='form.invitees[index]'
             @keyup='(e) => inviteeUpdate(e, index)'
             aria-required
           )
-          button.is-icon-small(
+          button.is-icon-small.is-btn-shifted(
             v-if='ephemeral.invitesCount > 1'
             type='button'
             @click='removeInvitee(index)'
@@ -155,5 +160,17 @@ export default {
 
 .c-feedback {
   text-align: center;
+}
+
+.c-fieldset {
+  .is-btn-shifted {
+    display: none;
+  }
+
+  &.is-shifted {
+    .is-btn-shifted {
+      display: block;
+    }
+  }
 }
 </style>

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -118,7 +118,7 @@ export default {
 
           this.ephemeral.currentStep += 1 // Show Success step
         } catch (e) {
-          this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(e)))
+          this.$refs.formMsg.danger(L('Failed to propose mincome change: {reportError}', LError(e)))
           this.ephemeral.currentStep = 0
         }
         return
@@ -134,7 +134,7 @@ export default {
         this.$refs.proposal.close()
       } catch (e) {
         console.error('Mincome.vue submit() error:', e)
-        this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(e)))
+        this.$refs.formMsg.danger(L('Failed to change mincome: {reportError}', LError(e)))
       }
     }
   }

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -118,15 +118,14 @@ export default {
 
           this.ephemeral.currentStep += 1 // Show Success step
         } catch (e) {
-          console.error(`Failed to change mincome to ${mincomeAmount}`, e.message)
-          this.$refs.formMsg.danger(L('Failed to change mincome. {codeError}', { codeError: e.message }))
+          console.error('Mincome submit() error:', mincomeAmount, e.message)
+          this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(e)))
           this.ephemeral.currentStep = 0
         }
         return
       }
 
       try {
-        this.foo.dumbError = 'force-an-error' // DELETE THIS BEFORE MERGE
         const updatedSettings = await sbp(
           'gi.contracts/group/updateSettings/create',
           { mincomeAmount },
@@ -134,9 +133,9 @@ export default {
         )
         await sbp('backend/publishLogEntry', updatedSettings)
         this.$refs.proposal.close()
-      } catch (error) {
-        console.error('Mincome.vue submit() error:', error)
-        this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(error)))
+      } catch (e) {
+        console.error('Mincome.vue submit() error:', e)
+        this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(e)))
       }
     }
   }

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -135,12 +135,8 @@ export default {
         await sbp('backend/publishLogEntry', updatedSettings)
         this.$refs.proposal.close()
       } catch (error) {
-        console.error('Mincome.vue submit() error:', error.message)
-        // @taoeffect, please try to make this work!
-        this.$refs.formMsg.danger(`${L('Failed to change mincome.')} ${LError(error)}`)
-
-        // The original implemented solution:
-        // this.$refs.formMsg.danger(L('Failed to change mincome.'), { error })
+        console.error('Mincome.vue submit() error:', error)
+        this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(error)))
       }
     }
   }

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -30,7 +30,7 @@ import { validationMixin } from 'vuelidate'
 import { required } from 'vuelidate/lib/validators'
 import { mapGetters, mapState } from 'vuex'
 import { decimals } from '@view-utils/validators.js'
-import L from '@view-utils/translations.js'
+import L, { LError } from '@view-utils/translations.js'
 import ProposalTemplate from './ProposalTemplate.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import { PROPOSAL_GROUP_SETTING_CHANGE } from '@model/contracts/voting/constants.js'
@@ -126,7 +126,7 @@ export default {
       }
 
       try {
-        this.foo.mincome = 'force-an-error' // DELETE THIS BEFORE MERGE
+        this.foo.dumbError = 'force-an-error' // DELETE THIS BEFORE MERGE
         const updatedSettings = await sbp(
           'gi.contracts/group/updateSettings/create',
           { mincomeAmount },
@@ -136,7 +136,11 @@ export default {
         this.$refs.proposal.close()
       } catch (error) {
         console.error('Mincome.vue submit() error:', error.message)
-        this.$refs.formMsg.danger(L('Failed to change mincome.'), { error })
+        // @taoeffect, please try to make this work!
+        this.$refs.formMsg.danger(`${L('Failed to change mincome.')} ${LError(error)}`)
+
+        // The original implemented solution:
+        // this.$refs.formMsg.danger(L('Failed to change mincome.'), { error })
       }
     }
   }

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -118,8 +118,6 @@ export default {
 
           this.ephemeral.currentStep += 1 // Show Success step
         } catch (e) {
-          this.dumbError.dumbError = 'forcer-error' // DELETE BEFORE MERGE!!
-          console.error('Mincome submit() error:', mincomeAmount, e.message)
           this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(e)))
           this.ephemeral.currentStep = 0
         }

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -126,6 +126,7 @@ export default {
       }
 
       try {
+        this.foo.mincome = 'force-an-error' // DELETE THIS BEFORE MERGE
         const updatedSettings = await sbp(
           'gi.contracts/group/updateSettings/create',
           { mincomeAmount },
@@ -133,9 +134,9 @@ export default {
         )
         await sbp('backend/publishLogEntry', updatedSettings)
         this.$refs.proposal.close()
-      } catch (e) {
-        console.error(`Failed to change mincome to ${mincomeAmount}`, e.message)
-        this.$refs.formMsg.danger(L('Failed to change mincome {codeError}', { codeError: e.message }))
+      } catch (error) {
+        console.error('Mincome.vue submit() error:', error.message)
+        this.$refs.formMsg.danger(L('Failed to change mincome.'), { error })
       }
     }
   }

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -118,6 +118,7 @@ export default {
 
           this.ephemeral.currentStep += 1 // Show Success step
         } catch (e) {
+          this.dumbError.dumbError = 'forcer-error' // DELETE BEFORE MERGE!!
           console.error('Mincome submit() error:', mincomeAmount, e.message)
           this.$refs.formMsg.danger(L('Failed to change mincome. {reportError}', LError(e)))
           this.ephemeral.currentStep = 0

--- a/frontend/views/containers/proposals/ProposalVoteOptions.vue
+++ b/frontend/views/containers/proposals/ProposalVoteOptions.vue
@@ -25,7 +25,7 @@
 <script>
 import { mapGetters, mapState } from 'vuex'
 import sbp from '~/shared/sbp.js'
-import L from '@view-utils/translations.js'
+import L, { LError } from '@view-utils/translations.js'
 import { VOTE_FOR, VOTE_AGAINST } from '@model/contracts/voting/rules.js'
 import { oneVoteToPass } from '@model/contracts/voting/proposals.js'
 import { PROPOSAL_INVITE_MEMBER, PROPOSAL_REMOVE_MEMBER } from '@model/contracts/voting/constants.js'
@@ -125,9 +125,9 @@ export default {
           this.currentGroupId
         )
         await sbp('backend/publishLogEntry', vote)
-      } catch (error) {
-        console.error('ProposalVoteOptions voteFor failed:', error)
-        this.refVoteMsg.danger(L('We couldn’t register your vote.'))
+      } catch (e) {
+        console.error('ProposalVoteOptions voteFor failed:', e)
+        this.refVoteMsg.danger(L('We couldn’t register your vote. {reportError}', LError(e)))
       }
     },
     async voteAgainst () {
@@ -146,9 +146,9 @@ export default {
           this.currentGroupId
         )
         await sbp('backend/publishLogEntry', vote)
-      } catch (error) {
-        console.error('ProposalVoteOptions voteAgainst failed:', error)
-        this.refVoteMsg.danger(L('We couldn’t register your vote.'))
+      } catch (e) {
+        console.error('ProposalVoteOptions voteAgainst failed:', e)
+        this.refVoteMsg.danger(L('We couldn’t register your vote. {reportError}', LError(e)))
       }
     },
     async cancelProposal () {
@@ -164,9 +164,9 @@ export default {
           this.currentGroupId
         )
         await sbp('backend/publishLogEntry', vote)
-      } catch (error) {
-        console.error('ProposalVoteOptions cancelProposal failed:', error)
-        this.refVoteMsg.danger(L('Failed to cancel proposal.'))
+      } catch (e) {
+        console.error('ProposalVoteOptions cancelProposal failed:', e)
+        this.refVoteMsg.danger(L('Failed to cancel proposal. {reportError}', LError(e)))
       }
     }
   }

--- a/frontend/views/containers/proposals/RemoveMember.vue
+++ b/frontend/views/containers/proposals/RemoveMember.vue
@@ -21,7 +21,7 @@ proposal-template(
 import { mapState, mapGetters } from 'vuex'
 import sbp from '~/shared/sbp.js'
 import { CLOSE_MODAL } from '@utils/events.js'
-import L from '@view-utils/translations.js'
+import L, { LError } from '@view-utils/translations.js'
 import Avatar from '@components/Avatar.vue'
 import { PROPOSAL_REMOVE_MEMBER } from '@model/contracts/voting/constants.js'
 import BannerScoped from '@components/banners/BannerScoped.vue'
@@ -105,8 +105,8 @@ export default {
 
           this.ephemeral.currentStep += 1
         } catch (e) {
-          console.error(`Failed to propose remove ${member}.`, e)
-          this.$refs.formMsg.danger(L('Failed to propose remove {member}: {codeError}', { codeError: e.message, member }))
+          console.error('RemoveMember submit() error:', member, e)
+          this.$refs.formMsg.danger(L('Failed to propose remove {member}: {reportError}', { ...LError(e), member }))
 
           this.ephemeral.currentStep = 0
         }

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -58,8 +58,6 @@ export default {
       lastEntry = entry.prev
     } while (lastEntry)
     this.ephemeral.logs = logs.reverse() // chronological order (oldest to most recent)
-
-    this.ephemeral.reportError = this.$route.query.errorMsg
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', CAPTURED_LOGS)
@@ -89,9 +87,9 @@ export default {
         .join('\n')
     },
     instructions () {
-      const errorMsg = this.ephemeral.reportError
+      const errorMsg = this.$route.query.errorMsg
       const linkTag = {
-        'a_': '<a class="link" target="_blank" href="https://github.com/okTurtles/group-income-simple/issues/new">',
+        'a_': '<a class="link" target="_blank" href="https://github.com/okTurtles/group-income-simple/issues">',
         '_a': '</a>'
       }
       return errorMsg

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -2,6 +2,10 @@
   .settings-container
     section.card
       .c-header
+        span(v-if='referalError')
+          p You should report this last error: #[b {{referalError.message}}].
+          p And we should talk with @mmbotelho about the UX/UI of this! 💅
+          br
         fieldset.c-filters
           .c-filters-inner
             legend.c-filters-legend Optional logs:
@@ -31,7 +35,9 @@ import { CAPTURED_LOGS, SET_APP_LOGS_FILTER } from '@utils/events.js'
 import { downloadLogs, getLog } from '@model/captureLogs.js'
 export default {
   name: 'AppLogs',
-  components: {},
+  props: {
+    referalError: Error // The Error that leaded the user to this page.
+  },
   data () {
     return {
       form: {
@@ -43,6 +49,7 @@ export default {
     }
   },
   created () {
+    console.log('referalError:', this.referalError)
     this.form.filter = this.appLogsFilter
     sbp('okTurtles.events/on', CAPTURED_LOGS, this.addLog)
 

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -2,10 +2,8 @@
   .settings-container
     section.card
       .c-header
-        span(v-if='referalError')
-          p You should report this last error: #[b {{referalError.message}}].
-          p And we should talk with @mmbotelho about the UX/UI of this! 💅
-          br
+        p.c-instructions(v-if='ephemeral.reportError')
+          | [Give some instructions to the user about this page. Ask @mmbotelho for help]
         fieldset.c-filters
           .c-filters-inner
             legend.c-filters-legend Optional logs:
@@ -35,21 +33,18 @@ import { CAPTURED_LOGS, SET_APP_LOGS_FILTER } from '@utils/events.js'
 import { downloadLogs, getLog } from '@model/captureLogs.js'
 export default {
   name: 'AppLogs',
-  props: {
-    referalError: Error // The Error that leaded the user to this page.
-  },
   data () {
     return {
       form: {
         filter: []
       },
       ephemeral: {
-        logs: []
+        logs: [],
+        reportError: null
       }
     }
   },
   created () {
-    console.log('referalError:', this.referalError)
     this.form.filter = this.appLogsFilter
     sbp('okTurtles.events/on', CAPTURED_LOGS, this.addLog)
 
@@ -62,6 +57,8 @@ export default {
       lastEntry = entry.prev
     } while (lastEntry)
     this.ephemeral.logs = logs.reverse() // chronological order (oldest to most recent)
+
+    this.ephemeral.reportError = this.$route.query.errorMsg
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', CAPTURED_LOGS)
@@ -133,6 +130,10 @@ export default {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
+}
+
+.c-instructions {
+  margin-bottom: 1.5rem;
 }
 
 .c-filters {

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -40,8 +40,7 @@ export default {
         filter: []
       },
       ephemeral: {
-        logs: [],
-        reportError: null
+        logs: []
       }
     }
   },
@@ -93,8 +92,8 @@ export default {
         '_a': '</a>'
       }
       return errorMsg
-        ? L('You faced a recent error: "{errorMsg}". Please download the logs and {a_}send to us{_a}, so that we can help you solve the problem.', { errorMsg, ...linkTag })
-        : L('If you are facing any problem with Group Income, download the logs and {a_}send to us{_a}, so that we can help you solve the problem.', linkTag)
+        ? L('Recent error: "{errorMsg}". Please download the logs and {a_}send them to us{_a}, so we can help troubleshoot.', { errorMsg, ...linkTag })
+        : L('If you encounter problems, please download the logs and {a_}send them to us{_a}.', linkTag)
     }
   },
   methods: {

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -2,8 +2,7 @@
   .settings-container
     section.card
       .c-header
-        p.c-instructions(v-if='ephemeral.reportError')
-          | [Give some instructions to the user about this page. Ask @mmbotelho for help]
+        p.c-instructions(v-html='instructions')
         fieldset.c-filters
           .c-filters-inner
             legend.c-filters-legend Optional logs:
@@ -31,6 +30,8 @@ import { mapState, mapMutations, mapActions } from 'vuex'
 import sbp from '~/shared/sbp.js'
 import { CAPTURED_LOGS, SET_APP_LOGS_FILTER } from '@utils/events.js'
 import { downloadLogs, getLog } from '@model/captureLogs.js'
+import L from '@view-utils/translations.js'
+
 export default {
   name: 'AppLogs',
   data () {
@@ -86,6 +87,16 @@ export default {
         .filter(({ type }) => this.form.filter.includes(type))
         .map(({ type, msg, timestamp }) => `${timestamp} [${type}] ${msg.map(JSON.stringify).join(' ')}`)
         .join('\n')
+    },
+    instructions () {
+      const errorMsg = this.ephemeral.reportError
+      const linkTag = {
+        'a_': '<a class="link" target="_blank" href="https://github.com/okTurtles/group-income-simple/issues/new">',
+        '_a': '</a>'
+      }
+      return errorMsg
+        ? L('You faced a recent error: "{errorMsg}". Please download the logs and {a_}send to us{_a}, so that we can help you solve the problem.', { errorMsg, ...linkTag })
+        : L('If you are facing any problem with Group Income, download the logs and {a_}send to us{_a}, so that we can help you solve the problem.', linkTag)
     }
   },
   methods: {

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -147,15 +147,16 @@ export default {
       }
 
       try {
+        this.foo.profile = 'force-an-error' // DELETE THIS BEFORE MERGE
         const attributes = await sbp('gi.contracts/identity/setAttributes/create',
           attrs,
           this.$store.state.loggedIn.identityContractID
         )
         await sbp('backend/publishLogEntry', attributes)
         this.$refs.formMsg.success(L('Your changes were saved!'))
-      } catch (e) {
-        console.error('Failed to update profile', e)
-        this.$refs.formMsg.danger(L('Failed to update profile, please try again. {codeError}', { codeError: e.message }))
+      } catch (error) {
+        console.error('UserProfile.vue saveProfile() error:', error)
+        this.$refs.formMsg.danger(L('Failed to update profile'), { error })
       }
     }
   }

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -86,7 +86,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import AvatarUpload from '@components/AvatarUpload.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 import sbp from '~/shared/sbp.js'
-import L from '@view-utils/translations.js'
+import L, { LError } from '@view-utils/translations.js'
 
 export default {
   name: 'UserProfile',
@@ -156,7 +156,7 @@ export default {
         this.$refs.formMsg.success(L('Your changes were saved!'))
       } catch (error) {
         console.error('UserProfile.vue saveProfile() error:', error)
-        this.$refs.formMsg.danger(L('Failed to update profile'), { error })
+        this.$refs.formMsg.danger(L('Failed to update profile. {reportError}', LError(error)))
       }
     }
   }

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -147,16 +147,15 @@ export default {
       }
 
       try {
-        this.foo.profile = 'force-an-error' // DELETE THIS BEFORE MERGE
         const attributes = await sbp('gi.contracts/identity/setAttributes/create',
           attrs,
           this.$store.state.loggedIn.identityContractID
         )
         await sbp('backend/publishLogEntry', attributes)
         this.$refs.formMsg.success(L('Your changes were saved!'))
-      } catch (error) {
-        console.error('UserProfile.vue saveProfile() error:', error)
-        this.$refs.formMsg.danger(L('Failed to update profile. {reportError}', LError(error)))
+      } catch (e) {
+        console.error('UserProfile saveProfile() error:', e)
+        this.$refs.formMsg.danger(L('Failed to update profile. {reportError}', LError(e)))
       }
     }
   }

--- a/frontend/views/containers/user-settings/UserSettingsModal.vue
+++ b/frontend/views/containers/user-settings/UserSettingsModal.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 modal-base-template(class='has-background')
   .wrapper-container
-    tab-wrapper(:title='L("Settings")' :tabNav='settings' @close='$emit("close")')
+    tab-wrapper(:title='L("Settings")' :tabNav='settings' :defaultTab='defaultTab' @close='$emit("close")')
       tab-item
         user-profile
       tab-item
@@ -11,7 +11,7 @@ modal-base-template(class='has-background')
       tab-item
         appearence
       tab-item
-        app-logs
+        app-logs(v-bind='tabProps["application-logs"]')
       tab-item
         tab-placeholder(name='Troubleshooting')
 </template>
@@ -28,7 +28,6 @@ import settings from './settings.js'
 
 export default {
   name: 'SettingsWrapper',
-
   components: {
     ModalBaseTemplate,
     TabWrapper,
@@ -38,7 +37,13 @@ export default {
     UserProfile,
     TabPlaceholder
   },
-
+  props: {
+    defaultTab: String, // initial tab name
+    tabProps: {
+      type: Object, // props to pass down to a specific tab
+      default () { return {} }
+    }
+  },
   data () {
     return settings
   }

--- a/frontend/views/containers/user-settings/UserSettingsModal.vue
+++ b/frontend/views/containers/user-settings/UserSettingsModal.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 modal-base-template(class='has-background')
   .wrapper-container
-    tab-wrapper(:title='L("Settings")' :tabNav='settings' :defaultTab='defaultTab' @close='$emit("close")')
+    tab-wrapper(:title='L("Settings")' :tabNav='settings' @close='$emit("close")')
       tab-item
         user-profile
       tab-item
@@ -11,7 +11,7 @@ modal-base-template(class='has-background')
       tab-item
         appearence
       tab-item
-        app-logs(v-bind='tabProps["application-logs"]')
+        app-logs
       tab-item
         tab-placeholder(name='Troubleshooting')
 </template>
@@ -36,13 +36,6 @@ export default {
     AppLogs,
     UserProfile,
     TabPlaceholder
-  },
-  props: {
-    defaultTab: String, // initial tab name
-    tabProps: {
-      type: Object, // props to pass down to a specific tab
-      default () { return {} }
-    }
   },
   data () {
     return settings

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -167,7 +167,7 @@ export default {
         await sbp('gi.actions/group/updateSettings', attrs, this.currentGroupId)
         this.$refs.formMsg.success(L('Your changes were saved!'))
       } catch (e) {
-        console.error('GroupSettings saveSettings failed!', e)
+        console.error('GroupSettings saveSettings() failed:', e)
         this.$refs.formMsg.danger(e.message)
       }
     },

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -167,7 +167,7 @@ export default {
         await sbp('gi.actions/group/updateSettings', attrs, this.currentGroupId)
         this.$refs.formMsg.success(L('Your changes were saved!'))
       } catch (e) {
-        console.error('GroupSettings saveSettings() failed:', e)
+        console.error('GroupSettings saveSettings() error:', e)
         this.$refs.formMsg.danger(e.message)
       }
     },

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -167,7 +167,7 @@ export default {
         await sbp('gi.actions/group/updateSettings', attrs, this.currentGroupId)
         this.$refs.formMsg.success(L('Your changes were saved!'))
       } catch (e) {
-        console.error('Failed to update group settings.', e)
+        console.error('GroupSettings saveSettings failed!', e)
         this.$refs.formMsg.danger(e.message)
       }
     },

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -67,8 +67,9 @@ export default function L (
 
 export function LError (error) {
   return {
-    reportError: L('Please {a_}report to us{_a} the error.', {
-      'a_': `<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=application-logs&errorMsg=${error.message}">`,
+    reportError: L('{errorMsg}. {a_}Report the error{_a}.', {
+      errorMsg: error.message,
+      'a_': `<a class='link' target='_blank' href='/app/dashboard?modal=UserSettingsModal&section=application-logs&errorMsg=${encodeURI(error.message)}'>`,
       '_a': '</a>'
     })
   }

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -74,7 +74,7 @@ export function LError (error) {
   return {
     reportError: L('"{errorMsg}". {a_}Report the error{_a}.', {
       errorMsg: error.message,
-      'a_': `<a class='link' target='_blank' href='/app/dashboard?modal=UserSettingsModal&section=application-logs&errorMsg=${encodeURI(error.message)}'>`,
+      'a_': `<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=application-logs&errorMsg=${encodeURI(error.message)}">`,
       '_a': '</a>'
     })
   }

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -66,38 +66,12 @@ export default function L (
 }
 
 export function LError (error) {
-  const translation = L('{link_}Click to troubleshoot.{_link}', {
-    // Note/TODO: change /group-settings to correct path.
-    'link_': `<router-link class='link' :to="{ path: '/group-settings', query: { error: "${error.message}" } }">`,
-    '_link': '</router-link>'
-  })
-
-  console.log(translation)
-  const result = Vue.compile('<wrap>' + translation + '</wrap>')
-
-  console.log(':::', result)
-
-  // WIP...
-
-  /*
-    h variable comes from Vue render(). But here that doesn't exist.
-    h stands for hyperscript. Searching how to create a component programatically.
-    Some resources:
-    https://css-tricks.com/what-does-the-h-stand-for-in-vues-render-method/
-    https://css-tricks.com/creating-vue-js-component-instances-programmatically/
-  */
-
-  const h = (tag, ...args) => {
-    console.log(tag, args)
-    return tag
+  return {
+    reportError: L('Please {a_}report to us{_a} the error.', {
+      'a_': `<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=application-logs&errorMsg=${error.message}">`,
+      '_a': '</a>'
+    })
   }
-
-  return result.render.call({
-    _c: (tag, ...args) => {
-      return h(tag, ...args)
-    },
-    _v: x => x
-  })
 }
 
 Vue.component('i18n', {

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -2,6 +2,7 @@
 
 import Vue from 'vue'
 import template from '~/frontend/utils/stringTemplate.js'
+import { GIErrorUIRuntimeError } from '@model/errors.js'
 
 Vue.prototype.L = L
 Vue.prototype.LTags = LTags
@@ -66,8 +67,12 @@ export default function L (
 }
 
 export function LError (error) {
+  if (error instanceof GIErrorUIRuntimeError) {
+    // It's a controlled/predictable error, so we don't need the user to report it to us.
+    return { reportError: error.message }
+  }
   return {
-    reportError: L('{errorMsg}. {a_}Report the error{_a}.', {
+    reportError: L('"{errorMsg}". {a_}Report the error{_a}.', {
       errorMsg: error.message,
       'a_': `<a class='link' target='_blank' href='/app/dashboard?modal=UserSettingsModal&section=application-logs&errorMsg=${encodeURI(error.message)}'>`,
       '_a': '</a>'

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -2,7 +2,6 @@
 
 import Vue from 'vue'
 import template from '~/frontend/utils/stringTemplate.js'
-import { GIErrorUIRuntimeError } from '@model/errors.js'
 
 Vue.prototype.L = L
 Vue.prototype.LTags = LTags
@@ -67,12 +66,8 @@ export default function L (
 }
 
 export function LError (error) {
-  if (error instanceof GIErrorUIRuntimeError) {
-    // It's a controlled/predictable error, so we don't need the user to report it to us.
-    return { reportError: error.message }
-  }
   return {
-    reportError: L('"{errorMsg}". {a_}Report the error{_a}.', {
+    reportError: L('"{errorMsg}". You can {a_}report the error{_a}.', {
       errorMsg: error.message,
       'a_': `<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=application-logs&errorMsg=${encodeURI(error.message)}">`,
       '_a': '</a>'

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -65,6 +65,41 @@ export default function L (
   return template(key, args)
 }
 
+export function LError (error) {
+  const translation = L('{link_}Click to troubleshoot.{_link}', {
+    // Note/TODO: change /group-settings to correct path.
+    'link_': `<router-link class='link' :to="{ path: '/group-settings', query: { error: "${error.message}" } }">`,
+    '_link': '</router-link>'
+  })
+
+  console.log(translation)
+  const result = Vue.compile('<wrap>' + translation + '</wrap>')
+
+  console.log(':::', result)
+
+  // WIP...
+
+  /*
+    h variable comes from Vue render(). But here that doesn't exist.
+    h stands for hyperscript. Searching how to create a component programatically.
+    Some resources:
+    https://css-tricks.com/what-does-the-h-stand-for-in-vues-render-method/
+    https://css-tricks.com/creating-vue-js-component-instances-programmatically/
+  */
+
+  const h = (tag, ...args) => {
+    console.log(tag, args)
+    return tag
+  }
+
+  return result.render.call({
+    _c: (tag, ...args) => {
+      return h(tag, ...args)
+    },
+    _v: x => x
+  })
+}
+
 Vue.component('i18n', {
   functional: true,
   props: {

--- a/test/cypress/integration/group-proposals.spec.js
+++ b/test/cypress/integration/group-proposals.spec.js
@@ -33,7 +33,7 @@ function tryUnsuccessfullyToProposeNewSimilarMincome () {
     cy.getByDT('nextBtn', 'button')
       .click()
     cy.getByDT('submitBtn').click()
-    cy.getByDT('proposalError').contains('Failed to change mincome. There is an identical open proposal.')
+    cy.getByDT('proposalError').contains('Failed to change mincome. "There is an identical open proposal."')
     cy.getByDT('closeModal').click()
     cy.getByDT('closeModal').should('not.exist')
   })

--- a/test/cypress/integration/group-proposals.spec.js
+++ b/test/cypress/integration/group-proposals.spec.js
@@ -33,7 +33,7 @@ function tryUnsuccessfullyToProposeNewSimilarMincome () {
     cy.getByDT('nextBtn', 'button')
       .click()
     cy.getByDT('submitBtn').click()
-    cy.getByDT('proposalError').contains('Failed to change mincome. "There is an identical open proposal."')
+    cy.getByDT('proposalError').contains('Failed to propose mincome change: "There is an identical open proposal."')
     cy.getByDT('closeModal').click()
     cy.getByDT('closeModal').should('not.exist')
   })


### PR DESCRIPTION
Closes #788

![demo](https://user-images.githubusercontent.com/14869087/78315577-5790d180-7555-11ea-82a8-b681e1c57b2b.gif)

Based on #788, the original idea to normalize the error messages is to create a `L()` function with a link `<router-link>` pointing to the Application Logs page. That approach has one major problem: `L` does not support `compile` and even if it does, it can't be a `router-link`. It needs to be `sbp` to open `ApplicationLogs` modal correctly with the needed props.

Since our design is consistent and all error messages appear inside the banner scoped, I thought about using it as our "bridge" to the Application logs. I made a POC in two places: Change Mincome modal and User Settings form. **Please go give it a try on your computer**

This is the only change needed to be done everywhere to standardize the error messages:

```js
// Note as danger() accepts 2 arguments: A `L()` function with a normal string
// and as the 2nd parameter, we pass the `error`. 
this.$refs.formMsg.danger(L('Failed to change mincome.'), { error })
```

The tricky part (already done in this PR) was to update `BannerScoped` so it redirects correctly to the Application Logs page through `OPEN_MODAL` sbp call. There both custom props and url query are passed down to the modal component. This way the modal is open correctly at ApplicationLogs section with the error message.

What do you guys think? @taoeffect and @pieer 

