### PR TITLE
#778 improve modal keyboard navigation

### DIFF
--- a/frontend/assets/style/components/_buttons.scss
+++ b/frontend/assets/style/components/_buttons.scss
@@ -1,6 +1,7 @@
 @mixin buttonState($color, $color_2) {
   @media (hover: hover) {
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: #{$color};
     }
 
@@ -261,7 +262,8 @@ button.link {
   }
 
   @media (hover: hover) {
-    &:hover {
+    &:hover,
+    &:focus {
       background-color: transparent;
     }
 

--- a/frontend/views/components/modal/ModalBaseTemplate.vue
+++ b/frontend/views/components/modal/ModalBaseTemplate.vue
@@ -1,12 +1,13 @@
 <template lang='pug'>
   transition(name='zoom' appear @after-leave='unload')
     .modal(
+      v-if='modalIsActive'
       :class='{ fullscreen }'
-      data-test='modal'
       role='dialog'
       tabindex='-1'
-      @keyup.tab='trapFocus'
-      v-if='modalIsActive'
+      :aria-label='a11yTitle'
+      v-focus=''
+      data-test='modal'
       @close='close'
     )
       modal-close(@close='close' :fullscreen='fullscreen')

--- a/frontend/views/components/modal/ModalMixins.js
+++ b/frontend/views/components/modal/ModalMixins.js
@@ -17,8 +17,8 @@ const modaMixins = {
     return {
       modalIsActive: true,
       focusableElements: 'a[href], area[href], ' +
-      'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), ' +
-      'button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
+        'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), ' +
+        'button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
     }
   },
   mounted () {

--- a/frontend/views/components/modal/ModalMixins.js
+++ b/frontend/views/components/modal/ModalMixins.js
@@ -4,6 +4,10 @@ import ModalClose from './ModalClose.vue'
 
 const modaMixins = {
   props: {
+    a11yTitle: {
+      type: String,
+      required: true
+    },
     backOnMobile: {
       type: Boolean,
       default: false
@@ -12,16 +16,16 @@ const modaMixins = {
   data () {
     return {
       modalIsActive: true,
-      focusableChildren: []
+      focusableElements: 'a[href], area[href], ' +
+      'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), ' +
+      'button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
     }
   },
   mounted () {
-    const focusableElementsString =
-      'a[href], area[href], ' +
-      'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), ' +
-      'button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
-
-    this.focusableChildren = Array.from(this.$el.querySelectorAll(focusableElementsString))
+    document.addEventListener('keydown', this.trapFocus)
+  },
+  beforeDestroy () {
+    document.removeEventListener('keydown', this.trapFocus)
   },
   components: {
     ModalClose
@@ -34,18 +38,25 @@ const modaMixins = {
       sbp('okTurtles.events/emit', CLOSE_MODAL)
     },
     trapFocus (e) {
-      const currentFocus = document.activeElement
-      const totalOfFocusable = this.focusableChildren.length
-      const focusedIndex = this.focusableChildren.indexOf(currentFocus)
-      if (e.shiftKey) {
-        if (focusedIndex === 0) {
+      // Trap focus on modal while navigating through clickable elements only
+      if (e.key === 'Tab') {
+        // look for focusableChilds each time tab is pressed
+        // to catch any element that may have changed disabled attr.
+        // ex: submit button gets enabled or a form step changed.
+        const focusableChilds = Array.from(this.$el.querySelectorAll(this.focusableElements))
+        const firstFocusChild = focusableChilds[0]
+        const lastFocusChild = focusableChilds[focusableChilds.length - 1]
+
+        if (e.shiftKey) { // Shift + Tab
+          if (document.activeElement === firstFocusChild) {
+            // tab backwards, so go back to last element
+            e.preventDefault()
+            lastFocusChild.focus()
+          }
+        } else if (document.activeElement === lastFocusChild) {
+          // tab forwards, so go back to first element
           e.preventDefault()
-          this.focusableChildren[totalOfFocusable - 1].focus()
-        }
-      } else {
-        if (focusedIndex === totalOfFocusable - 1) {
-          e.preventDefault()
-          this.focusableChildren[0].focus()
+          firstFocusChild.focus()
         }
       }
     }

--- a/frontend/views/components/modal/ModalTemplate.vue
+++ b/frontend/views/components/modal/ModalTemplate.vue
@@ -2,10 +2,9 @@
   .c-modal(
     data-test='modal'
     role='dialog'
-    :aria-labelledby='$scopedSlots.title'
     tabindex='-1'
+    :aria-label='a11yTitle'
     v-focus=''
-    @keyup.tab='trapFocus'
   )
     transition(name='fade' appear)
       .c-modal-background(@click='close' v-if='modalIsActive')

--- a/frontend/views/containers/access/LoginForm.vue
+++ b/frontend/views/containers/access/LoginForm.vue
@@ -15,7 +15,7 @@ form(data-test='login' @submit.prevent='')
 
   password-form(:label='L("Password")' name='password' :$v='$v')
 
-  i18n.link.c-forgot(tag='a' @click='forgotPassword') Forgot your password?
+  i18n.link.c-forgot(tag='button' @click='forgotPassword') Forgot your password?
 
   banner-scoped(ref='formMsg' data-test='loginError')
 

--- a/frontend/views/containers/access/LoginModal.vue
+++ b/frontend/views/containers/access/LoginModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-  modal-template(class='has-background' ref='modal')
+  modal-template(class='has-background' ref='modal' :a11yTitle='L("Login")')
     template(slot='title')
       i18n Log in
 

--- a/frontend/views/containers/access/LoginModal.vue
+++ b/frontend/views/containers/access/LoginModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-  modal-template(class='has-background' ref='modal' :a11yTitle='L("Login")')
+  modal-template(class='has-background' ref='modal' :a11yTitle='L("Log in")')
     template(slot='title')
       i18n Log in
 
@@ -9,7 +9,7 @@
       p
         i18n Not on Group Income yet?
         | &nbsp;
-        i18n.link(tag='button' data-test='goToSignup' @click='showSignupModal') Create an account
+        i18n.link(tag='button' @click='showSignupModal' data-test='goToSignup') Create an account
 </template>
 
 <script>

--- a/frontend/views/containers/access/PasswordModal.vue
+++ b/frontend/views/containers/access/PasswordModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-template(class='is-centered is-left-aligned' back-on-mobile=true ref='modalTemplate')
+modal-template(class='is-centered is-left-aligned' back-on-mobile=true ref='modalTemplate' :a11yTitle='L("Change Password")')
   template(slot='title') Change password
 
   form(

--- a/frontend/views/containers/access/SignupModal.vue
+++ b/frontend/views/containers/access/SignupModal.vue
@@ -9,7 +9,7 @@
       p
         i18n Already have an account?
         | &nbsp;
-        i18n.link(tag='a' @click='showLoginModal' data-test='goToLogin') Log in
+        i18n.link(tag='button' @click='showLoginModal' data-test='goToLogin') Log in
 </template>
 
 <script>

--- a/frontend/views/containers/access/SignupModal.vue
+++ b/frontend/views/containers/access/SignupModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-  modal-template(class='has-background' ref='modal')
+  modal-template(class='has-background' ref='modal' :a11yTitle='L("Sign up")')
     template(slot='title')
       i18n Sign Up
 

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-base-template(ref='modal' :fullscreen='true')
+modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details")')
   .c-content
     i18n.is-title-2.c-title(tag='h2') Income Details
 

--- a/frontend/views/containers/dashboard/GroupMembersAllModal.vue
+++ b/frontend/views/containers/dashboard/GroupMembersAllModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-base-template.has-background(ref='modal' :fullscreen='true')
+modal-base-template.has-background(ref='modal' :fullscreen='true' :a11yTitle='L("Group members")')
   .c-container
     .c-header
       i18n.is-title-2.c-title(tag='h2') Group members

--- a/frontend/views/containers/design-system/DSModalNested.vue
+++ b/frontend/views/containers/design-system/DSModalNested.vue
@@ -2,7 +2,7 @@
 //- NOTE: If you use it as an example when creating other modals
 //-       (instead of existing modals), make sure to replace many
 //-       of the tags below with their equivalent i18n tags.
-modal-template(:class='{ "has-background": background, "is-left-aligned": backOnMobile }' :back-on-mobile='backOnMobile')
+modal-template(:class='{ "has-background": background, "is-left-aligned": backOnMobile }' :back-on-mobile='backOnMobile' :a11yTitle='L("Modal example")')
   template(#title='') Title
   template(#subtitle='' v-if='subtitle') subtitle
 

--- a/frontend/views/containers/design-system/DSModalSimple.vue
+++ b/frontend/views/containers/design-system/DSModalSimple.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-modal-base-template(:class='{ "has-background": background }')
+modal-base-template(:class='{ "has-background": background }' :a11yTitle='L("Modal title")')
   .wrapper-container
     .example-header
       h2.is-title-2 Modal base example

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-base-template(:fullscreen='true')
+modal-base-template(:fullscreen='true' :a11yTitle='L("Create Group")')
   .steps(v-if='currentStep + 1 < config.steps.length')
     button.step(
       v-for='(step, index) in config.steps'

--- a/frontend/views/containers/group-settings/GroupDeletionModal.vue
+++ b/frontend/views/containers/group-settings/GroupDeletionModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-  modal-template(ref='modal')
+  modal-template(ref='modal' :a11yTitle='L("Delete group")')
     template(slot='title')
       i18n Delete group
 

--- a/frontend/views/containers/group-settings/GroupJoinModal.vue
+++ b/frontend/views/containers/group-settings/GroupJoinModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-base-template(:fullscreen='true')
+modal-base-template(:fullscreen='true' :a11yTitle='L("How to join a group")')
   i18n.is-title-1.c-title(tag='h1') How to join a group
 
   .wrapper

--- a/frontend/views/containers/group-settings/GroupLeaveModal.vue
+++ b/frontend/views/containers/group-settings/GroupLeaveModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-  modal-template(ref='modal')
+  modal-template(ref='modal' :a11yTitle='L("Leave group")')
     template(slot='title')
       i18n Leave group
 

--- a/frontend/views/containers/group-settings/InvitationLinkModal.vue
+++ b/frontend/views/containers/group-settings/InvitationLinkModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-template(ref='modal')
+modal-template(ref='modal' :a11yTitle='L("Add new members")')
   template(#title='')
     i18n Add new members
 

--- a/frontend/views/containers/payments/PaymentDetail.vue
+++ b/frontend/views/containers/payments/PaymentDetail.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
 // Stop initialization if payment not present
-modal-template(ref='modal' v-if='payment')
+modal-template(ref='modal' v-if='payment' :a11yTitle='L("Payment details")')
   template(slot='title')
     i18n Payment details
 

--- a/frontend/views/containers/payments/PaymentsHistoryModal.vue
+++ b/frontend/views/containers/payments/PaymentsHistoryModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-base-template(:fullscreen='true')
+modal-base-template(:fullscreen='true' :a11yTitle='L("Payments History")')
   | TODO: Implement Payments History
 </template>
 

--- a/frontend/views/containers/payments/RecordPayment.vue
+++ b/frontend/views/containers/payments/RecordPayment.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
 // Stop initialization if paymentDistribution not present
-modal-base-template(ref='modal' :fullscreen='true' class='has-background' v-if='paymentsDistribution')
+modal-base-template(ref='modal' :fullscreen='true' class='has-background' v-if='paymentsDistribution' :a11yTitle='L("Record payments")')
   .c-header(:class='{"hide-desktop": donePayment}')
     i18n.is-title-2.c-title(tag='h2') Record payments
 

--- a/frontend/views/containers/proposals/ProposalTemplate.vue
+++ b/frontend/views/containers/proposals/ProposalTemplate.vue
@@ -4,6 +4,7 @@
     class='is-centered'
     :class='{"has-background": !isConfirmation}'
     ref='modal'
+    :a11yTitle='title'
   )
     template(slot='subtitle')
       i18n(v-if='groupShouldPropose') New proposal

--- a/frontend/views/containers/user-settings/UserSettingsModal.vue
+++ b/frontend/views/containers/user-settings/UserSettingsModal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-modal-base-template(class='has-background')
+modal-base-template(class='has-background' :a11yTitle='L("Settings")')
   .wrapper-container
     tab-wrapper(:title='L("Settings")' :tabNav='settings' @close='$emit("close")')
       tab-item


### PR DESCRIPTION
Closes #778 

![Apr-11-2020 14-49-02](https://user-images.githubusercontent.com/14869087/79045777-be248800-7c04-11ea-8723-7a4de7be6ebf.gif)

- Improved the keyboard navigation within a modal: It now works as expected: when reaching the last interactive element, the next time we press `Tab` it goes back to the first element and vice-versa.
- The "solid" buttons didn't change background color on `:focus`, Now they do, as in DS.
- Add a required prop to modal: `a11yTitle` so that SR (screen readers) can read correctly what's the modal about when they start to interact with it.
