### PR TITLE
fix: Exclude inactive members from members count

### DIFF
--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -244,7 +244,7 @@ DefineContract({
       return monthstamp => groupIncomeDistribution({ state, getters, monthstamp, adjusted: true })
     },
     groupMembersByUsername (state, getters) {
-      return Object.keys(getters.currentGroupState.profiles || {})
+      return Object.keys(getters.groupProfiles)
     },
     groupMembersCount (state, getters) {
       return getters.groupMembersByUsername.length

--- a/test/cypress/integration/group-member-removal.spec.js
+++ b/test/cypress/integration/group-member-removal.spec.js
@@ -228,7 +228,26 @@ describe('Group - Removing a member', () => {
 
     // User2 is part of only one group now.
     cy.getByDT('groupName').should('contain', groupNameB)
+  })
 
+  it('user2 rejoins the groupA', () => {
+    // Wait for contracts to sync before visiting invitationLink. TODO avoid .wait().
+    cy.wait(500); // eslint-disable-line
+    cy.giAcceptGroupInvite(invitationLinks.anyone_groupA, {
+      username: `user2-${userId}`,
+      groupName: groupNameA,
+      isLoggedIn: true,
+      shouldLogoutAfter: false
+    })
+    assertMembersCount(2)
+  })
+
+  it('user1 removes user2 from groupA', () => {
+    // this covers edge case scenario described at #944
+    cy.giSwitchUser(`user1-${userId}`)
+
+    openRemoveMemberModal('user2', 1)
+    removeMemberNow('user2')
     cy.giLogout()
   })
 })


### PR DESCRIPTION
Closes #944.

The original issue is about "Can't remove members when group size less than 3". This bug only happens if we try to remove a member in a group of 2 members that already had 3 or more members in the past. We are prompt to create a proposal instead of immediate removal.

Actually, this "proposal issue" happens with any kind of change (e.g. try to change the mincome and it will prompt you to create a proposal instead of being an immediate change.)

The **cause** was quite simple. Since #900, removed members are kept on the list of members but with a status `"removed"`. We were counting all members regardless of their status. From now on, the counting excludes members that are not `"active"`.
