### PR TITLE
Add Loading State to ButtonSubmit where it's needed.

### DIFF
--- a/frontend/assets/style/components/_buttons.scss
+++ b/frontend/assets/style/components/_buttons.scss
@@ -10,12 +10,12 @@
   }
 }
 
-@mixin outlinedButtonState($color, $color_2) {
+@mixin outlinedButtonState($color, $color_focus, $color_loading) {
   &[data-loading="true"] {
     color: transparent;
 
     &::after {
-      color: $color;
+      color: $color_loading;
     }
   }
 
@@ -28,7 +28,7 @@
     }
 
     &:focus {
-      box-shadow: 0 0 0 2px #{$color_2};
+      box-shadow: 0 0 0 2px $color_focus;
     }
   }
 }
@@ -147,19 +147,19 @@ button,
     background-color: $background;
     border-color: $general_0;
     color: $text_0;
-    @include outlinedButtonState($primary_0_1, $primary_1);
+    @include outlinedButtonState($primary_0_1, $primary_1, $text_0);
 
     &.is-success {
       border-color: $success_0;
       color: $success_0;
-      @include outlinedButtonState($success_0_1, $success_1);
+      @include outlinedButtonState($success_0_1, $success_1, $success_0);
     }
 
     &.is-danger,
     &.error {
       border-color: $danger_0;
       color: $danger_0;
-      @include outlinedButtonState($danger_0_1, $danger_1);
+      @include outlinedButtonState($danger_0_1, $danger_1, $danger_0);
     }
   }
 

--- a/frontend/views/components/ButtonSubmit.vue
+++ b/frontend/views/components/ButtonSubmit.vue
@@ -16,12 +16,12 @@
 Use ButtonSubmit on buttons that will trigger an **async** action.
 
 button-submit(
-@click='handleLogin'
+  @click='handleLogin'
 ) Login
 
-This will display a "loading state" on the button while the login is happening.
+This will display a spinner (the loading state) on the button while the login is happening.
 
-The button has type="submit" to catch any way of form submittion (ex: press Enter).
+The button has type="submit" to catch any way of form submission (ex: press Enter).
 
 That way we don't need to use $refs on the parent.
 

--- a/frontend/views/components/banners/BannerScoped.vue
+++ b/frontend/views/components/banners/BannerScoped.vue
@@ -80,6 +80,7 @@ export default {
     margin-top: 0.1875rem; // visually better centered aligned
     text-align: left; // force even when the parent has another alignment
     word-break: break-word; // handle long messages
+    font-weight: 600;
   }
 }
 

--- a/frontend/views/containers/proposals/ProposalItem.vue
+++ b/frontend/views/containers/proposals/ProposalItem.vue
@@ -21,6 +21,8 @@
         v-if='proposal.status === statuses.STATUS_OPEN'
         :proposalHash='proposalHash'
       )
+    // Note: $refs.voteMsg is used by children ProposalVoteOptions
+    banner-scoped(ref='voteMsg' data-test='voteMsg')
     p.c-sendLink(v-if='invitationLink' data-test='sendLink')
       i18n(
         :args='{ user: proposal.data.proposalData.member}'
@@ -50,6 +52,7 @@ import {
   STATUS_CANCELLED
 } from '@model/contracts/voting/constants.js'
 import ProposalVoteOptions from '@containers/proposals/ProposalVoteOptions.vue'
+import BannerScoped from '@components/banners/BannerScoped.vue'
 import LinkToCopy from '@components/LinkToCopy.vue'
 import Tooltip from '@components/Tooltip.vue'
 import { INVITE_STATUS } from '@model/contracts/group.js'
@@ -60,6 +63,7 @@ export default {
     proposalHash: String
   },
   components: {
+    BannerScoped,
     ProposalVoteOptions,
     LinkToCopy,
     Tooltip


### PR DESCRIPTION
Closes #868 

The only missing place was when voting in a proposal (yes, no and cancel). If you notice any other place, let me know and I'll add it in this PR.

![image](https://user-images.githubusercontent.com/14869087/78457510-91bbb980-76a2-11ea-84ec-e4f4f5220721.png)

#### Scouting stuff:
- Fix the banner text styles (turn them bold).
- Fix the spinning colors based on the button variant.

#### 🔥How to force an error to appear?
Well, our code is so good that the only way is to make it on purpose by breaking the code 😅.
Go to the file `ProposalVoteOptions.vue`. You'll find 3 functions, each one for each possible action: `voteFor`, `voteAgainst` and `cancelProposal`. 

Each one has a `try { }` block. You need to force an error inside it.

Example:
```js
async cancelProposal () {
  // ...
  try {
     // Add these 2 lines to force the error 2.5s after you click the button.
     await new Promise((resolve, reject) => { setTimeout(resolve, 2500) })
     this.dumb.error = 'forced-dumb-error'
    
     this.refVoteMsg.clean()
     // ...


