### PR TITLE
Fix null reference error in unloadModal()

### DIFF
--- a/frontend/views/components/modal/Modal.vue
+++ b/frontend/views/components/modal/Modal.vue
@@ -121,8 +121,8 @@ export default {
         this.subcontent.pop()
       } else {
         this.content = null
-        // Refocus on button that open the modal
-        this.lastFocus.focus()
+        // Refocus on the button that opened this modal, if any.
+        if (this.lastFocus) this.lastFocus.focus()
       }
       if (this.replacement) {
         this.openModal(this.replacement)


### PR DESCRIPTION
Closes #1019 

Not sure if an additional Cypress tests would be useful for this one, since I think its the kind of error which would be better prevented by static analysis.

In such a test, we might have to load every modal in turn and test whether it actually disappears without any error when the user tries to dismiss them, either by clicking outside or using the keyboard.