### PR TITLE
Fix new CSS assets not being used after a rebuild

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -44,7 +44,7 @@ Object.assign(process.env, applyPortShift(process.env))
 const chalk = require('chalk')
 const crypto = require('crypto')
 const { exec, fork } = require('child_process')
-const fs = require('fs')
+const { copyFile, readFile } = require('fs/promises')
 const path = require('path')
 const { resolve } = path
 
@@ -132,21 +132,35 @@ module.exports = (grunt) => {
     watch: false // Not using esbuild's own watch mode since it involves polling.
   }
 
-  // Options for building the main entry point.
+  // Native options for building the main entry point.
   const esbuildOptionsMain = {
     assetNames: '../css/[name]',
     entryPoints: [`${srcDir}/main.js`],
     format: 'esm',
-    outfile: `${distJS}/main.js`,
-    splitting: false
+    outfile: `${distJS}/main.js`
   }
 
-  // Options for building the service worker(s).
+  // Additional options which are not part of the esbuild API.
+  const esbuildOtherOptionsMain = {
+    // Our `index.html` file is designed to load its CSS from `dist/assets/css`;
+    // however, esbuild outputs `main.css` and `main.css.map` along `main.js`,
+    // making a post-build copying operation necessary.
+    postoperation: async ({ fileEventName, filePath } = {}) => {
+      // Only after a fresh build or a rebuild caused by a CSS file event.
+      if (!fileEventName || ['.css', '.sass', '.scss'].includes(path.extname(filePath))) {
+        await copyFile(`${distJS}/main.css`, `${distCSS}/main.css`)
+        if (development) {
+          await copyFile(`${distJS}/main.css.map`, `${distCSS}/main.css.map`)
+        }
+      }
+    }
+  }
+
+  // Native options for building the service worker(s).
   const esbuildOptionsServiceWorkers = {
     entryPoints: ['./frontend/controller/serviceworkers/primary.js'],
     format: 'iife',
-    outdir: distJS,
-    splitting: false
+    outdir: distJS
   }
 
   // https://github.com/rollup/plugins/tree/master/packages/eslint#options
@@ -352,22 +366,22 @@ module.exports = (grunt) => {
       ...esbuildOptionsDefault,
       ...esbuildOptionsMain,
       plugins: [aliasPlugin, flowRemoveTypesPlugin, sassPlugin, svgPlugin, vuePlugin]
-    })
+    }, esbuildOtherOptionsMain)
+
     const buildServiceWorkers = createEsbuildTask({
       ...esbuildOptionsDefault,
       ...esbuildOptionsServiceWorkers,
       plugins: [aliasPlugin, flowRemoveTypesPlugin]
     })
 
-    await Promise.all([buildMain.run(), buildServiceWorkers.run()])
-    // Necessary since our main HTML file loads its CSS from the `assets` folder.
-    await fs.promises.copyFile(`${distJS}/main.css`, `${distCSS}/main.css`)
-    await fs.promises.unlink(`${distJS}/main.css`)
+    await Promise.all([buildMain.run(), buildServiceWorkers.run()]).catch(error => {
+      grunt.log.error(error.message)
+      process.exit(1)
+    })
 
     if (!this.flags.watch) {
       return done()
     }
-
     const eslint = require('./scripts/esbuild-plugins/utils.js').createEslinter(eslintOptions)
     const puglint = require('./scripts/esbuild-plugins/utils.js').createPuglinter(puglintOptions)
     const stylelint = require('./scripts/esbuild-plugins/utils.js').createStylelinter(stylelintOptions)
@@ -388,13 +402,13 @@ module.exports = (grunt) => {
       [['frontend/views/**/*.vue'], [puglint, stylelint, eslint]]
     ].forEach(([globs, tasks]) => {
       globs.forEach(glob => {
-        browserSync.watch(glob, { ignoreInitial: true }, async (eventName, filePath) => {
+        browserSync.watch(glob, { ignoreInitial: true }, async (fileEventName, filePath) => {
           const extension = path.extname(filePath)
-          grunt.log.writeln(chalkFileEvent(eventName, filePath))
+          grunt.log.writeln(chalkFileEvent(fileEventName, filePath))
 
-          if (eventName === 'add' || eventName === 'change') {
+          if (fileEventName === 'add' || fileEventName === 'change') {
             // Read and lint the changed file.
-            const code = await fs.promises.readFile(filePath, 'utf8')
+            const code = await readFile(filePath, 'utf8')
             const linters = tasks.filter(task => typeof task === 'object')
             const lintingStartMs = Date.now()
 
@@ -406,7 +420,7 @@ module.exports = (grunt) => {
             grunt.log.writeln(chalkLintingTime(Date.now() - lintingStartMs, linters, [filePath]))
           }
 
-          if (eventName === 'change' || eventName === 'unlink') {
+          if (fileEventName === 'change' || fileEventName === 'unlink') {
             // Remove the corresponding plugin cache entry, if any.
             if (extension === '.js') {
               flowRemoveTypesPluginOptions.cache.delete(filePath)
@@ -422,18 +436,14 @@ module.exports = (grunt) => {
             }
           }
           // Only rebuild the relevant entry point.
-          if (filePath.startsWith(serviceWorkerDir)) {
-            await buildServiceWorkers.run()
-          } else {
-            await buildMain.run()
-            if (['.css', '.sass', '.scss'].includes(extension)) {
-              // Esbuild outputs `main.css` and `main.css.map` along `main.js`,
-              // but `index.html` wants to load them from `dist/assets/css`.
-              await fs.promises.copyFile(`${distJS}/main.css`, `${distCSS}/main.css`)
-              if (buildMain.options.sourcemap) {
-                await fs.promises.copyFile(`${distJS}/main.css.map`, `${distCSS}/main.css.map`)
-              }
+          try {
+            if (filePath.startsWith(serviceWorkerDir)) {
+              await buildServiceWorkers.rerun({ fileEventName, filePath })
+            } else {
+              await buildMain.rerun({ fileEventName, filePath })
             }
+          } catch (error) {
+            grunt.log.error(error.message)
           }
           grunt.task.run(tasks.filter(task => typeof task === 'string'))
           grunt.task.run(['keepalive'])

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -441,9 +441,9 @@ module.exports = (grunt) => {
           // Only rebuild the relevant entry point.
           try {
             if (filePath.startsWith(serviceWorkerDir)) {
-              await buildServiceWorkers.rerun({ fileEventName, filePath })
+              await buildServiceWorkers.run({ fileEventName, filePath })
             } else {
-              await buildMain.rerun({ fileEventName, filePath })
+              await buildMain.run({ fileEventName, filePath })
             }
           } catch (error) {
             grunt.log.error(error.message)

--- a/scripts/esbuild-commands.js
+++ b/scripts/esbuild-commands.js
@@ -50,8 +50,10 @@ const defaultPlugin = {
     })
 
     build.onEnd((result) => {
-      const duration = Date.now() - t0
-      console.log(chalk`{green esbuild: created} {bold ${output}} {green from} {bold ${entryPoint}} {green in} {bold ${(duration / 1e3).toFixed(1)}s}`)
+      if (!result.errors.length) {
+        const duration = Date.now() - t0
+        console.log(chalk`{green esbuild: created} {bold ${output}} {green from} {bold ${entryPoint}} {green in} {bold ${(duration / 1e3).toFixed(1)}s}`)
+      }
     })
   }
 }


### PR DESCRIPTION
Closes #1099

Fixes the relevant issue by copying new `main.css` and `main.css.map` over to the correct location.