### PR TITLE
#1026 Use an empty string instead of null as the default mincome

### DIFF
--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -135,7 +135,7 @@ export default {
         sharedValues: '',
         // randomize to reduce choice bias
         ruleOrder: Math.round(Math.random()) === 1 ? [RULE_PERCENTAGE, RULE_DISAGREEMENT] : [RULE_DISAGREEMENT, RULE_PERCENTAGE],
-        mincomeAmount: null,
+        mincomeAmount: '',
         mincomeCurrency: 'USD',
         ruleName: null,
         ruleThreshold: {

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -172,6 +172,8 @@ Cypress.Commands.add('giCreateGroup', (name, {
     // ...so that it catches correctly the next "Next" button.
     cy.getByDT('nextBtn').click()
 
+    // Make sure that attempting to submit the form without providing a mincome amount doesn't throw (see #1026).
+    cy.get('input[name="mincomeAmount"]').type('{enter}')
     cy.get('input[name="mincomeAmount"]').type(mincome)
     cy.getByDT('nextBtn').click()
 


### PR DESCRIPTION
Closes #1026

- Use an empty string instead of `null` as the default value of the mincome input field in the `GroupCreationModal` Vue component.
- Modify the custom `giCreateGroup()` Cypress command to include a regression check