### PR TITLE
Fix Cypress test related to non-monetary contribution

### DIFF
--- a/frontend/views/containers/contributions/Contribution.vue
+++ b/frontend/views/containers/contributions/Contribution.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
 transition(name='replace-list')
-  li.c-contribution-edit(v-if='isEditing || isAdding' key='editing')
+  li.c-contribution-edit(v-if='isEditing || isAdding' data-test='editing' key='editing')
     form.c-contribution(
       @submit.prevent=''
       novalidate='true'
@@ -40,7 +40,7 @@ transition(name='replace-list')
             data-test='buttonSaveNonMonetaryContribution'
           ) {{ L('Save') }}
 
-  li(v-else-if='isEditable' :class='itemClasses' key='editable')
+  li(v-else-if='isEditable' :class='itemClasses' data-test='editable' key='editable')
     slot
 
     button.button.is-small.is-outlined.c-inline-button(
@@ -51,7 +51,7 @@ transition(name='replace-list')
       i.icon-pencil-alt.is-prefix
       | {{ L('Edit') }}
 
-  li.c-spacer-above(v-else-if='isUnfilled' key='isUnfilled')
+  li.c-spacer-above(v-else-if='isUnfilled' data-test='unfilled' key='unfilled')
     button.button.is-small(
       data-test='addNonMonetaryContribution'
       :class='itemClasses'
@@ -59,7 +59,7 @@ transition(name='replace-list')
     )
       slot
 
-  li(v-else='' :class='itemClasses' key='basic')
+  li(v-else='' :class='itemClasses' data-test='basic' key='basic')
     slot
 </template>
 
@@ -244,7 +244,7 @@ export default {
 .c-buttons-right {
   display: flex;
   justify-content: flex-end;
-  width: 100%;
+  flex-grow: 1;
 }
 
 .button + .c-buttons-right {

--- a/test/cypress/integration/group-payments.spec.js
+++ b/test/cypress/integration/group-payments.spec.js
@@ -14,6 +14,15 @@ function addNonMonetaryContribution (name) {
   cy.getByDT('addNonMonetaryContribution', 'button').click()
   cy.getByDT('inputNonMonetaryContribution').type(name)
   cy.getByDT('buttonAddNonMonetaryContribution', 'button').click()
+  cy.getByDT('buttonAddNonMonetaryContribution', 'button').should('not.exist')
+
+  // Assert the contribution was added to the list once
+  cy.getByDT('givingList').should($list => {
+    const contribution = $list.find('li').filter((i, item) => {
+      return item.textContent.includes(name) && item.getAttribute('data-test') === 'editable'
+    })
+    expect(contribution).to.have.length(1)
+  })
 }
 
 function assertNonMonetaryEditableValue (name) {
@@ -292,36 +301,40 @@ describe('Payments', () => {
     cy.getByDT('closeProfileCard').click()
   })
 
+  const firstContribution = 'Portuguese classes'
+
   it('user1 adds non monetary contribution', () => {
-    addNonMonetaryContribution('Portuguese classes')
+    addNonMonetaryContribution(firstContribution)
 
     cy.getByDT('givingList', 'ul')
       .get('li.is-editable')
       .should('have.length', 1)
-      .should('contain', 'Portuguese classes')
+      .should('contain', firstContribution)
   })
 
   it('user1 removes non monetary contribution', () => {
+    cy.getByDT('buttonEditNonMonetaryContribution')
+
+    cy.getByDT('givingList').find('li').should('have.length', 2) // contribution + cta to add
     cy.getByDT('buttonEditNonMonetaryContribution').click()
     cy.getByDT('buttonRemoveNonMonetaryContribution').click()
-    cy.getByDT('givingList', 'ul')
-      .get('li.is-editable')
-      .should('have.length', 0)
+    cy.getByDT('givingList').find('li').should('have.length', 1) // cta to add
+    cy.getByDT('givingParagraph').should('exist')
   })
 
   it('user1 re-adds the same non monetary contribution', () => {
-    addNonMonetaryContribution('Portuguese classes')
+    addNonMonetaryContribution(firstContribution)
     cy.getByDT('givingList', 'ul')
       .get('li.is-editable')
       .should('have.length', 1)
-      .should('contain', 'Portuguese classes')
+      .should('contain', firstContribution)
   })
 
   it('user1 edits the non monetary contribution', () => {
     cy.getByDT('buttonEditNonMonetaryContribution').click()
     cy.getByDT('inputNonMonetaryContribution').clear().type('French classes{enter}')
     assertNonMonetaryEditableValue('French classes')
-    // Double check
+    // Double check // TODO - Why do we need this?
     assertNonMonetaryEditableValue('French classes')
 
     cy.getByDT('givingList', 'ul')


### PR DESCRIPTION
There is an unstable test happening from time to time, for a while now [(see example)](https://dashboard.cypress.io/projects/q6whky/runs/577/specs?utm_source=github) related to Contributions page: _"user1 removes non monetary contribution"_

The error:
```
     CypressError: cy.type() can only be called on a single element. Your subject contained 2 elements.
```

The screenshot:
![cypress-screenshot](https://user-images.githubusercontent.com/14869087/82752976-ec77b480-9db9-11ea-887d-33f9ef0bf269.png)


The related cypress test:

```js
  it('user1 removes non monetary contribution', () => {
    cy.getByDT('buttonEditNonMonetaryContribution').click()
    cy.getByDT('buttonRemoveNonMonetaryContribution').click()
    cy.getByDT('givingList', 'ul')	 
      .get('li.is-editable')	    
      .should('have.length', 0)
  })

it('user1 re-adds the same non monetary contribution', () => {
    addNonMonetaryContribution(firstContribution)
    // ...
});
```

So, the error happens because we did not assert correctly the first contribution was removed.

### Detailed explanation of the bug:
Verifying that `li.is-editable` does not exist is not enough to make sure the "remove action" was successful because that assertion is also true when we are still removing the element. So, even if the "remove action" is still happening or failed, the test would pass and move to the next one.

Then in comes the next step with a group of assertions `addNonMonetaryContribution()`. After we do the first part (clicking Add), we end up with a layout similar to the screenshot above.

So, that leads us to the next assertions: typing the contribution in the input field:
```
cy.getByDT('inputNonMonetaryContribution').type(name)
```

But because the first contribution is still being removed, as explained before, there are now two inputs, causing the test to fail.

### In summary: 
- **Force the test to fail to make sure it works properly:** - In this case, even if we commented `cy.getByDT('buttonRemoveNonMonetaryContribution').click()` the test would still pass.
- **Make sure any async action result is completed before moving to the next step** - An async action in this context is anything related to async `sbp` calls that _"talk"_ with the DB.

### Extra stuff
- I also verified all the other tests in this spec looking for other async actions without proper result assertion and added the missing assertion. (e.g. `addNonMonetaryContribution()`)
- Fixed a bug in the contribution UI layout: "Remove" is now in the same line as "Cancel" and "Save".

