### PR TITLE
Persistence implemented

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ node_js:
 dist: trusty
 compiler: clang # per: https://docs.travis-ci.com/user/languages/c
 env:
+  - NO_PERSIST
+  - GI_PERSIST
 branches:
   only:
     - master # https://github.com/okTurtles/group-income-simple/issues/58

--- a/backend/index.js
+++ b/backend/index.js
@@ -10,6 +10,7 @@ import chalk from 'chalk'
 global.logger = function (err) {
   console.error(err)
   err.stack && console.error(err.stack)
+  return err // routes.js is written in a way that depends on this returning the error
 }
 
 const dontLog = { 'backend/pubsub/setup': true }

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -109,10 +109,6 @@ route.GET('/time', {}, function (request, h) {
 // TODO: if the browser deletes our cache then not everyone
 //       has a complete copy of the data and can act as a
 //       new coordinating server... I don't like that.
-//
-// TODO: combine all of these routes into a single generic key-value store?
-//       i.e. the first two routes (/event and /events) should be renamed
-//       and should be able to handle file upload too...
 
 const MEGABTYE = 1048576 // TODO: add settings for these
 const SECOND = 1000
@@ -143,7 +139,7 @@ route.POST('/file', {
       console.error(`hash(${hash}) != ourHash(${ourHash})`)
       return Boom.badRequest('bad hash!')
     }
-    await sbp('backend/db/writeFile', hash, data)
+    await sbp('backend/db/writeFileOnce', hash, data)
     return process.env.API_URL + '/file/' + hash
   } catch (err) {
     return logger(err)

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -77,7 +77,7 @@ route.POST('/name', {
       value: Joi.string().required()
     })
   }
-}, function (request, h) {
+}, async function (request, h) {
   try {
     const { name, value } = request.payload
     if (sbp('backend/db/lookupName', name)) {
@@ -92,7 +92,7 @@ route.POST('/name', {
   }
 })
 
-route.GET('/name/{name}', {}, function (request, h) {
+route.GET('/name/{name}', {}, async function (request, h) {
   try {
     return sbp('backend/db/lookupName', request.params.name) || Boom.notFound()
   } catch (err) {

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -42,10 +42,8 @@ route.POST('/event', {
     if (err.name === 'ErrorDBBadPreviousHEAD') {
       console.error(chalk.bold.yellow('ErrorDBBadPreviousHEAD'), err)
       return Boom.conflict(err.message)
-    } else {
-      logger(err)
     }
-    return err
+    return logger(err)
   }
 })
 
@@ -65,8 +63,7 @@ route.GET('/events/{contractID}/{since}', {}, async function (request, h) {
     request.events.once('disconnect', stream.destroy.bind(stream))
     return stream
   } catch (err) {
-    logger(err)
-    return err
+    return logger(err)
   }
 })
 
@@ -80,24 +77,17 @@ route.POST('/name', {
 }, async function (request, h) {
   try {
     const { name, value } = request.payload
-    if (sbp('backend/db/lookupName', name)) {
-      return Boom.conflict('exists')
-    } else {
-      sbp('backend/db/registerName', name, value)
-      return { name, value }
-    }
+    return await sbp('backend/db/registerName', name, value)
   } catch (err) {
-    logger(err)
-    return err
+    return logger(err)
   }
 })
 
 route.GET('/name/{name}', {}, async function (request, h) {
   try {
-    return sbp('backend/db/lookupName', request.params.name) || Boom.notFound()
+    return await sbp('backend/db/lookupName', request.params.name)
   } catch (err) {
-    logger(err)
-    return err
+    return logger(err)
   }
 })
 
@@ -106,8 +96,7 @@ route.GET('/latestHash/{contractID}', {}, async function (request, h) {
     const entry = await sbp('gi.db/log/lastEntry', request.params.contractID)
     return entry ? entry.hash() : Boom.notFound()
   } catch (err) {
-    logger(err)
-    return err
+    return logger(err)
   }
 })
 
@@ -157,17 +146,15 @@ route.POST('/file', {
     await sbp('backend/db/writeFile', hash, data)
     return process.env.API_URL + '/file/' + hash
   } catch (err) {
-    logger(err)
-    return err
+    return logger(err)
   }
 })
 
-route.GET('/file/{hash}', {}, function (request, h) {
+route.GET('/file/{hash}', {}, async function (request, h) {
   try {
-    return sbp('backend/db/readFile', request.params.hash)
+    return await sbp('backend/db/readFile', request.params.hash)
   } catch (err) {
-    logger(err)
-    return Boom.notFound()
+    return logger(err)
   }
 })
 
@@ -175,8 +162,7 @@ route.GET('/translations/get/{language}', {}, async function (request, h) {
   try {
     return await sbp('backend/translations/get', request.params.language)
   } catch (err) {
-    logger(err)
-    return Boom.notFound()
+    return logger(err)
   }
 })
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,7 +9,7 @@ import { makeResponse } from '~/shared/functions.js'
 import { RESPONSE_TYPE } from '~/shared/constants.js'
 import { SERVER_RUNNING } from './events.js'
 import { SERVER_INSTANCE, PUBSUB_INSTANCE } from './instance-keys.js'
-import { bold } from 'chalk'
+import chalk from 'chalk'
 
 const Inert = require('@hapi/inert')
 
@@ -44,7 +44,7 @@ sbp('sbp/selectors/register', {
     const contractID = entry.isFirstMessage() ? entry.hash() : entry.message().contractID
     await sbp('gi.db/log/addEntry', entry)
     const response = makeResponse(RESPONSE_TYPE.ENTRY, entry.serialize())
-    console.log(bold.blue(`broadcasting to room ${contractID}:`), entry.hash(), entry.type())
+    console.log(chalk.blue.bold(`broadcasting to room ${contractID}:`), entry.hash(), entry.type())
     sbp('okTurtles.data/apply', PUBSUB_INSTANCE, p => {
       p.room(contractID).write(response)
     })
@@ -54,10 +54,11 @@ sbp('sbp/selectors/register', {
   }
 })
 
-// NOTE: uncomment this or enable debug logging support to show all requests
-// hapi.events.on('response', (request, event, tags) => {
-//   console.debug(chalk`{grey ${request.info.remoteAddress}: ${request.method.toUpperCase()} ${request.path} --> ${request.response.statusCode}}`)
-// })
+if (process.env.NODE_ENV === 'development' && !process.env.CI) {
+  hapi.events.on('response', (request, event, tags) => {
+    console.debug(chalk`{grey ${request.info.remoteAddress}: ${request.method.toUpperCase()} ${request.path} --> ${request.response.statusCode}}`)
+  })
+}
 
 ;(async function () {
   // https://hapi.dev/tutorials/plugins

--- a/backend/server.js
+++ b/backend/server.js
@@ -69,6 +69,6 @@ if (process.env.NODE_ENV === 'development' && !process.env.CI) {
   require('./routes.js')
   require('./pubsub.js')
   await hapi.start()
-  console.log('API server running at:', hapi.info.uri)
+  console.log('Backend server running at:', hapi.info.uri)
   sbp('okTurtles.events/emit', SERVER_RUNNING, hapi)
 })()

--- a/backend/translations.js
+++ b/backend/translations.js
@@ -6,6 +6,8 @@ import util from 'util'
 
 import sbp from '~/shared/sbp.js'
 
+const Boom = require('@hapi/boom')
+
 const readFileAsync = util.promisify(fs.readFile)
 
 const defaultLanguage = 'en-US'
@@ -26,6 +28,9 @@ export default sbp('sbp/selectors/register', {
     // returns empty so that the UI stays in the default language.
     if (!fileName || !fileName.endsWith(languageFileExtension)) return ''
     const filePath = path.join(languageDir, fileName)
+    if (!fs.existsSync(filePath)) {
+      return Boom.notFound()
+    }
     try {
       return await readFileAsync(filePath)
     } catch (error) {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -43,9 +43,9 @@ async function startApp () {
       'okTurtles.data'
     ].reduce(reducer, {})
     const selBlacklist = [
-      'gi.db/log/get',
+      'gi.db/get',
       'gi.db/log/logHEAD',
-      'gi.db/log/set'
+      'gi.db/set'
     ].reduce(reducer, {})
     sbp('sbp/filters/global/add', (domain, selector, data) => {
       if (domainBlacklist[domain] || selBlacklist[selector]) return

--- a/frontend/model/database.js
+++ b/frontend/model/database.js
@@ -11,9 +11,9 @@ const log = localforage.createInstance({
 
 // make gi.log use localforage for storage
 sbp('sbp/selectors/overwrite', {
-  'gi.db/log/get': key => log.getItem(key),
+  'gi.db/get': key => log.getItem(key),
   // TODO: handle QuotaExceededError
-  'gi.db/log/set': (key, value) => log.setItem(key, value)
+  'gi.db/set': (key, value) => log.setItem(key, value)
 })
 
 // =======================

--- a/shared/domains/okTurtles/data.js
+++ b/shared/domains/okTurtles/data.js
@@ -9,11 +9,12 @@ import sbp from '~/shared/sbp.js'
 const _store = new Map()
 
 export default sbp('sbp/selectors/register', {
-  'okTurtles.data/get': function (key: any) {
+  'okTurtles.data/get': function (key: any): any {
     return _store.get(key)
   },
-  'okTurtles.data/set': function (key: any, data: any) {
+  'okTurtles.data/set': function (key: any, data: any): any {
     _store.set(key, data)
+    return data
   },
   'okTurtles.data/delete': function (key: any) {
     return _store.delete(key)

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -180,6 +180,8 @@ describe('Full walkthrough', function () {
     it('Should register Alice and Bob in the namespace', async function () {
       const { alice, bob } = users
       let res = await sbp('namespace/register', alice.data().attributes.username, alice.hash())
+      // NOTE: don't rely on the return values for 'namespace/register'
+      //       too much... in the future we might remove these checks
       res.value.should.equal(alice.hash())
       res = await sbp('namespace/register', bob.data().attributes.username, bob.hash())
       res.value.should.equal(bob.hash())

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -100,6 +100,9 @@ describe('Full walkthrough', function () {
   }
 
   function createIdentity (username, email) {
+    // append random id to username to prevent conflict across runs
+    // when GI_PERSIST environment variable is defined
+    username = `${username}-${Math.floor(Math.random() * 1000)}`
     return sbp('gi.contracts/identity/create', {
       // authorizations: [Events.CanModifyAuths.dummyAuth(name)],
       attributes: { username, email }
@@ -170,7 +173,7 @@ describe('Full walkthrough', function () {
       users.alice = await createIdentity('Alice', 'alice@okturtles.org')
       const { alice, bob } = users
       // verify attribute creation and state initialization
-      bob.data().attributes.username.should.equal('Bob')
+      bob.data().attributes.username.should.match(/^Bob/)
       bob.data().attributes.email.should.equal('bob@okturtles.com')
       // send them off!
       await postEntry(alice)

--- a/test/cypress/integration/group-member-removal.spec.js
+++ b/test/cypress/integration/group-member-removal.spec.js
@@ -7,7 +7,7 @@ describe('Group - Removing a member', () => {
   const groupNameA = 'Dreamers'
   const groupNameB = 'Donuts'
 
-  const invitationLinks = []
+  const invitationLinks = {}
 
   function assertMembersCount (count) {
     cy.getByDT('groupMembers').find('ul>li').should('have.length', count)
@@ -242,7 +242,7 @@ describe('Group - Removing a member', () => {
     assertMembersCount(2)
   })
 
-  it('user1 removes user2 from groupA', () => {
+  it('user1 removes user2 from groupA again', () => {
     // this covers edge case scenario described at #944
     cy.giSwitchUser(`user1-${userId}`)
 

--- a/test/cypress/integration/group-paying.spec.js
+++ b/test/cypress/integration/group-paying.spec.js
@@ -5,10 +5,6 @@ export function humanDate (datems, opts = { month: 'short', day: 'numeric' }) {
   return new Date(datems).toLocaleDateString(locale, opts)
 }
 
-function dateToMonthstamp (date) {
-  return date.toISOString().slice(0, 7)
-}
-
 const userId = Math.floor(Math.random() * 10000)
 const groupName = 'Dreamers'
 const mincome = 1000
@@ -122,7 +118,21 @@ describe('Group Payments', () => {
       cy.getByDT('amount').should('contain', '$71.43')
       cy.getByDT('subtitle').should('contain', `Sent to user2-${userId}`)
 
-      cy.getByDT('details').find('li:nth-child(2)').should('contain', humanDate(dateToMonthstamp(new Date(timeStart)), { month: 'long', year: 'numeric' }))
+      // cy.getByDT('details').find('li:nth-child(2)').should('contain', humanDate(dateToMonthstamp(new Date(timeStart)), { month: 'long', year: 'numeric' }))
+      // BUG/TODO: I had to revert Sebin's change from here:
+      // https://github.com/okTurtles/group-income-simple/pull/1018/commits/fbb55a22a6c2bf6238a17b4c121272bf5e13014e#r533006646
+      // Because suddenly I started to get failing Cypress tests on December 2, 2020
+      // on my machine. The UI would produce "December 2020", and this would
+      // produce "November 2020":
+      // > humanDate('2020-12', { month: 'long', year: 'numeric' })
+      // 'November 2020'
+      // If I put a single space after the 12, it produces the right date:
+      // > humanDate('2020-12 ', { month: 'long', year: 'numeric' })
+      // 'December 2020'
+      // Not sure how to make this work in all timezones/systems... adding a space
+      // after feels hackish/buggy. If anyone knows the "proper" way to do this
+      // please fix!
+      cy.getByDT('details').find('li:nth-child(2)').should('contain', humanDate(timeStart, { month: 'long', year: 'numeric' }))
       cy.getByDT('details').find('li:nth-child(3)').should('contain', '$1000')
     })
     cy.closeModal()

--- a/test/cypress/support/output-logs.js
+++ b/test/cypress/support/output-logs.js
@@ -31,7 +31,7 @@ Cypress.on('window:before:load', (window) => {
       // you make to keep track of the logs
       // Use JSON.stringify to avoid [object, object] in the output
       // logs += JSON.stringify(args.join(' ')) + '\n'
-      logs += `::${consoleProperty}:: ${JSON.stringify(args)} \n`
+      logs += JSON.stringify([consoleProperty, ...args]) + ',\n'
     }
   })
 })
@@ -47,8 +47,8 @@ Cypress.mocha.getRunner().on('test', () => {
 // On a cypress fail. I add the console logs, from the start of test or after the last test fail to the
 // current fail, to the end of the error.stack property.
 Cypress.on('fail', (error) => {
-  error.stack += '\nConsole Logs:\n========================'
-  error.stack += logs
+  error.stack += '\nConsole Logs:\n========================\n'
+  error.stack += '[' + logs + ' null]'
   // clear logs after fail so we dont see duplicate logs
   logs = ''
   // still need to throw the error so tests wont be marked as a pass


### PR DESCRIPTION
This PR partially implements #852, adding persistence of groups and accounts.

To test locally, run like so:

```bash
$ GI_PERSIST=true grunt dev
```

To clear out the "database", quit the server and run:

```bash
$ rm -rf data/*
```

Missing still is the ability to associate an account with a password. That's coming after the issues with Cypress in this are fixed.

### WIP Notes

Although the Cypress tests pass when testing with the in-memory storage, they fail when running using persistent storage. Travis doesn't catch this because it's not yet configured to test the persistent storage method. Am currently working to address this.