### PR TITLE
#761 Recovery page layout

### DIFF
--- a/frontend/assets/style/_layout.scss
+++ b/frontend/assets/style/_layout.scss
@@ -37,8 +37,6 @@ $bannerGeneralHeight: 2.3rem;
   position: sticky;
   height: $bannerGeneralHeight;
   width: 100%;
-  background: $text_0;
-  color: $background;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/frontend/assets/style/_layout.scss
+++ b/frontend/assets/style/_layout.scss
@@ -37,9 +37,7 @@ $bannerGeneralHeight: 2.3rem;
   position: sticky;
   height: $bannerGeneralHeight;
   width: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  text-align: center;
   padding: 0.5rem;
   z-index: $zindex-banner;
 
@@ -65,7 +63,8 @@ $bannerGeneralHeight: 2.3rem;
         margin-top: $bannerGeneralHeight;
       }
 
-      .c-modal-close {
+      .c-modal-close,
+      .has-background .c-modal-close {
         top: 3rem;
       }
     }

--- a/frontend/assets/style/_layout.scss
+++ b/frontend/assets/style/_layout.scss
@@ -38,6 +38,7 @@ $bannerGeneralHeight: 2.3rem;
   height: $bannerGeneralHeight;
   width: 100%;
   text-align: center;
+  font-weight: 600;
   padding: 0.5rem;
   z-index: $zindex-banner;
 

--- a/frontend/assets/style/_layout.scss
+++ b/frontend/assets/style/_layout.scss
@@ -55,6 +55,10 @@ $bannerGeneralHeight: 2.3rem;
     height: calc(100vh - #{$bannerGeneralHeight});
   }
 
+  & ~ .l-modal .modal {
+    top: $bannerGeneralHeight;
+  }
+
   @include touch {
     & ~ .l-modal {
       .c-modal {
@@ -65,8 +69,6 @@ $bannerGeneralHeight: 2.3rem;
         top: 3rem;
       }
     }
-
-    // TODO - handle fullscreen modals
   }
 }
 

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -129,7 +129,7 @@ async function startApp () {
       if (this.ephemeral.isCorrupted) {
         this.$refs.bannerGeneral.danger(
           this.L('Your app seems to be corrupted. Please {a_}re-sync your app data.{_a}', {
-            'a_': '<a class="link" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
+            'a_': `<a class="link" href="${window.location.pathname}?modal=UserSettingsModal&section=troubleshooting">`,
             '_a': '</a>'
           }),
           'times-circle'

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -126,15 +126,15 @@ async function startApp () {
       // }, 2500)
 
       // #761 - Hardcoded banner
-      setTimeout(() => {
-        this.$refs.bannerGeneral.danger(
-          this.L('Your app seems to be corrupted and some functionality is unavailable. {a_}Click here to fix it.{_a}', {
-            'a_': '<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
-            '_a': '</a>'
-          }),
-          'times-circle'
-        )
-      }, 2500)
+      // setTimeout(() => {
+      //   this.$refs.bannerGeneral.danger(
+      //     this.L('Your app seems to be corrupted and some functionality is unavailable. {a_}Click here to fix it.{_a}', {
+      //       'a_': '<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
+      //       '_a': '</a>'
+      //     }),
+      //     'times-circle'
+      //   )
+      // }, 2500)
     },
     computed: {
       showNav () {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -96,7 +96,7 @@ async function startApp () {
           syncs: [],
           // TODO/REVIEW page can load with already loggedin. -> this.$store.state.loggedIn ? 'yes' : 'no'
           finishedLogin: 'no',
-          isCorrupted: true // TODO #761
+          isCorrupted: false // TODO #761
         }
       }
     },
@@ -128,7 +128,7 @@ async function startApp () {
 
       if (this.ephemeral.isCorrupted) {
         this.$refs.bannerGeneral.danger(
-          this.L('Your app seems to be corrupted and some functionality is unavailable. {a_}Click here to fix it.{_a}', {
+          this.L('Your app seems to be corrupted. Please {a_}re-sync your app data.{_a}', {
             'a_': '<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
             '_a': '</a>'
           }),

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -129,7 +129,7 @@ async function startApp () {
       if (this.ephemeral.isCorrupted) {
         this.$refs.bannerGeneral.danger(
           this.L('Your app seems to be corrupted. Please {a_}re-sync your app data.{_a}', {
-            'a_': '<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
+            'a_': '<a class="link" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
             '_a': '</a>'
           }),
           'times-circle'

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -96,7 +96,7 @@ async function startApp () {
           syncs: [],
           // TODO/REVIEW page can load with already loggedin. -> this.$store.state.loggedIn ? 'yes' : 'no'
           finishedLogin: 'no',
-          isCorrupted: false // TODO #761
+          isCorrupted: true // TODO #761
         }
       }
     },

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -95,7 +95,8 @@ async function startApp () {
         ephemeral: {
           syncs: [],
           // TODO/REVIEW page can load with already loggedin. -> this.$store.state.loggedIn ? 'yes' : 'no'
-          finishedLogin: 'no'
+          finishedLogin: 'no',
+          isCorrupted: true // TODO #761
         }
       }
     },
@@ -125,16 +126,15 @@ async function startApp () {
       //   this.$refs.bannerGeneral.show(this.L('Trying to reconnect...'), 'wifi')
       // }, 2500)
 
-      // #761 - Hardcoded banner
-      // setTimeout(() => {
-      //   this.$refs.bannerGeneral.danger(
-      //     this.L('Your app seems to be corrupted and some functionality is unavailable. {a_}Click here to fix it.{_a}', {
-      //       'a_': '<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
-      //       '_a': '</a>'
-      //     }),
-      //     'times-circle'
-      //   )
-      // }, 2500)
+      if (this.ephemeral.isCorrupted) {
+        this.$refs.bannerGeneral.danger(
+          this.L('Your app seems to be corrupted and some functionality is unavailable. {a_}Click here to fix it.{_a}', {
+            'a_': '<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
+            '_a': '</a>'
+          }),
+          'times-circle'
+        )
+      }
     },
     computed: {
       showNav () {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -96,7 +96,7 @@ async function startApp () {
           syncs: [],
           // TODO/REVIEW page can load with already loggedin. -> this.$store.state.loggedIn ? 'yes' : 'no'
           finishedLogin: 'no',
-          isCorrupted: true // TODO #761
+          isCorrupted: false // TODO #761
         }
       }
     },

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -124,6 +124,17 @@ async function startApp () {
       // setTimeout(() => {
       //   this.$refs.bannerGeneral.show(this.L('Trying to reconnect...'), 'wifi')
       // }, 2500)
+
+      // #761 - Hardcoded banner
+      setTimeout(() => {
+        this.$refs.bannerGeneral.danger(
+          this.L('Your app seems to be corrupted and some functionality is unavailable. {a_}Click here to fix it.{_a}', {
+            'a_': '<a class="link" target="_blank" href="/app/dashboard?modal=UserSettingsModal&section=troubleshooting">',
+            '_a': '</a>'
+          }),
+          'times-circle'
+        )
+      }, 2500)
     },
     computed: {
       showNav () {

--- a/frontend/views/components/banners/BannerGeneral.vue
+++ b/frontend/views/components/banners/BannerGeneral.vue
@@ -4,6 +4,7 @@
       v-if='ephemeral.message'
       data-test='bannerGeneral'
       :class='`is-${ephemeral.severity}`'
+      aria-live='polite'
     )
       i(:class='`icon-${ephemeral.icon} is-prefix`')
       span(v-html='ephemeral.message')

--- a/frontend/views/components/banners/BannerGeneral.vue
+++ b/frontend/views/components/banners/BannerGeneral.vue
@@ -1,8 +1,12 @@
 <template lang='pug'>
   transition-expand
-    .l-banner(v-if='ephemeral.message' data-test='bannerGeneral')
+    .l-banner(
+      v-if='ephemeral.message'
+      data-test='bannerGeneral'
+      :class='`is-${ephemeral.severity}`'
+    )
       i(:class='`icon-${ephemeral.icon} is-prefix`')
-      | {{ ephemeral.message }}
+      span(v-html='ephemeral.message')
 </template>
 
 <script>
@@ -16,7 +20,8 @@ export default {
   data: () => ({
     ephemeral: {
       message: null,
-      icon: null
+      icon: null,
+      severity: null
     }
   }),
   methods: {
@@ -25,11 +30,37 @@ export default {
     clean () {
       this.ephemeral.message = ''
       this.ephemeral.icon = ''
+      this.ephemeral.severity = ''
     },
     show (message, icon) {
       this.ephemeral.message = message
       this.ephemeral.icon = icon
+      this.ephemeral.severity = 'neutral'
+    },
+    danger (message, icon) {
+      this.ephemeral.message = message
+      this.ephemeral.icon = icon
+      this.ephemeral.severity = 'danger'
     }
   }
 }
 </script>
+<style lang="scss" scoped>
+@import "@assets/style/_variables.scss";
+
+.l-banner ::v-deep .link {
+  color: inherit;
+  border-bottom-color: inherit;
+  font-weight: inherit;
+}
+
+.is-neutral {
+  background-color: $text_0;
+  color: $background;
+}
+
+.is-danger {
+  background-color: $danger_0;
+  color: $background;
+}
+</style>

--- a/frontend/views/components/banners/BannerScoped.vue
+++ b/frontend/views/components/banners/BannerScoped.vue
@@ -77,7 +77,6 @@ export default {
   align-items: flex-start;
 
   &-text {
-    margin-top: 0.1875rem; // visually better centered aligned
     text-align: left; // force even when the parent has another alignment
     word-break: break-word; // handle long messages
     font-weight: 600;

--- a/frontend/views/components/banners/BannerSimple.vue
+++ b/frontend/views/components/banners/BannerSimple.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-.c-message(:class='`is-${severity}`')
+.c-message(:class='`is-${severity}`' aria-live='polite')
   i(:class='getIcon')
 
   .c-content
@@ -14,8 +14,10 @@
 export default {
   name: 'Message',
   props: {
-    severity: String,
-    default () { return 'info' }
+    severity: {
+      type: String,
+      default: 'info'
+    }
   },
   validator: function (value) {
     // The value must match one of these strings

--- a/frontend/views/components/banners/BannerSimple.vue
+++ b/frontend/views/components/banners/BannerSimple.vue
@@ -50,7 +50,7 @@ export default {
   }
 
   ::v-deep .link {
-    font-weight: 400;
+    font-weight: inherit;
     color: currentColor;
     border-bottom-color: currentColor;
 

--- a/frontend/views/components/graphs/Progress.vue
+++ b/frontend/views/components/graphs/Progress.vue
@@ -3,13 +3,8 @@
     :class='{ "is-completed": percent === "100%", "has-marks": hasMarks }'
   )
   .c-bg
-  .c-marks(
-    v-if='hasMarks'
-    :style='marksStyle'
-  )
-  .c-bar(
-    :style='{ width: percent }'
-  )
+  .c-marks(v-if='hasMarks' :style='marksStyle')
+  .c-bar(:style='`--percent: ${percent}`')
 </template>
 
 <script>
@@ -74,17 +69,13 @@ export default {
 }
 
 .c-bar {
+  width: 100%;
   background-color: $primary_0;
-  // Animation to modify the bar
-  transition: width 450ms ease-in-out;
-  // Animation to show up the bar
-  transform: translateY(-50%) scaleX(0);
+  transition: transform 450ms ease-out;
+  // Animation to modify grow the bar
+  transform: translateY(-50%) scaleX(1); // fallback
+  transform: translateY(-50%) scaleX(calc(1 * var(--percent)));
   transform-origin: 0 0;
-  animation: progress 700ms ease-out 350ms forwards;
-
-  .js-reducedMotion & {
-    transform: translateY(-50%) scaleX(1);
-  }
 
   .is-completed & {
     background-color: $success_0;
@@ -105,14 +96,5 @@ export default {
   // hide last marker
   $edge: calc(100% - 2px);
   clip-path: polygon(0 0, $edge 0, $edge 100%, 0 100%);
-}
-
-@keyframes progress {
-  from {
-    transform: translateY(-50%) scaleX(0);
-  }
-  to {
-    transform: translateY(-50%) scaleX(1);
-  }
 }
 </style>

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -22,7 +22,7 @@
       textarea.textarea.c-logs(ref='textarea' rows='12' readonly)
         | {{ prettyLogs }}
 
-      i18n.link(tag='a' @click='openTroubleshooting') Troubleshooting
+      i18n.link(tag='button' @click='openTroubleshooting') Troubleshooting
 </template>
 
 <script>

--- a/frontend/views/containers/user-settings/Troubleshooting.vue
+++ b/frontend/views/containers/user-settings/Troubleshooting.vue
@@ -23,7 +23,7 @@
       template(v-else-if='ephemeral.status === "recovering"')
         .c-progress
           progress-bar(:max='1' :value='ephemeral.progress.percentage')
-          .c-progress-desc.has-text-1
+          .c-progress-desc.has-text-1(aria-label='polite')
             span {{ephemeral.progress.part}}
             span {{ephemeral.progress.percentage * 100}} %
 
@@ -114,6 +114,8 @@ export default {
 
       try {
         // Dummy logic, obviously.
+        this.updateProgress(L('Deleting local data...'), 0.05)
+        await this.dummy3secTask()
         this.updateProgress(L('Deleting local data...'), 0.25)
         await this.dummy3secTask()
         this.updateProgress(L('Downloading new data...'), 0.50)

--- a/frontend/views/containers/user-settings/Troubleshooting.vue
+++ b/frontend/views/containers/user-settings/Troubleshooting.vue
@@ -1,0 +1,198 @@
+<template lang='pug'>
+  .settings-container
+    section.card
+      i18n.is-title-3(tag='h3') Re-sync and rebuild data
+
+      p.c-desc.has-text-1
+        i18n All of your information is stored locally, on your personal device, and encrypted when sent {over the network, to other group members}. Re-syncing will download the latest version of the group's information.
+        | &nbsp;
+        i18n.link(tag='button' @click='openAppLogs') See application logs.
+
+      ul.c-legend
+        li.c-legend-item
+          i18n Total space used
+          strong.c-legend-dd {{ ephemeral.sizeMb }}
+        li.c-legend-item
+          i18n Status
+          strong.c-legend-dd {{ ephemeral.statusText }}
+          .c-marker(:class='`has-background-${ephemeral.style}-solid`')
+
+      template(v-if='ephemeral.status === "corrupted"')
+        banner-simple.c-banner(data-test='corruptedMsg' severity='danger')
+          i18n Please use the re-sync option below to restore functionality.
+      template(v-else-if='ephemeral.status === "recovering"')
+        p [progress bar on the way!]
+        | {{ephemeral.progress.part}}
+        | {{ephemeral.progress.percentage}}
+
+      banner-scoped(ref='doneMsg' data-test='doneMsg')
+
+      i18n.c-cta(
+        v-if='ephemeral.status !== "recovering"'
+        tag='button'
+        @click='startResync'
+      ) Re-sync
+</template>
+
+<script>
+import { mapState } from 'vuex'
+import L, { LError } from '@view-utils/translations.js'
+import BannerScoped from '@components/banners/BannerScoped.vue'
+import BannerSimple from '@components/banners/BannerSimple.vue'
+
+// import sbp from '~/shared/sbp.js'
+
+export default {
+  name: 'Troubleshooting',
+  components: {
+    BannerScoped,
+    BannerSimple
+  },
+  data () {
+    return {
+      ephemeral: {
+        status: 'ok', //  'ok' | 'corrupted' | 'recovering' | 'done'
+        sizeMb: '', // e.g. '9Mb'
+        statusText: '', //  Corrupted | Ok
+        style: '', // danger | success
+        progress: {
+          part: '', // e.g. 'Downloading...'
+          percentage: '' // e.g. '0.75'
+        }
+      }
+    }
+  },
+  created () {
+    const dummyStatus = 'corrupted' // 'ok' or 'corrupted'
+
+    const mapData = {
+      corrupted: {
+        statusText: L('Corrupted'),
+        style: 'danger'
+      },
+      ok: {
+        statusText: L('Ok'),
+        style: 'success'
+      }
+    }
+
+    this.ephemeral.status = dummyStatus
+    this.ephemeral.statusText = mapData[dummyStatus].statusText
+    this.ephemeral.style = mapData[dummyStatus].style
+    // Get dummy size Mb.
+    this.ephemeral.sizeMb = '9Mb'
+  },
+  computed: {
+    ...mapState([
+      'appLogsFilter'
+    ])
+  },
+  methods: {
+    openAppLogs () {
+      this.$router.push({
+        query: {
+          ...this.$route.query,
+          section: 'application-logs'
+        }
+      })
+    },
+    dummy3secTask () {
+      return new Promise((resolve, reject) => {
+        setTimeout(resolve, 3000)
+      })
+    },
+    async startResync () {
+      this.ephemeral.status = 'recovering'
+      this.$refs.doneMsg.clean()
+
+      // Dummy logic, obviously.
+      this.updateProgress(L('Deleting local data...'), 0.25)
+
+      await this.dummy3secTask()
+
+      this.updateProgress(L('Downloading new data...'), 0.50)
+
+      await this.dummy3secTask()
+
+      this.updateProgress(L('Last touches...'), 0.75)
+
+      await this.dummy3secTask()
+
+      // Done!
+      this.ephemeral.status = 'done'
+      this.updateProgress('', '')
+
+      // Success or failure
+      if (1 === 1) { // eslint-disable-line
+        this.$refs.doneMsg.success(L('Your local contract version is synced! All the app functionality was restored!'))
+      } else {
+        const e = Error
+        this.$refs.doneMsg.danger(L('Re-sync failed. Make sure you are online and try again. {reportError}', LError(e)))
+      }
+    },
+    updateProgress (part, percentage) {
+      this.ephemeral.progress.part = part
+      this.ephemeral.progress.percentage = percentage
+    }
+  }
+}
+</script>
+
+<style lang='scss' scoped>
+@import "@assets/style/_variables.scss";
+
+.settings-container {
+  @include desktop {
+    padding-top: 1.5rem;
+  }
+}
+
+.c-desc {
+  margin: 1rem 0;
+}
+
+.c-legend {
+  display: flex;
+
+  &-item {
+    margin-right: 2.5rem;
+
+    @include phone {
+      margin-right: 1.5rem;
+    }
+  }
+
+  &-dd {
+    font-family: "Poppins";
+    font-weight: 600;
+    margin-left: 0.5rem;
+  }
+}
+
+.c-marker {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  margin-left: 0.5rem;
+  margin-bottom: 0.06rem; // visually aligned
+  border-radius: 1px;
+  border: 1px solid;
+
+  &.has-background-success-solid {
+    border-color: $success_0;
+  }
+
+  &.has-background-danger-solid {
+    border-color: $danger_0;
+  }
+}
+
+.c-banner {
+  margin-top: 1.5rem;
+}
+
+.c-cta {
+  margin-top: 1.5rem;
+}
+
+</style>

--- a/frontend/views/containers/user-settings/Troubleshooting.vue
+++ b/frontend/views/containers/user-settings/Troubleshooting.vue
@@ -5,7 +5,7 @@
       p.c-desc.has-text-1
         i18n All of your information is stored locally, on your personal device, and encrypted when sent {over the network, to other group members}. Re-syncing will download the latest version of the group's information.
         | &nbsp;
-        i18n.link(tag='button' @click='openAppLogs') See application logs.
+        i18n.link(tag='button' @click='openAppLogs') See application logs
 
       ul.c-legend
         li.c-legend-item

--- a/frontend/views/containers/user-settings/UserSettingsModal.vue
+++ b/frontend/views/containers/user-settings/UserSettingsModal.vue
@@ -13,7 +13,7 @@ modal-base-template(class='has-background' :a11yTitle='L("Settings")')
       tab-item
         app-logs
       tab-item
-        tab-placeholder(name='Troubleshooting')
+        troubleshooting
 </template>
 
 <script>
@@ -23,6 +23,7 @@ import TabWrapper from '@components/tabs/TabWrapper.vue'
 import TabPlaceholder from './Placeholder.vue'
 import Appearence from './Appearence.vue'
 import AppLogs from './AppLogs.vue'
+import Troubleshooting from './Troubleshooting.vue'
 import UserProfile from './UserProfile.vue'
 import settings from './settings.js'
 
@@ -34,6 +35,7 @@ export default {
     TabItem,
     Appearence,
     AppLogs,
+    Troubleshooting,
     UserProfile,
     TabPlaceholder
   },


### PR DESCRIPTION
Part of #761 

![recovery-3](https://user-images.githubusercontent.com/14869087/80511517-1af99f80-8974-11ea-86d4-4e66e1716c53.gif)

Implemented the layout with a dummy logic. The real logic will be done in a future PR by @taoeffect  

### Notes:
To see some specific scenario, the code needs to be modified.

- **App banner visibility:** Go to `frontend/main.js`, line 99. Change the key `isCorrupted` to true.

- **Troubleshooting initial status:** Go to `frontend/containers/user-settings/Troubleshooting.vue`. In line 80, change const `status` from `'ok'` to `'corrupted'`.
- **Recovery result:** Same file as before, line 124. Change the condition `false|true` to throw a dummy error and "break" the recovery process.

