### PR TITLE
Fix cypress test group creation optional step

### DIFF
--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -159,14 +159,18 @@ Cypress.Commands.add('giCreateGroup', (name, {
   cy.fixture(image, 'base64').then(fileContent => {
     cy.get('[data-test="groupPicture"]').upload({ fileContent, fileName: image, mimeType: 'image/png' }, { subjectType: 'input' })
   })
-
   cy.getByDT('nextBtn').click()
 
-  if (sharedValues) cy.get('textarea[name="sharedValues"]').type(sharedValues)
+  if (sharedValues) {
+    cy.get('textarea[name="sharedValues"]').type(sharedValues)
+  } else {
+    // Make sure this step is in the DOM...
+    cy.get('textarea[name="sharedValues"]')
+  }
+  // ...so that it catches correctly the next "Next" button.
   cy.getByDT('nextBtn').click()
 
   cy.get('input[name="mincomeAmount"]').type(mincome)
-
   cy.getByDT('nextBtn').click()
 
   // TODO - It seems we are not testing the Percentages Rules ATM, so, let's just move on...


### PR DESCRIPTION
There is an unstable test happening since #905, [(see example)](https://dashboard.cypress.io/projects/q6whky/runs/573/specs) in the exact step when a group without description is being created. The error is the following:

```
 CypressError: Timed out retrying: cy.click() failed because this element is detached from the DOM.

<button data-v-d4d51b50="" data-v-7093228c="" data-test="nextBtn" class="is-primary">...</button>

Cypress requires elements be attached in the DOM to interact with them.

This DOM element likely became detached somewhere between the previous and current command.

Common situations why this happens:
  - Your JS framework re-rendered asynchronously
  - Your app code reacted to an event firing and removed the element
```

The related cypress test:

```js
  cy.getByDT('nextBtn').click() // click next on the first step (group name)

  if (sharedValues) cy.get('textarea[name="sharedValues"]').type(sharedValues)

  cy.getByDT('nextBtn').click() // click next on the second step (group description)
```

So, the error happened because cypress is so fast that it gets the second `nextBtn` before the DOM updates to show the second step. So in reality, it got the first `nextBtn` again. When it tries to click it, the btn no longer exists because in the meantime it was already replaced by the 2nd `nextBtn`.

The solution is to make sure the 2nd step is in the DOM (`<textarea>`) before trying to click the 2nd `nextBtn`.

I did run this test locally multiple times and it didn't fail. I hope this fixes the test. 

P.S. There's [another unstable test](https://dashboard.cypress.io/projects/q6whky/runs/577/specs?utm_source=github) with a similar issue (trying to find an element but it finds two. I'll try to fix it too in another PR.