### PR TITLE
#763 Payments - improve search, tabs and tests

### DIFF
--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -347,6 +347,7 @@ const getters = {
     return monthstamp => groupIncomeDistribution({ state, getters, monthstamp, adjusted: true })
   },
   ourPayments (state, getters) {
+    // Payments relative to the current month only
     const currency = currencies[getters.groupSettings.mincomeCurrency]
     const ourUsername = getters.ourUsername
     const cMonthstamp = currentMonthstamp()
@@ -354,26 +355,23 @@ const getters = {
     const dueIn = lastDayOfMonth(pDate)
     const monthlyPayments = getters.groupMonthlyPayments
     const allPayments = getters.currentGroupState.payments
+    const thisMonthPayments = monthlyPayments[cMonthstamp]
+    const paymentsFrom = thisMonthPayments && thisMonthPayments.paymentsFrom
 
     const sent = (() => {
       const payments = []
-      for (const monthstamp of Object.keys(monthlyPayments).sort()) {
-        const { paymentsFrom } = monthlyPayments[monthstamp]
 
-        if (paymentsFrom) {
-          for (const toUser in paymentsFrom[getters.ourUsername]) {
-            for (const paymentHash of paymentsFrom[getters.ourUsername][toUser]) {
-              const { data, meta } = allPayments[paymentHash]
-              payments.push({ hash: paymentHash, data, meta })
-            }
+      if (paymentsFrom) {
+        for (const toUser in paymentsFrom[getters.ourUsername]) {
+          for (const paymentHash of paymentsFrom[getters.ourUsername][toUser]) {
+            const { data, meta } = allPayments[paymentHash]
+            payments.push({ hash: paymentHash, data, meta })
           }
         }
       }
       return payments
     })()
     const received = (() => {
-      const thisMonthPayments = monthlyPayments[cMonthstamp]
-      const paymentsFrom = thisMonthPayments && thisMonthPayments.paymentsFrom
       const payments = []
 
       if (paymentsFrom) {

--- a/frontend/views/components/Search.vue
+++ b/frontend/views/components/Search.vue
@@ -17,7 +17,7 @@ form.c-search-form(
         @input='$emit("input", $event.target.value)'
       )
       .addons
-        button.is-icon-small(
+        button.c-clear.is-icon-small(
           v-if='value !== ""'
           :aria-label='L("Clear search")'
           @click='$emit("input", "")'
@@ -64,6 +64,27 @@ export default {
     display: flex;
     align-items: center;
     margin-right: 0.5rem;
+  }
+
+  // hide close by default...
+  .input + .addons button {
+    opacity: 0;
+  }
+
+  // visible when interacted
+  .input:focus + .addons .c-clear,
+  .c-clear:hover,
+  .c-clear:focus {
+    opacity: 1;
+  }
+
+  .c-clear {
+    background-color: $general_2;
+
+    &:hover,
+    &:focus {
+      background-color: $general_1;
+    }
   }
 }
 </style>

--- a/frontend/views/components/Search.vue
+++ b/frontend/views/components/Search.vue
@@ -13,6 +13,7 @@ form.c-search-form(
         data-test='search'
         :placeholder='placeholder'
         :value='value'
+        @keyup.esc='$emit("input", "")'
         @input='$emit("input", $event.target.value)'
       )
       .addons

--- a/frontend/views/containers/payments/MonthOverview.vue
+++ b/frontend/views/containers/payments/MonthOverview.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-.c-summary
+.c-summary(data-test='monthOverview')
   i18n.c-summary-title.is-title-4(
     tag='h4'
     data-test='thisMonth'
@@ -84,14 +84,14 @@ export default {
           value: amountDone,
           max: amountTotal,
           hasMarks: false,
-          label: L('{value} of {max}', {
+          label: L('{value} out of {max}', {
             value: this.currency(amountDone),
             max: this.currency(amountTotal)
           })
         })
       } else {
         pS.push({
-          title: L('Amout sent'),
+          title: L('Amount sent'),
           value: amountDone,
           max: amountTotal,
           hasMarks: false,

--- a/frontend/views/containers/payments/PaymentDetail.vue
+++ b/frontend/views/containers/payments/PaymentDetail.vue
@@ -3,11 +3,11 @@ modal-template(ref='modal' v-if='payment' :a11yTitle='L("Payment details")')
   template(slot='title')
     i18n Payment details
 
-  .is-title-2.c-title {{ withCurrency(payment.data.amount) }}
-  .c-subtitle.has-text-1 {{ subtitleCopy }}
+  .is-title-2.c-title(data-test='amount') {{ withCurrency(payment.data.amount) }}
+  .c-subtitle.has-text-1(data-test='subtitle') {{ subtitleCopy }}
 
   //- TODO This should be a table...
-  ul.c-payment-list
+  ul.c-payment-list(data-test='details')
     li.c-payment-list-item
       i18n.has-text-1 Date & Time
       strong {{ humanDate(this.payment.date, { year: 'numeric', month: 'long', day: 'numeric', hour: '2-digit', minute: '2-digit' }) }}

--- a/frontend/views/containers/payments/PaymentsPagination.vue
+++ b/frontend/views/containers/payments/PaymentsPagination.vue
@@ -7,14 +7,14 @@
     label.selectsolo.c-select
       i18n.sr-only Show per page
       select.select(
-        ref='select'
+        :value='rowsPerPage'
         @change='updatePagination'
       )
         option(
-          v-for='numberPerPage in [10, 20, 30]'
-          :index='numberPerPage'
-          :value='numberPerPage'
-        ) {{ `${numberPerPage} ${L('results')}` }}
+          v-for='count in config.options'
+          :index='count'
+          :value='count'
+        ) {{ `${count} ${L('results')}` }}
     i18n.has-text-1(
       tag='span' aria-hidden='true'
     ) per page
@@ -23,17 +23,19 @@
     i18n.has-text-1(
       tag='p'
       data-test='paginationInfo'
-      :args='{ currentPage: `<span class="has-text-0">1 — 5</span>`, maxPages: `<span class="has-text-0">5</span>`}'
-    ) {currentPage} out of {maxPages}
+      :args='paginationInfo'
+    ) {currentPage} out of {count}
 
     .c-previous-next
-      button.c-control.is-unstyled(
+      button.is-icon-small.c-btn(
+        :disabled='page === 0'
         @click='previousPage'
         :aria-label='L("Previous page")'
       )
         i.icon-chevron-left
 
-      button.c-control.is-unstyled(
+      button.is-icon-small.c-btn(
+        :disabled='page + 1 >= maxPages'
         @click='nextPage'
         :aria-label='L("Next page")'
       )
@@ -43,15 +45,41 @@
 <script>
 export default {
   name: 'PaymentsPagination',
+  props: {
+    count: Number,
+    page: Number,
+    rowsPerPage: Number
+    // @changePage('next'|'prev')
+    // @changeRowsPerPage(String) // Page Number
+  },
+  data: () => ({
+    config: {
+      options: [10, 20, 30]
+    }
+  }),
+  computed: {
+    maxPages () {
+      return Math.ceil(this.count / this.rowsPerPage)
+    },
+    paginationInfo () {
+      const style = text => `<span class="has-text-0">${text}</span>`
+      const start = this.rowsPerPage * this.page
+      const currentRows = `${start + 1} - ${Math.min(start + this.rowsPerPage, this.count)}`
+      return {
+        currentPage: style(currentRows),
+        count: style(this.count)
+      }
+    }
+  },
   methods: {
-    updatePagination () {
-      console.log('Todo: implement update pagination settings')
+    updatePagination (e) {
+      this.$emit('changeRowsPerPage', +e.target.value)
     },
     previousPage () {
-      console.log('Todo: implement previous page functionality')
+      this.$emit('changePage', 'prev')
     },
     nextPage () {
-      console.log('Todo: implement next page functionality')
+      this.$emit('changePage', 'next')
     }
   }
 }
@@ -71,13 +99,19 @@ export default {
   margin: 0 0.5rem;
 }
 
-.c-control {
-  width: 1.7rem;
-  height: 1.7rem;
-  border-radius: 50%;
-  color: $general_0;
+.c-btn {
   background-color: $general_2;
   margin: 0 0.25rem;
+
+  &[disabled] {
+    background-color: $general_2;
+    color: $general_0;
+  }
+
+  &:hover,
+  &:focus {
+    background-color: $general_0;
+  }
 
   &:first-child i {
     margin-left: -1px;
@@ -85,11 +119,6 @@ export default {
 
   &:last-child i {
     margin-right: -1px;
-  }
-
-  &::hover {
-    color: $text_0;
-    background-color: $general_0;
   }
 }
 </style>

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -76,7 +76,7 @@ page(
               ) Record payments
             payments-pagination(v-else)
 
-        .c-container-empty(v-else)
+        .c-container-empty(v-else data-test='noPayments')
           svg-contributions.c-svg
           i18n.c-description(tag='p') There are no payments.
 </template>

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -48,7 +48,7 @@ page(
           span.tabs-notification(v-if='link.notification') {{ link.notification }}
 
       search(
-        v-if='paymentsListData.length > 0'
+        v-if='paymentsListData.length && ephemeral.activeTab !== "PaymentRowTodo"'
         :placeholder='L("Search payments...")'
         :label='L("Search for a payment")'
         v-model='form.search'
@@ -75,7 +75,8 @@ page(
                 @click='openModal("RecordPayment")'
               ) Record payments
             payments-pagination(v-else)
-
+        .c-container-noresults(v-else-if='paymentsListData.length && !paymentsFiltered.length' data-test='noResults')
+          i18n(tag='p' :args='{query: form.search }') No results for "{query}".
         .c-container-empty(v-else data-test='noPayments')
           svg-contributions.c-svg
           i18n.c-description(tag='p') There are no payments.
@@ -158,8 +159,7 @@ export default {
 
         items.push({
           title: L('Sent'),
-          url: 'PaymentRowSent',
-          notification: this.paymentsSent.length
+          url: 'PaymentRowSent'
         })
       }
 
@@ -169,16 +169,14 @@ export default {
       if (doesNotNeedIncomeAndDidReceiveBefore || doesNeedIncomeAndDidSentBefore) {
         items.push({
           title: L('Received'),
-          url: 'PaymentRowReceived',
-          notification: this.paymentsReceived.length
+          url: 'PaymentRowReceived'
         })
       }
 
       if (doesNeedIncomeAndDidSentBefore) {
         items.push({
           title: L('Sent'),
-          url: 'PaymentRowSent',
-          notification: this.paymentsSent.length
+          url: 'PaymentRowSent'
         })
       }
 
@@ -340,7 +338,6 @@ export default {
   margin-top: 1.5rem;
 }
 
-// Empty
 .c-container-empty {
   max-width: 25rem;
   margin: 0 auto;
@@ -363,6 +360,10 @@ export default {
     margin-left: -0.5rem;
     filter: contrast(0%) brightness(172%);
   }
+}
+
+.c-container-noresults {
+  padding-top: 1.5rem;
 }
 
 .card .c-container-empty {

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -8,7 +8,7 @@ page(
 )
   template(#title='') {{ L('Payments') }}
 
-  template(#sidebar='' v-if='hasIncomeDetails')
+  template(#sidebar='' v-if='tabItems.length > 0 || paymentsListData.length > 0')
     month-overview
 
   add-income-details-widget(v-if='!hasIncomeDetails')

--- a/test/cypress/integration/group-paying.spec.js
+++ b/test/cypress/integration/group-paying.spec.js
@@ -118,7 +118,7 @@ describe('Group Payments', () => {
       cy.getByDT('amount').should('contain', '$71.43')
       cy.getByDT('subtitle').should('contain', `Sent to user2-${userId}`)
 
-      cy.getByDT('details').find('li:nth-child(1)').should('contain', humanDate(timeStart, { month: 'long', year: 'numeric' }))
+      cy.getByDT('details').find('li:nth-child(2)').should('contain', humanDate(timeStart, { month: 'long', year: 'numeric' }))
       cy.getByDT('details').find('li:nth-child(3)').should('contain', '$1000')
     })
     cy.closeModal()
@@ -171,7 +171,7 @@ describe('Group Payments', () => {
     cy.getByDT('payList').within(() => {
       cy.getByDT('payRow').eq(1).find('td:nth-child(1)').should('contain', `user3-${userId}`)
       cy.getByDT('payRow').eq(1).find('td:nth-child(2)').should('contain', '$100')
-      cy.getByDT('payRow').eq(1).find('td:nth-child(3)').should('contain', 'Feb 10')
+      cy.getByDT('payRow').eq(1).find('td:nth-child(3)').should('contain', humanDateToday)
     })
 
     cy.log('user3 confirms the received payment')
@@ -230,7 +230,7 @@ describe('Group Payments', () => {
     /*
     assertNavTabs(['Todo3', 'Sent2'])
     */
-    // TODO: Assert each payment data. 1 late (Feb 29) and 2 new (Mar 31).
+    // TODO: Assert each payment data. 1 late and 2 new.
     /*
     cy.getByDT('recordPayment').click()
     cy.getByDT('modal').within(() => {


### PR DESCRIPTION
Continue #763

- Making the ESC key clear the search field
- Fixing a bug where if we switched from sending payments to receiving payments, we suddenly lose the "Sent" tab
- Continue tests
- @mmbotelho can you review if the UI and data are correct when the user changes between receiving and giving mincome?

### Update 10 July

- Make payments pagination functional.

**Tip:** You can create N payments manually and see the pagination work... or you can create *dummy sent payments* by following these steps:
1. Create a group with members and **send at least one payment**.
2. Go to `views/pages/Payments.vue`. Inside the function `paymentsSent ()` (~line 260-275) there's a block of code commented. Uncomment it from `/*` to `*/`. You can change the variable `copies` to customize the number of dummy payments.
3. Save it and the page should refresh within a few seconds. _Voilà!_