### PR TITLE
Add Flow support to Vue files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -225,7 +225,8 @@ module.exports = (grunt) => {
     // This map's keys will be relative Vue file paths without leading dot,
     // while its values will be corresponding compiled JS strings.
     cache: new Map(),
-    debug: false
+    debug: false,
+    flowtype: flowRemoveTypesPluginOptions
   }
 
   grunt.initConfig({

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,7 @@
         "eslint-config-standard": "16.0.2",
         "eslint-plugin-cypress": "2.11.3",
         "eslint-plugin-flowtype": "5.7.2",
+        "eslint-plugin-flowtype-errors": "4.4.0",
         "eslint-plugin-import": "2.22.1",
         "eslint-plugin-node": "11.1.0",
         "eslint-plugin-promise": "4.2.1",
@@ -7240,6 +7241,37 @@
       },
       "peerDependencies": {
         "eslint": "^7.1.0"
+      }
+    },
+    "node_modules/eslint-plugin-flowtype-errors": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype-errors/-/eslint-plugin-flowtype-errors-4.4.0.tgz",
+      "integrity": "sha512-vlDxFUaAWRtI1Koc2YOWLTdORV5dmvqChkKyySE6b5VXxiWH7C0Ax7RJ4s3yRdt8TOk968OU7jEwRKL2l8aTIQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "core-js": "3.8.1",
+        "find-up": "^5.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4.x",
+        "npm": ">=5.x"
+      },
+      "peerDependencies": {
+        "eslint": ">=5.16.0",
+        "flow-bin": ">=0.93.0"
+      }
+    },
+    "node_modules/eslint-plugin-flowtype-errors/node_modules/core-js": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
+      "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
       }
     },
     "node_modules/eslint-plugin-import": {
@@ -23238,6 +23270,26 @@
       "requires": {
         "lodash": "^4.17.15",
         "string-natural-compare": "^3.0.1"
+      }
+    },
+    "eslint-plugin-flowtype-errors": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype-errors/-/eslint-plugin-flowtype-errors-4.4.0.tgz",
+      "integrity": "sha512-vlDxFUaAWRtI1Koc2YOWLTdORV5dmvqChkKyySE6b5VXxiWH7C0Ax7RJ4s3yRdt8TOk968OU7jEwRKL2l8aTIQ==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "core-js": "3.8.1",
+        "find-up": "^5.0.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "3.8.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.8.1.tgz",
+          "integrity": "sha512-9Id2xHY1W7m8hCl8NkhQn5CufmF/WuR30BTRewvCXc1aZd3kMECwNZ69ndLbekKfakw9Rf2Xyc+QR6E7Gg+obg==",
+          "dev": true
+        }
       }
     },
     "eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "eslintfix": "eslint \"**/*.{js,vue}\" --fix",
     "i18n": "node scripts/i18n.js",
     "flow": "flow",
+    "flow:vue": "eslint --cache --plugin flowtype-errors --rule 'flowtype-errors/show-errors: error' './frontend/views/**/*.vue'",
     "double": "PORT_SHIFT=1 grunt dev",
     "stylelint": "stylelint 'frontend/**/*.{css,scss,vue}' --fix",
     "docker": "./scripts/docker.sh"

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "eslint-config-standard": "16.0.2",
     "eslint-plugin-cypress": "2.11.3",
     "eslint-plugin-flowtype": "5.7.2",
+    "eslint-plugin-flowtype-errors": "4.4.0",
     "eslint-plugin-import": "2.22.1",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "4.2.1",

--- a/scripts/esbuild-plugins/vue-plugin.js
+++ b/scripts/esbuild-plugins/vue-plugin.js
@@ -16,7 +16,7 @@ const { createAliasReplacer } = require('./utils')
  * @param {Map} [options.cache]
  * @param {boolean} [options.debug]
  * @param {Object} [options.flowtype] Options for `flow-remove-types`.
- * Pass `null` to disable Flowtype syntax support.
+ * Leave it out to disable Flowtype syntax support.
  * @returns {Object}
  */
 module.exports = ({ aliases = null, cache = null, debug = false, flowtype = null } = {}) => {

--- a/scripts/esbuild-plugins/vue-plugin.js
+++ b/scripts/esbuild-plugins/vue-plugin.js
@@ -35,7 +35,7 @@ module.exports = ({ aliases = null, cache = null, debug = false, flowtype = null
           .then(source => aliasReplacer ? aliasReplacer({ path, source }) : source)
 
         if (debug) console.log('vue plugin: compiling', filename)
-        const { result /*, usedFiles */ } = await compile({ filename, source, options: { flowtype } })
+        const result = await compile({ filename, source, options: { flowtype } })
 
         if (cache) cache.set(filename, result)
         return result
@@ -44,60 +44,30 @@ module.exports = ({ aliases = null, cache = null, debug = false, flowtype = null
   }
 }
 
-let requireDepth = 0
-let usedFiles = new Set()
-
-editModule('fs', (fs) => {
-  fs.readFileSync = new Proxy(fs.readFileSync, {
-    apply (target, thisArg, args) {
-      if (usedFiles && requireDepth === 0) usedFiles.add(args[0])
-      return Reflect.apply(target, thisArg, args)
-    }
-  })
-})
-
-editModule('module', (mod) => {
-  mod.prototype.require = new Proxy(mod.prototype.require, {
-    apply (target, thisArg, args) {
-      requireDepth++
-      try {
-        return Reflect.apply(target, thisArg, args)
-      } finally {
-        requireDepth--
-      }
-    }
-  })
-})
-
 const compiler = componentCompiler.createDefaultCompiler()
 const compile = ({ filename, source, options }) => {
-  usedFiles = new Set()
-
   try {
     if (/^\s*$/.test(source)) {
       throw new Error('File is empty')
     }
-    const result = compiler.compileToDescriptor(filename, source)
-    const resultErrors = combineErrors(result.template, ...result.styles)
-    if (resultErrors.length > 0) {
-      return { result: { errors: resultErrors }, usedFiles }
+    const descriptor = compiler.compileToDescriptor(filename, source)
+    const errors = combineErrors(descriptor.template, ...descriptor.styles)
+    if (errors.length > 0) {
+      return { errors }
     }
     if (options.flowtype) {
-      result.script.code = flowRemoveTypes(result.script.code, options.flowtype).toString()
+      descriptor.script.code = flowRemoveTypes(descriptor.script.code, options.flowtype).toString()
     }
-    const output = componentCompiler.assemble(compiler, source, result, {})
-    return { result: { contents: output.code }, usedFiles }
+    const output = componentCompiler.assemble(compiler, source, descriptor, {})
+    return { contents: output.code }
   } catch (error) {
     return {
-      result: {
-        errors: [
-          {
-            text: `Could not compile Vue single-file component: ${error}`,
-            detail: error
-          }
-        ]
-      },
-      usedFiles
+      errors: [
+        {
+          text: `Could not compile Vue single-file component: ${error}`,
+          detail: error
+        }
+      ]
     }
   }
 }
@@ -119,8 +89,4 @@ function convertError (error) {
     return { text: error.message }
   }
   throw new Error(`Cannot convert Vue compiler error: ${error}`)
-}
-
-function editModule (name, fn) {
-  fn(require(name))
 }


### PR DESCRIPTION
Closes #273

### Summary of changes:
#### Pros:
- Flowtype syntax can now be used in Vue components without preventing the app to build.
- New `npm run flow:vue` command available to typecheck our .vue files.
#### Cons:
- New dependency [eslint-plugin-flowtype-errors](https://github.com/amilajack/eslint-plugin-flowtype-errors) installed.
- Travis build time slightly increased by ~2s because of the new syntax support, although no additional typechecking is done by default. Rebuilds might also be a bit slower, something like a tenth of a second per .vue file changed.