### PR TITLE
#664 Invite links - Implement "Revoke link" action

### DIFF
--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -50,7 +50,7 @@ export function createInvite (
     invitee,
     status: INVITE_STATUS.VALID,
     responses: {}, // { bob: true } list of usernames that accepted the invite.
-    expires: 1638588240000 // 04 december 2021.
+    expires: 1638588240000 // 04 december 2021. // TODO this
   }
 }
 
@@ -603,7 +603,6 @@ DefineContract({
         }
       },
       process ({ data, meta }, { state, getters }) {
-        console.debug('inviteRevoke:', data, state.invites)
         const invite = state.invites[data.inviteSecret]
         Vue.set(invite, 'status', INVITE_STATUS.REVOKED)
       }

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -50,7 +50,7 @@ export function createInvite (
     invitee,
     status: INVITE_STATUS.VALID,
     responses: {}, // { bob: true } list of usernames that accepted the invite.
-    expires: 123456789 // TODO: this
+    expires: 1638588240000 // 04 december 2021.
   }
 }
 
@@ -590,6 +590,22 @@ DefineContract({
           // new member has joined, so subscribe to their identity contract
           await sbp('state/enqueueContractSync', meta.identityContractID)
         }
+      }
+    },
+    'gi.contracts/group/inviteRevoke': {
+      validate: (data, { state, getters, meta }) => {
+        objectOf({
+          inviteSecret: string // NOTE: simulate the OP_KEY_* stuff for now
+        })(data)
+
+        if (!state.invites[data.inviteSecret]) {
+          throw new TypeError(L('The link does not exist.'))
+        }
+      },
+      process ({ data, meta }, { state, getters }) {
+        console.debug('inviteRevoke:', data, state.invites)
+        const invite = state.invites[data.inviteSecret]
+        Vue.set(invite, 'status', INVITE_STATUS.REVOKED)
       }
     },
     'gi.contracts/group/updateSettings': {

--- a/frontend/views/containers/group-settings/InvitationsTable.vue
+++ b/frontend/views/containers/group-settings/InvitationsTable.vue
@@ -48,14 +48,23 @@ page-section.c-section(:title='L("Invite links")')
             i.icon-ellipsis-v
           menu-parent.c-webshare-fallback
             menu-trigger.is-icon-small.c-fallback-trigger(ref='webShareFallbackBtn')
-
             menu-content.c-dropdown-fallback
               ul
                 menu-item(
                   tag='button'
                   icon='link'
                 )
+                  // #780 TODO test/verify if webShare works in a real mobile device.
+                  //      And refactor this markup to only have one menu-parent
                   i18n Copy link
+                menu-item(
+                  v-if='item.status.isActive'
+                  tag='button'
+                  item-id='revoke'
+                  icon='times'
+                  @click='handleRevokeClick(item.inviteSecret)'
+                )
+                  i18n Revoke Link
         td.c-state
           span.c-state-description {{ item.description }}
           span.c-state-expire(

--- a/frontend/views/containers/group-settings/InvitationsTable.vue
+++ b/frontend/views/containers/group-settings/InvitationsTable.vue
@@ -211,7 +211,7 @@ export default {
       if (days) return L('{days}d {hours}h {minutes}m left', { days, hours, minutes })
       if (hours) return L('{hours}h {minutes}m left', { hours, minutes })
       if (minutes) return L('{minutes}m left', { minutes })
-      return L('Not used')
+      return L('Expired')
     },
     mapInvite ({
       creator,

--- a/test/cypress/integration/group-proposals.spec.js
+++ b/test/cypress/integration/group-proposals.spec.js
@@ -273,7 +273,7 @@ describe('Proposals - Add members', () => {
     cy.visit(invitationLinks.user6) // already used on the previous test
     cy.getByDT('pageTitle')
       .invoke('text')
-      .should('contain', 'Oh no! Your link has expired.')
+      .should('contain', 'Oh no! This invite is not valid')
     cy.getByDT('helperText').should('contain', 'You should ask for a new one. Sorry about that!')
     cy.get('button').click()
     cy.url().should('eq', 'http://localhost:8000/app/')
@@ -284,7 +284,7 @@ describe('Proposals - Add members', () => {
     cy.visit('http://localhost:8000/app/join?groupId=321&secret=123')
     cy.getByDT('pageTitle')
       .invoke('text')
-      .should('contain', 'Oh no! Something went wrong.')
+      .should('contain', 'Oh no! This invite is not valid')
     cy.getByDT('helperText').should('contain', 'Something went wrong. Please, try again. 404: Not Found')
     cy.get('button').click()
     cy.url().should('eq', 'http://localhost:8000/app/')


### PR DESCRIPTION
Closes #664.

![screenshot](https://user-images.githubusercontent.com/14869087/82690872-e9af7f00-9c54-11ea-99a8-b38a5e071089.png)

### Things done:
- The menu item "See original proposal" was removed. It will be added back at #925.
- The "time left" now shows the correct timing. Note: all invitations still have the same static expiration date. (4 December 2021)
- The revoke action works.
- Simplified the "Join Group" page. When visiting a revoked/expired/incorrect link, it shows a message saying the invite is invalid.
