### PR TITLE
#989 clean up currencies file

### DIFF
--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -64,7 +64,7 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
 
     group-pledges-graph.c-graph(
       :type='form.incomeDetailsType'
-      :amount='form.amount === "" ? undefined : saferFloat(form.amount)'
+      :amount='form.amount === "" ? undefined : normalizeCurrency(form.amount)'
     )
 </template>
 
@@ -72,7 +72,7 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
 import { mapGetters } from 'vuex'
 import { validationMixin } from 'vuelidate'
 import { required } from 'vuelidate/lib/validators'
-import currencies, { mincomePositive, saferFloat } from '@view-utils/currencies.js'
+import currencies, { mincomePositive, normalizeCurrency } from '@view-utils/currencies.js'
 import sbp from '~/shared/sbp.js'
 import PaymentMethods from './PaymentMethods.vue'
 import GroupPledgesGraph from './GroupPledgesGraph.vue'
@@ -151,7 +151,7 @@ export default {
     }
   },
   methods: {
-    saferFloat,
+    normalizeCurrency,
     resetAmount () {
       this.form.amount = this.form.incomeDetailsType === this.ourGroupProfile.incomeDetailsType ? this.ourGroupProfile[this.ourGroupProfile.incomeDetailsType] : ''
       this.$v.form.$reset()
@@ -194,7 +194,7 @@ export default {
         const groupProfileUpdate = await sbp('gi.contracts/group/groupProfileUpdate/create',
           {
             incomeDetailsType,
-            [incomeDetailsType]: saferFloat(this.form.amount),
+            [incomeDetailsType]: normalizeCurrency(this.form.amount),
             paymentMethods
           },
           this.$store.state.currentGroupId
@@ -219,7 +219,7 @@ export default {
           return currencies[this.groupSettings.mincomeCurrency].validate(value)
         },
         [L('Your income must be lower than the group mincome')]: function (value) {
-          return !this.needsIncome || saferFloat(value) < this.groupSettings.mincomeAmount
+          return !this.needsIncome || normalizeCurrency(value) < this.groupSettings.mincomeAmount
         }
       }
     }

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -64,7 +64,7 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
 
     group-pledges-graph.c-graph(
       :type='form.incomeDetailsType'
-      :amount='form.amount === "" ? undefined : saferFloat(form.amount)'
+      :amount='(form.amount === "" || form.amount === null) ? undefined : saferFloat(form.amount)'
     )
 </template>
 

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -64,7 +64,7 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
 
     group-pledges-graph.c-graph(
       :type='form.incomeDetailsType'
-      :amount='(form.amount === "" || form.amount === null) ? undefined : saferFloat(form.amount)'
+      :amount='form.amount === "" ? undefined : saferFloat(form.amount)'
     )
 </template>
 
@@ -144,6 +144,7 @@ export default {
   },
   created () {
     const incomeDetailsType = this.ourGroupProfile.incomeDetailsType
+    this.form.amount = ''
     if (incomeDetailsType) {
       this.form.incomeDetailsType = incomeDetailsType
       this.form.amount = this.ourGroupProfile[incomeDetailsType]

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -55,7 +55,7 @@ import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import { RULE_PERCENTAGE, RULE_DISAGREEMENT } from '@model/contracts/voting/rules.js'
 import proposals from '@model/contracts/voting/proposals.js'
 import { PROPOSAL_GENERIC } from '@model/contracts/voting/constants.js'
-import currencies, { mincomePositive, saferFloat } from '@view-utils/currencies.js'
+import currencies, { mincomePositive, normalizeCurrency } from '@view-utils/currencies.js'
 import L from '@view-utils/translations.js'
 import StepAssistant from '@view-utils/stepAssistant.js'
 import BannerScoped from '@components/banners/BannerScoped.vue'
@@ -113,7 +113,7 @@ export default {
           name: this.form.groupName,
           picture: this.ephemeral.groupPictureFile,
           sharedValues: this.form.sharedValues,
-          mincomeAmount: saferFloat(this.form.mincomeAmount),
+          mincomeAmount: normalizeCurrency(this.form.mincomeAmount),
           mincomeCurrency: this.form.mincomeCurrency,
           ruleName: this.form.ruleName,
           ruleThreshold: this.form.ruleThreshold[this.form.ruleName]

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -31,7 +31,7 @@ import sbp from '~/shared/sbp.js'
 import { validationMixin } from 'vuelidate'
 import { required } from 'vuelidate/lib/validators'
 import { mapGetters, mapState } from 'vuex'
-import currencies, { mincomePositive, saferFloat } from '@view-utils/currencies.js'
+import currencies, { mincomePositive, normalizeCurrency } from '@view-utils/currencies.js'
 import L, { LError } from '@view-utils/translations.js'
 import ProposalTemplate from './ProposalTemplate.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
@@ -100,7 +100,7 @@ export default {
   },
   methods: {
     validateMincome () {
-      const mincomeAmount = saferFloat(this.form.mincomeAmount)
+      const mincomeAmount = normalizeCurrency(this.form.mincomeAmount)
       if (mincomeAmount === this.groupSettings.mincomeAmount) {
         this.$refs.formMsg.danger(L('The new mincome should be different than the current one.'))
         this.ephemeral.currentStep = 0
@@ -114,7 +114,7 @@ export default {
         return
       }
 
-      const mincomeAmount = saferFloat(this.form.mincomeAmount)
+      const mincomeAmount = normalizeCurrency(this.form.mincomeAmount)
 
       if (this.groupShouldPropose) {
         try {

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -7,35 +7,40 @@
 // this value, switch to a different currency base, e.g. from BTC to mBTC.
 export const DECIMALS_MAX = 8
 
-function commaToDots (value) {
+function commaToDots (value: string | number): string {
   // ex: "1,55" -> "1.55"
-  return typeof value === 'string' ? value.replace(/,/, '.') : value
+  return typeof value === 'string' ? value.replace(/,/, '.') : value.toString()
 }
 
-function isNumeric (nr) {
-  return !isNaN(nr - parseFloat(nr))
+function isNumeric (nr: string): boolean {
+  return !isNaN((nr: any) - parseFloat(nr))
 }
 
-function isInDecimalsLimit (nr, currency) {
+// NOTE: $Keys<typeof currencies> will not work unless `currencies` is above it,
+//       but then it uses functions that aren't defined yet (but are hoisted)
+function isInDecimalsLimit (nr: string, currency: $Keys<typeof currencies>) {
   const decimals = nr.toString().split('.')[1]
   return !decimals || decimals.length <= currencies[currency].decimalsMax
 }
 
-function validateMincome (value, currency) {
+// NOTE: Unsure whether this is *only* ever string; it comes from 'validate' function below
+function validateMincome (value: string, currency: $Keys<typeof currencies>) {
   const nr = commaToDots(value)
   return isNumeric(nr) && isInDecimalsLimit(nr, currency)
 }
 
-function decimalsOrInt (num: number, currency: string): string {
+function decimalsOrInt (num: number, currency: $Keys<typeof currencies>): string {
+  // ex: 12.5 -> "12.50", but 250 -> "250"
   return num.toFixed(currencies[currency].decimalsMax).replace(/\.0+$/, '')
 }
 
-export function saferFloat (value): number {
+export function saferFloat (value: string | number): number {
   // ex: "1,333333333333333333" -> 1.33333333
   return parseFloat(parseFloat(commaToDots(value)).toFixed(DECIMALS_MAX))
 }
 
-export function mincomePositive (value): boolean {
+// NOTE: Unsure whether this is *always* string; it comes from 'validators' in other files
+export function mincomePositive (value: string): boolean {
   return parseFloat(commaToDots(value)) > 0
 }
 

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -48,9 +48,9 @@ function makeCurrency (options) {
     symbol,
     symbolWithCode,
     decimalsMax,
-    displayWithCurrency: (n) => formatCurrency(decimalsOrInt(n, decimalsMax)),
-    displayWithoutCurrency: (n) => decimalsOrInt(n, decimalsMax),
-    validate: (n) => validateMincome(n, decimalsMax),
+    displayWithCurrency: (n: number) => formatCurrency(decimalsOrInt(n, decimalsMax)),
+    displayWithoutCurrency: (n: number) => decimalsOrInt(n, decimalsMax),
+    validate: (n: string) => validateMincome(n, decimalsMax),
   }
 }
 

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -50,7 +50,7 @@ function makeCurrency (options) {
     decimalsMax,
     displayWithCurrency: (n: number) => formatCurrency(decimalsOrInt(n, decimalsMax)),
     displayWithoutCurrency: (n: number) => decimalsOrInt(n, decimalsMax),
-    validate: (n: string) => validateMincome(n, decimalsMax),
+    validate: (n: string) => validateMincome(n, decimalsMax)
   }
 }
 
@@ -63,19 +63,19 @@ const currencies = {
     symbol: '$',
     symbolWithCode: '$ USD',
     decimalsMax: 2,
-    formatCurrency: amount => '$' + amount,
+    formatCurrency: amount => '$' + amount
   }),
   EUR: makeCurrency({
     symbol: '€',
     symbolWithCode: '€ EUR',
     decimalsMax: 2,
-    formatCurrency: amount => '€' + amount,
+    formatCurrency: amount => '€' + amount
   }),
   BTC: makeCurrency({
     symbol: 'Ƀ',
     symbolWithCode: 'Ƀ BTC',
     decimalsMax: DECIMALS_MAX,
-    formatCurrency: amount => amount + 'Ƀ',
+    formatCurrency: amount => amount + 'Ƀ'
   })
 }
 

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -7,9 +7,9 @@
 // this value, switch to a different currency base, e.g. from BTC to mBTC.
 export const DECIMALS_MAX = 8
 
-function commaToDots (value: string | number | null): string {
+function commaToDots (value: string | number): string {
   // ex: "1,55" -> "1.55"
-  return typeof value === 'string' ? value.replace(/,/, '.') : String(value)
+  return typeof value === 'string' ? value.replace(/,/, '.') : value.toString()
 }
 
 function isNumeric (nr: string): boolean {

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -21,7 +21,7 @@ function isInDecimalsLimit (nr: string, decimalsMax: number) {
   return !decimals || decimals.length <= decimalsMax
 }
 
-// NOTE: Unsure whether this is *only* ever string; it comes from 'validate' function below
+// NOTE: Unsure whether this is *always* string; it comes from 'validators' in other files
 function validateMincome (value: string, decimalsMax: number) {
   const nr = commaToDots(value)
   return isNumeric(nr) && isInDecimalsLimit(nr, decimalsMax)
@@ -32,9 +32,14 @@ function decimalsOrInt (num: number, decimalsMax: number): string {
   return num.toFixed(decimalsMax).replace(/\.0+$/, '')
 }
 
-export function saferFloat (value: string | number): number {
+export function saferFloat (value: number): number {
+  // ex: 1.333333333333333333 -> 1.33333333
+  return parseFloat(value.toFixed(DECIMALS_MAX))
+}
+
+export function normalizeCurrency (value: string): number {
   // ex: "1,333333333333333333" -> 1.33333333
-  return parseFloat(parseFloat(commaToDots(value)).toFixed(DECIMALS_MAX))
+  return saferFloat(parseFloat(commaToDots(value)))
 }
 
 // NOTE: Unsure whether this is *always* string; it comes from 'validators' in other files

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -17,7 +17,7 @@ function isNumeric (nr: string): boolean {
 }
 
 function isInDecimalsLimit (nr: string, decimalsMax: number) {
-  const decimals = nr.toString().split('.')[1]
+  const decimals = nr.split('.')[1]
   return !decimals || decimals.length <= decimalsMax
 }
 

--- a/frontend/views/utils/currencies.js
+++ b/frontend/views/utils/currencies.js
@@ -7,9 +7,9 @@
 // this value, switch to a different currency base, e.g. from BTC to mBTC.
 export const DECIMALS_MAX = 8
 
-function commaToDots (value: string | number): string {
+function commaToDots (value: string | number | null): string {
   // ex: "1,55" -> "1.55"
-  return typeof value === 'string' ? value.replace(/,/, '.') : value.toString()
+  return typeof value === 'string' ? value.replace(/,/, '.') : String(value)
 }
 
 function isNumeric (nr: string): boolean {


### PR DESCRIPTION
Resolves: #989

**Actions taken:**

* Added types for *almost* everything in currencies.js
* Simplified parameters to remove redundant information (`currencies` key)
* Removed duplication in `currencies` entry definitions
* Removed an unnecessary `.toString()` in one spot and added a necessary `.toString()` in another.

**Concerns:**

* `mincomePositive` and `validateMincome` are called from `validations` but I can't figure out what exact types it *always* gets. It seems to always be a string from my usage of the app, and since it's coming from the UI, I assume so, but I haven't fully traced down how/where these validators are called.
* Tracked down many calls to `displayWithCurrency` and `displayWithoutCurrency` which are always numbers, but haven't found them all yet and not sure if it's ever a string.