### PR TITLE
#910 Support multiple similar payment methods

### DIFF
--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -541,12 +541,12 @@ DefineContract({
           with: string
         }),
         nonMonetaryRemove: string,
-        paymentMethods: optional(arrayOf(
+        paymentMethods: arrayOf(
           objectOf({
             name: string,
             value: string
           })
-        ))
+        )
       }),
       process ({ data, meta }, { state }) {
         var groupProfile = state.profiles[meta.username]

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -3,7 +3,7 @@
 import sbp from '~/shared/sbp.js'
 import Vue from 'vue'
 import { DefineContract } from './Contract.js'
-import { mapOf, objectOf, objectMaybeOf, optional, string, number, object, unionOf } from '~/frontend/utils/flowTyper.js'
+import { arrayOf, mapOf, objectOf, objectMaybeOf, optional, string, number, object, unionOf } from '~/frontend/utils/flowTyper.js'
 // TODO: use protocol versioning to load these (and other) files
 //       https://github.com/okTurtles/group-income-simple/issues/603
 import votingRules, { ruleType, VOTE_FOR, VOTE_AGAINST } from './voting/rules.js'
@@ -536,17 +536,17 @@ DefineContract({
         incomeAmount: x => typeof x === 'number' && x >= 0,
         pledgeAmount: x => typeof x === 'number' && x >= 0,
         nonMonetaryAdd: string,
-        paymentMethods: objectMaybeOf({
-          bitcoin: objectMaybeOf({ value: string }),
-          paypal: objectMaybeOf({ value: string }),
-          venmo: objectMaybeOf({ value: string }),
-          other: objectMaybeOf({ value: string })
-        }),
         nonMonetaryEdit: objectOf({
           replace: string,
           with: string
         }),
-        nonMonetaryRemove: string
+        nonMonetaryRemove: string,
+        paymentMethods: optional(arrayOf(
+          objectOf({
+            name: string,
+            value: string
+          })
+        ))
       }),
       process ({ data, meta }, { state }) {
         var groupProfile = state.profiles[meta.username]

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -163,7 +163,7 @@ export default {
         return
       }
 
-      const paymentMethods = {}
+      const paymentMethods = []
 
       if (this.needsIncome) {
         // Find the methods that have some info filled...
@@ -182,9 +182,7 @@ export default {
 
         if (filledMethods.length > 0) {
           for (const method of filledMethods) {
-            paymentMethods[method.name] = {
-              value: method.value
-            }
+            paymentMethods.push(method)
           }
         }
       }

--- a/frontend/views/containers/contributions/PaymentMethods.vue
+++ b/frontend/views/containers/contributions/PaymentMethods.vue
@@ -68,9 +68,8 @@ export default {
     }
   }),
   created () {
-    const savedMethods = this.ourGroupProfile.paymentMethods || {}
-    const savedMethodsKeys = Object.keys(savedMethods)
-    const savedMethodsCount = savedMethodsKeys.length
+    const savedMethods = this.ourGroupProfile.paymentMethods || []
+    const savedMethodsCount = savedMethods.length
 
     if (savedMethodsCount === 0) {
       // set the minimum necessary to show the first empty field.
@@ -82,10 +81,10 @@ export default {
     }
 
     for (let index = 0; index < savedMethodsCount; index++) {
-      const method = savedMethodsKeys[index]
+      const method = savedMethods[index]
       Vue.set(this.form.methods, index, {
-        name: method,
-        value: this.ourGroupProfile.paymentMethods[method].value
+        name: method.name,
+        value: method.value
       })
     }
   },

--- a/test/cypress/integration/group-payments.spec.js
+++ b/test/cypress/integration/group-payments.spec.js
@@ -206,15 +206,25 @@ describe('Payments', () => {
       })
 
       cy.getByDT('fields', 'ul').children().should('have.length', 2)
+
+      cy.log('Add a 3º same payment method (other)')
+      cy.getByDT('addMethod', 'button').click()
+      cy.getByDT('method').eq(2).within(() => {
+        cy.get('select').should('have.value', null)
+        cy.get('input').should('have.value', '')
+        cy.get('select').select('other')
+        cy.get('input').type('MBWAY: 91 2345678')
+        cy.getByDT('remove', 'button').should('be.visible')
+      })
     })
 
     cy.getByDT('submitIncome').click()
     cy.getByDT('closeModal').should('not.exist')
 
-    cy.log('Verify saved payment info (bitcoin and other)')
+    cy.log('Verify saved payment info (bitcoin and 2 other)')
     cy.getByDT('openIncomeDetailsModal').click()
     cy.getByDT('paymentMethods').within(() => {
-      cy.getByDT('fields', 'ul').children().should('have.length', 2)
+      cy.getByDT('fields', 'ul').children().should('have.length', 3)
       cy.getByDT('method').eq(0).within(() => {
         cy.get('select').should('have.value', 'bitcoin')
         cy.get('input').should('have.value', 'h4sh-t0-b3-s4ved')
@@ -225,10 +235,15 @@ describe('Payments', () => {
         cy.get('input').should('have.value', 'IBAN: 12345')
         cy.getByDT('remove', 'button').should('be.visible')
       })
-
-      cy.log('Try to add a 3º payment method - incompleted !name')
-      cy.getByDT('addMethod', 'button').click()
       cy.getByDT('method').eq(2).within(() => {
+        cy.get('select').should('have.value', 'other')
+        cy.get('input').should('have.value', 'MBWAY: 91 2345678')
+        cy.getByDT('remove', 'button').should('be.visible')
+      })
+
+      cy.log('Try to add a 4º payment method - incompleted !name')
+      cy.getByDT('addMethod', 'button').click()
+      cy.getByDT('method').eq(3).within(() => {
         cy.get('input').type('mylink.com')
       })
     })
@@ -238,14 +253,14 @@ describe('Payments', () => {
 
     cy.getByDT('paymentMethods').within(() => {
       // Remove the previous incomplete method
-      cy.getByDT('method').eq(2).within(() => {
+      cy.getByDT('method').eq(3).within(() => {
         cy.getByDT('remove', 'button').click()
       })
 
-      cy.log('Try to add a 3º payment method - incompleted !value')
+      cy.log('Try to add a 4º payment method - incompleted !value')
       // Add a new method... incompleted (no value)
       cy.getByDT('addMethod', 'button').click()
-      cy.getByDT('method').eq(2).within(() => {
+      cy.getByDT('method').eq(3).within(() => {
         cy.get('select').select('paypal')
       })
     })


### PR DESCRIPTION
Fixes #910

Note: When PR #884 is merged (after or before this PR), the `ProfileCard.vue` needs to be updated to fetch correctly `ourGroupProfile.paymentMethods`.