### PR TITLE
#983 Payments - improve search tabs and tests

### DIFF
--- a/frontend/views/containers/payments/PaymentsPagination.vue
+++ b/frontend/views/containers/payments/PaymentsPagination.vue
@@ -20,12 +20,14 @@
     ) per page
 
   .c-pagination-controls
-    p.has-text-1(data-test='paginationInfo')
-      span.has-text-0 {{paginationInfo.begin}} - {{paginationInfo.end}}
-      | &nbsp;
-      i18n out of
-      | &nbsp;
-      span.has-text-0 {{paginationInfo.count}}
+    i18n.has-text-1(
+      tag='p'
+      data-test='paginationInfo'
+      :args='{ \
+        range: `<span class="has-text-0">${paginationInfo.begin} - ${paginationInfo.end}</span>`, \
+        count: `<span class="has-text-0">${paginationInfo.count}</span>` \
+      }'
+    ) {range} out of {count}
 
     .c-previous-next
       button.is-icon-small.c-btn(

--- a/frontend/views/containers/payments/PaymentsPagination.vue
+++ b/frontend/views/containers/payments/PaymentsPagination.vue
@@ -20,11 +20,12 @@
     ) per page
 
   .c-pagination-controls
-    i18n.has-text-1(
-      tag='p'
-      data-test='paginationInfo'
-      :args='paginationInfo'
-    ) {currentPage} out of {count}
+    p.has-text-1(data-test='paginationInfo')
+      span.has-text-0 {{paginationInfo.begin}} - {{paginationInfo.end}}
+      | &nbsp;
+      i18n out of
+      | &nbsp;
+      span.has-text-0 {{paginationInfo.count}}
 
     .c-previous-next
       button.is-icon-small.c-btn(
@@ -62,12 +63,11 @@ export default {
       return Math.ceil(this.count / this.rowsPerPage)
     },
     paginationInfo () {
-      const style = text => `<span class="has-text-0">${text}</span>`
       const start = this.rowsPerPage * this.page
-      const currentRows = `${start + 1} - ${Math.min(start + this.rowsPerPage, this.count)}`
       return {
-        currentPage: style(currentRows),
-        count: style(this.count)
+        begin: start + 1,
+        end: Math.min(start + this.rowsPerPage, this.count),
+        count: this.count
       }
     }
   },

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -165,11 +165,6 @@ export default {
           url: 'PaymentRowTodo',
           notification: this.paymentsTodo.length
         })
-
-        items.push({
-          title: L('Sent'),
-          url: 'PaymentRowSent'
-        })
       }
 
       const doesNotNeedIncomeAndDidReceiveBefore = !this.needsIncome && this.paymentsReceived.length
@@ -182,7 +177,7 @@ export default {
         })
       }
 
-      if (doesNeedIncomeAndDidSentBefore) {
+      if (!this.needsIncome || this.paymentsSent.length) {
         items.push({
           title: L('Sent'),
           url: 'PaymentRowSent'

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -51,7 +51,7 @@ page(
         v-if='paymentsListData.length && ephemeral.activeTab !== "PaymentRowTodo"'
         :placeholder='L("Search payments...")'
         :label='L("Search for a payment")'
-        v-model='form.search'
+        v-model='form.searchText'
       )
 
       .tab-section
@@ -83,7 +83,7 @@ page(
               @changeRowsPerPage='handleRowsPerPageChange'
             )
         .c-container-noresults(v-else-if='paymentsListData.length && !paymentsFiltered.length' data-test='noResults')
-          i18n(tag='p' :args='{query: form.search }') No results for "{query}".
+          i18n(tag='p' :args='{query: form.searchText }') No results for "{query}".
         .c-container-empty(v-else data-test='noPayments')
           svg-contributions.c-svg
           i18n.c-description(tag='p') There are no payments.
@@ -119,7 +119,7 @@ export default {
   data () {
     return {
       form: {
-        search: ''
+        searchText: ''
       },
       ephemeral: {
         activeTab: '',
@@ -325,7 +325,7 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, name, props)
     },
     filterPayment (payment) {
-      const query = this.form.search
+      const query = this.form.searchText
       const { amount, username, displayName } = payment
       return query === '' || `${amount}${username.toUpperCase()}${displayName.toUpperCase()}`.indexOf(query.toUpperCase()) !== -1
     },

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -335,7 +335,6 @@ export default {
     },
     handleTabClick (url) {
       this.ephemeral.activeTab = url
-      this.form.search = ''
     },
     handleIncomeClick (e) {
       if (e.target.classList.contains('js-btnInvite')) {

--- a/test/cypress/integration/group-paying.spec.js
+++ b/test/cypress/integration/group-paying.spec.js
@@ -34,8 +34,8 @@ function assertNavTabs (tabs) {
 function assertMonthOverview (items) {
   cy.log('MonthOverview values are correct')
   cy.getByDT('monthOverview').within(() => {
-    items.forEach((text, i) => {
-      cy.get(`ul > li:nth-child(${i + 1})`).should('contain', text)
+    items.forEach((texts, i) => {
+      cy.get(`ul > li:nth-child(${i + 1})`).should('contain', texts.join(''))
     })
   })
 }
@@ -78,8 +78,8 @@ describe('Group Payments', () => {
 
     assertNavTabs(['Todo2', 'Sent'])
     assertMonthOverview([
-      'Payments sent0 out of 2',
-      'Amount sent$0 out of $250'
+      ['Payments sent', '0 out of 2'],
+      ['Amount sent', '$0 out of $250']
     ])
 
     cy.getByDT('recordPayment').click()
@@ -94,8 +94,8 @@ describe('Group Payments', () => {
     })
 
     assertMonthOverview([
-      'Payments sent1 out of 2',
-      'Amount sent$71.43 out of $250'
+      ['Payments sent', '1 out of 2'],
+      ['Amount sent', '$71.43 out of $250']
     ])
 
     cy.log('assert payments table is correct')
@@ -135,8 +135,8 @@ describe('Group Payments', () => {
     })
 
     assertMonthOverview([
-      'Payments received1 out of 2',
-      'Amount received$71.43 out of $100'
+      ['Payments received', '1 out of 2'],
+      ['Amount received', '$71.43 out of $100']
     ])
   })
 
@@ -158,8 +158,8 @@ describe('Group Payments', () => {
     assertNavTabs(['Todo1', 'Sent'])
 
     assertMonthOverview([
-      'Payments sent1 out of 2',
-      'Amount sent$171.43 out of $250'
+      ['Payments sent', '1 out of 2'],
+      ['Amount sent', '$171.43 out of $250']
     ])
 
     cy.getByDT('payList').within(() => {
@@ -200,8 +200,8 @@ describe('Group Payments', () => {
     cy.getByDT('payList').find('tbody').children().should('have.length', 2)
 
     assertMonthOverview([
-      'Payments received0 out of 1',
-      'Amount received$0 out of $12.50'
+      ['Payments received', '0 out of 1'],
+      ['Amount received', '$0 out of $12.50']
     ])
   })
 
@@ -222,8 +222,8 @@ describe('Group Payments', () => {
     cy.get('[data-test-date]').should('have.attr', 'data-test-date', humanDate(timeStart + timeOneMonth))
 
     assertMonthOverview([
-      'Payments sent0 out of 2',
-      'Amount sent$0 out of $250'
+      ['Payments sent', '0 out of 2'],
+      ['Amount sent', '$0 out of $250']
     ])
 
     // BUG - The payments are incorrect. The getter ourPayments.late logic is wrong.


### PR DESCRIPTION
This closes #983.

- [x] Clean up some [logic repetition](https://github.com/okTurtles/group-income-simple/pull/951#discussion_r486545255)
- [x] Extract [inline HTML](https://github.com/okTurtles/group-income-simple/pull/951#discussion_r486655374) and [inline text](https://github.com/okTurtles/group-income-simple/pull/951#discussion_r486656616) into view
- [x] Try to [separate text in tests](https://github.com/okTurtles/group-income-simple/pull/951#discussion_r486659907) if possible
- [x] No longer [clear search](https://github.com/okTurtles/group-income-simple/pull/951#discussion_r486665087) when changing tabs
- [x] Consider [renaming variable](https://github.com/okTurtles/group-income-simple/pull/951#discussion_r486666965) for semantic clarity
