### PR TITLE
#914 fix bug pressing enter to login

### DIFF
--- a/frontend/views/containers/access/LoginForm.vue
+++ b/frontend/views/containers/access/LoginForm.vue
@@ -15,7 +15,7 @@ form(data-test='login' @submit.prevent='')
 
   password-form(:label='L("Password")' name='password' :$v='$v')
 
-  i18n.link.c-forgot(tag='button' @click='forgotPassword') Forgot your password?
+  i18n.link.c-forgot(tag='button' type='button' @click='forgotPassword') Forgot your password?
 
   banner-scoped(ref='formMsg' data-test='loginError')
 


### PR DESCRIPTION
Fix #914

Pressing enter wasn't submitting the form (login) because the first button inside the form is the recover password. A button inside a form needs `type="button"` to prevent being interpreted as a submit button.