### PR TITLE
Fix hyperlinks in the User Settings modal

### DIFF
--- a/frontend/views/components/tabs/TabWrapper.vue
+++ b/frontend/views/components/tabs/TabWrapper.vue
@@ -65,6 +65,7 @@ export default {
       for (const tabItem of this.tabNav) {
         for (const link of tabItem.links) {
           if (this.activeTab !== link.index && link.url === section) {
+            this.activeComponent = link.component
             return this.changeTab(link.index)
           }
         }


### PR DESCRIPTION
Closes #1072

### Summary of changes:
- Fix hyperlinks in the User Settings modal that were not working properly due to a bug in TabWrapper.vue's `watch()` method.
