### PR TITLE
#913 - Prevent InvitationsTable to break in case there are no invites

### DIFF
--- a/frontend/views/containers/group-settings/InvitationsTable.vue
+++ b/frontend/views/containers/group-settings/InvitationsTable.vue
@@ -210,6 +210,9 @@ export default {
     ...mapState(['currentGroupId']),
     invitesToShow () {
       const { invites } = this.currentGroupState
+
+      if (!invites) { return [] }
+
       const invitesList = Object.values(invites)
         .filter(invite => invite.creator === INVITE_INITIAL_CREATOR || invite.creator === this.ourUsername)
         .map(this.mapInvite)


### PR DESCRIPTION
Closes #913

The error happens because the state is cleared on logout before redirecting the user to the homepage. The fix for this particular error is to prevent the `InvitationsTable` from breaking in case there are no invitations.