### PR TITLE
#961 Implement i18n

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -168,9 +168,9 @@ route.GET('/file/{hash}', {}, function (request, h) {
   }
 })
 
-route.GET('/translations/get/{language}', {}, function (request, h) {
+route.GET('/translations/get/{language}', {}, async function (request, h) {
   try {
-    return sbp('backend/translations/get', request.params.language)
+    return await sbp('backend/translations/get', request.params.language)
   } catch (err) {
     logger(err)
     return Boom.notFound()

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -8,6 +8,7 @@ import { blake32Hash } from '~/shared/functions.js'
 import { SERVER_INSTANCE } from './instance-keys.js'
 import chalk from 'chalk'
 import './database.js'
+import './translations.js'
 
 const Boom = require('@hapi/boom')
 const Joi = require('@hapi/joi')
@@ -161,6 +162,15 @@ route.POST('/file', {
 route.GET('/file/{hash}', {}, function (request, h) {
   try {
     return sbp('backend/db/readFile', request.params.hash)
+  } catch (err) {
+    logger(err)
+    return Boom.notFound()
+  }
+})
+
+route.GET('/translations/get/{language}', {}, function (request, h) {
+  try {
+    return sbp('backend/translations/get', request.params.language)
   } catch (err) {
     logger(err)
     return Boom.notFound()

--- a/backend/translations.js
+++ b/backend/translations.js
@@ -29,7 +29,9 @@ export default sbp('sbp/selectors/register', {
     try {
       return await readFileAsync(filePath)
     } catch (error) {
-      throw new Error(`No translation file was found for ${language}.`)
+      throw new Error(
+        `Could not read translation file for language '${language}': ${error.message}`
+      )
     }
   }
 })

--- a/backend/translations.js
+++ b/backend/translations.js
@@ -29,7 +29,7 @@ export default sbp('sbp/selectors/register', {
     try {
       return await readFileAsync(filePath)
     } catch (error) {
-      throw new Error(`No translation file was found for language ${language}.`)
+      throw new Error(`No translation file was found for ${language}.`)
     }
   }
 })

--- a/backend/translations.js
+++ b/backend/translations.js
@@ -1,0 +1,35 @@
+'use strict'
+
+import fs from 'fs'
+import path from 'path'
+import util from 'util'
+
+import sbp from '~/shared/sbp.js'
+
+const readFileAsync = util.promisify(fs.readFile)
+
+const defaultLanguage = 'en-US'
+const languageDir = path.resolve('./strings')
+const languageFileExtension = '.json'
+const languageFileMap = new Map([
+  ['en', 'english.json'],
+  ['fr', 'french.json']
+])
+
+export default sbp('sbp/selectors/register', {
+  'backend/translations/get': async function (language: string): Promise<string> {
+    if (language === defaultLanguage) return ''
+    const [languageCode] = language.toLowerCase().split('-')
+    const fileName = languageFileMap.get(languageCode) || ''
+
+    // If we don't have a matching file yet,
+    // returns empty so that the UI stays in the default language.
+    if (!fileName || !fileName.endsWith(languageFileExtension)) return ''
+    const filePath = path.join(languageDir, fileName)
+    try {
+      return await readFileAsync(filePath)
+    } catch (error) {
+      throw new Error(`No translation file was found for language ${language}.`)
+    }
+  }
+})

--- a/frontend/controller/backend.js
+++ b/frontend/controller/backend.js
@@ -144,5 +144,9 @@ sbp('sbp/selectors/register', {
   'backend/latestHash': (contractID: string) => {
     return fetch(`${process.env.API_URL}/latestHash/${contractID}`)
       .then(handleFetchResult('text'))
+  },
+  'backend/translations/get': (language: string) => {
+    return fetch(`${process.env.API_URL}/translations/get/${language}`)
+      .then(handleFetchResult('json'))
   }
 })

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -60,6 +60,8 @@ async function startApp () {
     strategy: ['disconnect', 'online', 'timeout']
   })
 
+  await sbp('translations/init', navigator.language)
+
   const username = await sbp('gi.db/settings/load', SETTING_CURRENT_USER)
   if (username) {
     const identityContractID = await sbp('namespace/lookup', username)

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -51,7 +51,7 @@ sbp('sbp/selectors/register', {
       currentLanguage = language
       currentLanguageCode = languageCode
     } catch (error) {
-      console.log(error)
+      console.error(error)
     }
   }
 })

--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -9,9 +9,10 @@ Vue.prototype.LTags = LTags
 
 const defaultLanguage = 'en-US'
 const defaultLanguageCode = 'en'
-const defaultTranslationTable: { [string]: string }  = {}
+const defaultTranslationTable: { [string]: string } = {}
 
 let currentLanguage = defaultLanguage
+let currentLanguageCode = defaultLanguage.split('-')[0]
 let currentTranslationTable = defaultTranslationTable
 
 /**
@@ -25,7 +26,7 @@ let currentTranslationTable = defaultTranslationTable
  * @see https://tools.ietf.org/rfc/bcp/bcp47.txt
  */
 sbp('sbp/selectors/register', {
-  'translations/init': async function init(language: string): Promise<void> {
+  'translations/init': async function init (language: string): Promise<void> {
     // A language code is usually the first part of a language tag.
     const [languageCode] = language.toLowerCase().split('-')
 
@@ -38,8 +39,9 @@ sbp('sbp/selectors/register', {
 
     // Avoid fetching any ressource if the requested language is the default one.
     if (languageCode === defaultLanguageCode) {
-      currentLanguage === defaultLanguage
-      translationTable = defaultTranslationTable
+      currentLanguage = defaultLanguage
+      currentLanguageCode = defaultLanguageCode
+      currentTranslationTable = defaultTranslationTable
       return
     }
     try {
@@ -47,6 +49,7 @@ sbp('sbp/selectors/register', {
 
       // Only set `currentLanguage` if there was no error fetching the ressource.
       currentLanguage = language
+      currentLanguageCode = languageCode
     } catch (error) {
       console.log(error)
     }

--- a/strings/french.strings
+++ b/strings/french.strings
@@ -340,7 +340,7 @@
 "Change Mincome" = "Modifier le revenu minimum";
 
 /* views/components/modal/ModalClose.vue */
-"ESC" = "Échappe";
+"ESC" = "ESC";
 
 /* views/containers/payments/PaymentDetail.vue */
 "Notes" = "Notes";
@@ -1264,7 +1264,7 @@
 "You can change this later in your Group Settings." = "Vous pouvez changer cela plus tard dans les Paramètres de Groupe.";
 
 /* views/containers/proposals/ProposalVoteOptions.vue */
-"Are you sure you want to vote no?" = "Êtes-vous sûr de vouloir voter non ?";
+"Are you sure you want to vote no?" = "Êtes-vous sûr(e) de vouloir voter non ?";
 
 /* views/containers/contributions/Contribution.vue, views/containers/dashboard/GroupMembers.vue */
 "Add" = "Ajouter";


### PR DESCRIPTION
### Changes:

- A new selector `sbp('translations/init', language)` registered in views/utils/translations.js,
 used to initialize the in-memory translation table, fetching it if necessary;
- A new route `'translations/get/:language'`,
 used to fetch a translation table for a given language, if one is available.
- A new selector `sbp('backend/translations/get', language)` registered in controller/backend.js,
 used inside the `translations/get` route.

I also wished to add a `language` setting in the Vuex store, so that users could change and save their preferred language. But if the translation table is changed, the strings that are already rendered don't get reactively updated, since the `L()` function and the `i18n` component are not reactive.

Is there a way to make the components which use these functions to call them again to update their displayed text?
Meanwhile, since I could not make this setting reactive I did not include it in the store.

### Other ideas for future work:

- Add Cypress tests. I'm not familiar enough with Cypress yet so any help is welcome.
- Allow more strings to be displayed in the locale language by only rendering them once the relevant ressource has been fetched.
- Maybe improve the L() and/or `template()` functions to handle localization of numbers and dates that are sometimes embedded in the text.