### PR TITLE
#1027 Disallow double curly braces in i18n strings

### DIFF
--- a/scripts/validate-i18n.js
+++ b/scripts/validate-i18n.js
@@ -25,6 +25,7 @@ const UNEXPECTED_KEY_TYPE = 'Only plain identifiers are allowed as property keys
 const UNEXPECTED_METHOD = 'Methods are not allowed in the `:args` attribute'
 const UNEXPECTED_PROPERTY_TYPE = 'An object literal used in the `:args` attribute can only have plain properties and `LTags()` rest properties'
 const UNEXPECTED_SPREAD_ELEMENT = 'The spread operator is not allowed in the `:args` attribute, unless it applies to an `LTags()` call'
+const UNEXPECTED_VARIABLE = 'Double curly braces (Vue.js variables) are not allowed in i18n strings. Use single braces in the `:args` attribute to pass in variables'
 
 /**
  * Unquotes a string, taking care of unescaping the escaped quotes it may
@@ -314,6 +315,20 @@ module.exports.prototype = {
       const textToken = nextToken
       const usedNames = listUsedNames(i18nString)
 
+      /**
+       * Double braces (Vue.js variables) are not allowed in i18n strings.
+       * Developers should instead use single braces in the `:args` attribute
+       * to pass in variables.
+       *
+       * @see https://github.com/okTurtles/group-income-simple/issues/1027
+       */
+      if (i18nString.includes('{{')) {
+        errors.add(
+          UNEXPECTED_VARIABLE,
+          textToken.line,
+          textToken.column
+        )
+      }
       const {
         names: providedNames,
         errors: errorsInArgsValue

--- a/test/validate-i18n.test.js
+++ b/test/validate-i18n.test.js
@@ -203,3 +203,12 @@ it('should report usage of the `html` attribute', function () {
   assert.equal(errors[0].code, errorCode)
   assert.match(errors[0].message, /html attribute/)
 })
+
+it('should report usage of double curly braces', function () {
+  const invalidUseCase = 'i18n Replying to {{replyingTo}}'
+  const errors = linter.checkString(invalidUseCase)
+
+  assert.equal(errors.length, 1)
+  assert.equal(errors[0].code, errorCode)
+  assert.match(errors[0].message, /double curly braces/i)
+})


### PR DESCRIPTION
### Changes

- Make the `scripts/validate-i18n` script check whether i18n strings contain any occurence of the `{{` pattern, which should be enough in our use case to safely detect incorrect usage of Vue.js variables
- Add a corresponding test in `test/validate-i18n.test.js`

When running this updated linting plugin against the codebase, two occurences of double curlies were detected, causing the build to fail:

![lint-errors](https://user-images.githubusercontent.com/64228468/101231996-59480180-36af-11eb-89c7-7def2dfb313d.jpg)
