### PR TITLE
#865 Improve mincome inputs ux

### DIFF
--- a/frontend/views/components/group-creation-steps/GroupMincome.vue
+++ b/frontend/views/components/group-creation-steps/GroupMincome.vue
@@ -3,9 +3,12 @@
   i18n.is-title-4.steps-title(tag='h4') 3. Minimum Income
 
   .card
-    fieldset
+    fieldset.field
       i18n.label What is the minimum each member should receive monthly?
-      .selectgroup
+      .selectgroup(
+        :class='{ error: $v.form.mincomeAmount.$error }'
+        v-error:mincomeAmount=''
+      )
         input.input(
           ref='mincome'
           inputmode='decimal'
@@ -16,7 +19,6 @@
           step='1'
           min='0'
           required=''
-          :class='{ error: $v.form.mincomeAmount.$error }'
           :value='group.mincomeAmount'
           @input='update'
           @keyup.enter='next'
@@ -34,7 +36,7 @@
             :key='code'
           ) {{ currency.symbolWithCode }}
 
-    i18n.has-text-1 This value can be adjusted in the future.
+      i18n.helper This value can be adjusted in the future.
 
     slot
 </template>

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -64,7 +64,7 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
 
     group-pledges-graph.c-graph(
       :type='form.incomeDetailsType'
-      :amount='form.amount === "" ? undefined : +form.amount'
+      :amount='form.amount === "" ? undefined : saferFloat(form.amount)'
     )
 </template>
 
@@ -72,7 +72,7 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
 import { mapGetters } from 'vuex'
 import { validationMixin } from 'vuelidate'
 import { required } from 'vuelidate/lib/validators'
-import { decimals } from '@view-utils/validators.js'
+import currencies, { mincomePositive, saferFloat } from '@view-utils/currencies.js'
 import sbp from '~/shared/sbp.js'
 import PaymentMethods from './PaymentMethods.vue'
 import GroupPledgesGraph from './GroupPledgesGraph.vue'
@@ -150,6 +150,7 @@ export default {
     }
   },
   methods: {
+    saferFloat,
     resetAmount () {
       this.form.amount = this.form.incomeDetailsType === this.ourGroupProfile.incomeDetailsType ? this.ourGroupProfile[this.ourGroupProfile.incomeDetailsType] : ''
       this.$v.form.$reset()
@@ -192,7 +193,7 @@ export default {
         const groupProfileUpdate = await sbp('gi.contracts/group/groupProfileUpdate/create',
           {
             incomeDetailsType,
-            [incomeDetailsType]: +this.form.amount,
+            [incomeDetailsType]: saferFloat(this.form.amount),
             paymentMethods
           },
           this.$store.state.currentGroupId
@@ -211,11 +212,13 @@ export default {
         [L('This field is required')]: required
       },
       amount: {
-        [L('Oops, you entered a negative number')]: v => v >= 0,
-        [L('The amount cannot have more than 2 decimals')]: decimals(2),
+        [L('Oops, you entered 0 or a negative number')]: mincomePositive,
+        [L('The amount has too many decimals')]: function (value) {
+          return currencies[this.groupSettings.mincomeCurrency].validate(value)
+        },
         [L('This field is required')]: required,
         [L('Your income must be lower than the group mincome')]: function (value) {
-          return !this.needsIncome || value < this.groupSettings.mincomeAmount
+          return !this.needsIncome || saferFloat(value) < this.groupSettings.mincomeAmount
         }
       }
     }

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -212,11 +212,11 @@ export default {
         [L('This field is required')]: required
       },
       amount: {
+        [L('This field is required')]: required,
         [L('Oops, you entered 0 or a negative number')]: mincomePositive,
         [L('The amount must be a number. (E.g. 100.75)')]: function (value) {
           return currencies[this.groupSettings.mincomeCurrency].validate(value)
         },
-        [L('This field is required')]: required,
         [L('Your income must be lower than the group mincome')]: function (value) {
           return !this.needsIncome || saferFloat(value) < this.groupSettings.mincomeAmount
         }

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -213,7 +213,7 @@ export default {
       },
       amount: {
         [L('Oops, you entered 0 or a negative number')]: mincomePositive,
-        [L('The amount has too many decimals')]: function (value) {
+        [L('The amount must be a number. (E.g. 100.75)')]: function (value) {
           return currencies[this.groupSettings.mincomeCurrency].validate(value)
         },
         [L('This field is required')]: required,

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -165,10 +165,10 @@ export default {
       groupPicture: { },
       sharedValues: { },
       mincomeAmount: {
-        required,
-        positive: mincomePositive,
-        decimals: function (val) {
-          return currencies[this.form.mincomeCurrency].validate(val)
+        [L('This field is required')]: required,
+        [L('Oops, you entered 0 or a negative number')]: mincomePositive,
+        [L('The amount must be a number. (E.g. 100.75)')]: function (value) {
+          return currencies[this.form.mincomeCurrency].validate(value)
         }
       },
       mincomeCurrency: {

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -55,8 +55,8 @@ import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import { RULE_PERCENTAGE, RULE_DISAGREEMENT } from '@model/contracts/voting/rules.js'
 import proposals from '@model/contracts/voting/proposals.js'
 import { PROPOSAL_GENERIC } from '@model/contracts/voting/constants.js'
+import currencies, { mincomePositive, saferFloat } from '@view-utils/currencies.js'
 import L from '@view-utils/translations.js'
-import { decimals } from '@view-utils/validators.js'
 import StepAssistant from '@view-utils/stepAssistant.js'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
@@ -113,7 +113,7 @@ export default {
           name: this.form.groupName,
           picture: this.ephemeral.groupPictureFile,
           sharedValues: this.form.sharedValues,
-          mincomeAmount: this.form.mincomeAmount,
+          mincomeAmount: saferFloat(this.form.mincomeAmount),
           mincomeCurrency: this.form.mincomeCurrency,
           ruleName: this.form.ruleName,
           ruleThreshold: this.form.ruleThreshold[this.form.ruleName]
@@ -166,8 +166,10 @@ export default {
       sharedValues: { },
       mincomeAmount: {
         required,
-        minValue: (val) => val > 0,
-        decimals: decimals(2)
+        positive: mincomePositive,
+        decimals: function (val) {
+          return currencies[this.form.mincomeCurrency].validate(val)
+        }
       },
       mincomeCurrency: {
         required

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -10,7 +10,10 @@
 
     label.field(v-if='ephemeral.currentStep === 0' key='0')
       i18n.label New minimum income
-      .inputgroup(:class='{ error: $v.form.mincomeAmount.$error }')
+      .inputgroup(
+        :class='{ error: $v.form.mincomeAmount.$error }'
+        v-error:mincomeAmount=''
+      )
         input.input(
           v-model='$v.form.mincomeAmount.$model'
           name='mincomeAmount'
@@ -69,10 +72,10 @@ export default {
   validations: {
     form: {
       mincomeAmount: {
-        required,
-        positive: mincomePositive,
-        decimals: function (val) {
-          return currencies[this.groupSettings.mincomeCurrency].validate(val)
+        [L('This field is required')]: required,
+        [L('Oops, you entered 0 or a negative number')]: mincomePositive,
+        [L('The amount must be a number. (E.g. 100.75)')]: function (value) {
+          return currencies[this.groupSettings.mincomeCurrency].validate(value)
         }
       }
     },

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -28,7 +28,7 @@ import sbp from '~/shared/sbp.js'
 import { validationMixin } from 'vuelidate'
 import { required } from 'vuelidate/lib/validators'
 import { mapGetters, mapState } from 'vuex'
-import { decimals } from '@view-utils/validators.js'
+import currencies, { mincomePositive, saferFloat } from '@view-utils/currencies.js'
 import L, { LError } from '@view-utils/translations.js'
 import ProposalTemplate from './ProposalTemplate.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
@@ -63,8 +63,10 @@ export default {
     form: {
       mincomeAmount: {
         required,
-        minValue: value => value > 0,
-        decimals: decimals(2)
+        positive: mincomePositive,
+        decimals: function (val) {
+          return currencies[this.groupSettings.mincomeCurrency].validate(val)
+        }
       }
     },
     // validation groups by route name for steps
@@ -88,7 +90,7 @@ export default {
   },
   methods: {
     async submit (form) {
-      const mincomeAmount = parseInt(this.form.mincomeAmount, 10)
+      const mincomeAmount = saferFloat(this.form.mincomeAmount)
       this.$refs.formMsg.clean()
 
       if (this.groupShouldPropose) {

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -59,6 +59,13 @@ export default {
       }
     }
   },
+  watch: {
+    'ephemeral.currentStep': function (step) {
+      if (step === 1) {
+        this.validateMincome()
+      }
+    }
+  },
   validations: {
     form: {
       mincomeAmount: {
@@ -89,9 +96,22 @@ export default {
     ])
   },
   methods: {
-    async submit (form) {
+    validateMincome () {
       const mincomeAmount = saferFloat(this.form.mincomeAmount)
+      if (mincomeAmount === this.groupSettings.mincomeAmount) {
+        this.$refs.formMsg.danger(L('The new mincome should be different than the current one.'))
+        this.ephemeral.currentStep = 0
+        return false
+      }
       this.$refs.formMsg.clean()
+      return true
+    },
+    async submit (form) {
+      if (!this.validateMincome()) {
+        return
+      }
+
+      const mincomeAmount = saferFloat(this.form.mincomeAmount)
 
       if (this.groupShouldPropose) {
         try {

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -7,8 +7,38 @@
 // this value, switch to a different currency base, e.g. from BTC to mBTC.
 export const DECIMALS_MAX = 8
 
-export function saferFloat (value: number): number {
-  return parseFloat(value.toFixed(DECIMALS_MAX))
+function commaToDots (value) {
+  // ex: "1,55" -> "1.55"
+  return typeof value === 'string' ? value.replace(/,/, '.') : value
+}
+
+function isNumeric (nr) {
+  return !isNaN(nr - parseFloat(nr))
+}
+
+function isInDecimalsLimit (nr, currency) {
+  const decimals = nr.toString().split('.')[1]
+  return !decimals || decimals.length <= currencies[currency].decimalsMax
+}
+
+function validateMincome (value, currency) {
+  const nr = commaToDots(value)
+  return isNumeric(nr) && isInDecimalsLimit(nr, currency)
+}
+
+function decimalsOrInt (num: number, currency: string): string {
+  const fixed = parseFloat(num.toFixed(currencies[currency].decimalsMax))
+  const integerPart = /^(.+)\.0+$/.exec(fixed)
+  return integerPart ? integerPart[1] : fixed
+}
+
+export function saferFloat (value): number {
+  // ex: "1,333333333333333333" -> 1.33333333
+  return parseFloat(parseFloat(commaToDots(value)).toFixed(DECIMALS_MAX))
+}
+
+export function mincomePositive (value): boolean {
+  return parseFloat(commaToDots(value)) > 0
 }
 
 // NOTE: if we needed for some reason, this could also be defined in
@@ -21,29 +51,25 @@ const currencies = {
     symbolWithCode: '$ USD',
     decimalsMax: 2,
     displayWithCurrency: n => '$' + decimalsOrInt(n, 'USD'),
-    displayWithoutCurrency: n => decimalsOrInt(n, 'USD')
+    displayWithoutCurrency: n => decimalsOrInt(n, 'USD'),
+    validate: n => validateMincome(n, 'USD')
   },
   EUR: {
     symbol: '€',
     symbolWithCode: '€ EUR',
     decimalsMax: 2,
     displayWithCurrency: n => '€' + decimalsOrInt(n, 'EUR'),
-    displayWithoutCurrency: n => decimalsOrInt(n, 'EUR')
-
+    displayWithoutCurrency: n => decimalsOrInt(n, 'EUR'),
+    validate: n => validateMincome(n, 'EUR')
   },
   BTC: {
     symbol: 'Ƀ',
     symbolWithCode: 'Ƀ BTC',
     decimalsMax: DECIMALS_MAX,
     displayWithCurrency: n => decimalsOrInt(n, 'BTC') + 'Ƀ',
-    displayWithoutCurrency: n => decimalsOrInt(n, 'BTC')
+    displayWithoutCurrency: n => decimalsOrInt(n, 'BTC'),
+    validate: n => validateMincome(n, 'BTC')
   }
-}
-
-function decimalsOrInt (num: number, currency: string): string {
-  const fixed = num.toFixed(currencies[currency].decimalsMax)
-  const integerPart = /^(.+)\.0+$/.exec(fixed)
-  return integerPart ? integerPart[1] : fixed
 }
 
 export default currencies


### PR DESCRIPTION
Closes #865

![image](https://user-images.githubusercontent.com/14869087/86058607-16776300-ba59-11ea-80e4-ada0b924c0aa.png)

- Support mincome with decimals based on group currency, using comma or dots

#### Places updated:
- Group Creations (mincome step) 
- Proposal to change mincome
- Update Income Details
- _somewhere missing? let me know!_

#### Scenarios covered:
- Decimals using comma or dots. E.g. `1,55` and `1.55` are both valid.
- Add decimals limit
  - EUR/USD: 2 (e.g. `100.50`)
  - BTC: 8 (e.g. `0.12345678`)
- 0 (zero) or negative mincome not allowed.


For future development reference:

- Use `saferFloat` when saving an amount based on an input value.
- Use `currencies[currency].validate()` to validate a currency amount value

```js
import currencies, { mincomePositive, saferFloat } from '@view-utils/currencies.js'

// ex: change the mincome...
const updatedSettings = await sbp('gi.contracts/group/updateSettings/create', {
  mincomeAmount: saferFloat(this.form.mincomeAmount) // e.g. "1,5" is converted to 1.5 
}, this.currentGroupId)

// ex: validating the mincome
validations: {
     mincomeAmount: {
        positive: mincomePositive,
        decimals: function (amount) {
          // e.g. USD - "1,55" is valid but "1.789" is not valid.
          return currencies["USD"].validate(amount)
        }
      },
    }
}
```