### PR TITLE
Cleanup trivial Flow errors in Vue components

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -10,7 +10,6 @@
 .*/dist/.*
 .*/frontend/assets/.*
 .*/frontend/controller/service-worker.js
-.*/frontend/controller/utils/primus.js
 .*/frontend/utils/blockies.js
 .*/frontend/utils/crypto.js
 .*/frontend/utils/flowTyper.js
@@ -32,10 +31,12 @@ all=true
 # experimental.const_params=true
 emoji=true
 module.ignore_non_literal_requires=true
-
+module.name_mapper.extension='svg' -> '<PROJECT_ROOT>/frontend/views/utils/vueComponentStub.js.flow'
+module.name_mapper.extension='vue' -> '<PROJECT_ROOT>/frontend/views/utils/vueComponentStub.js.flow'
 # https://github.com/entwicklerstube/babel-plugin-root-import#dont-let-flow-be-confused
 module.name_mapper='^~/\(.*\)$' -> '<PROJECT_ROOT>/\1'
 module.name_mapper='^@components/\(.*\)$' -> '<PROJECT_ROOT>/frontend/views/components/\1'
+module.name_mapper='^@containers/\(.*\)$' -> '<PROJECT_ROOT>/frontend/views/containers/\1'
 module.name_mapper='^@model/\(.*\)$' -> '<PROJECT_ROOT>/frontend/model/\1'
 module.name_mapper='^@pages/\(.*\)$' -> '<PROJECT_ROOT>/frontend/views/pages/\1'
 module.name_mapper='^@utils/\(.*\)$' -> '<PROJECT_ROOT>/frontend/utils/\1'

--- a/frontend/views/components/AppStyles.vue
+++ b/frontend/views/components/AppStyles.vue
@@ -41,7 +41,7 @@ import colorsMixins from '@view-utils/colorsManipulation.js'
 import '@assets/style/main.scss'
 import { mapGetters } from 'vuex'
 
-export default {
+export default ({
   name: 'AppStyles',
 
   mixins: [colorsMixins],
@@ -55,5 +55,5 @@ export default {
       return this.colors.theme === 'dark' ? 0.1 : -0.1
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/Avatar.vue
+++ b/frontend/views/components/Avatar.vue
@@ -14,7 +14,7 @@
 import sbp from '~/shared/sbp.js'
 import { handleFetchResult } from '~/frontend/controller/utils/misc.js'
 
-export default {
+export default ({
   name: 'Avatar',
   props: {
     src: String, // acts as a placeholder when used together with blobURL
@@ -97,7 +97,7 @@ export default {
       return this.objectURL || this.src
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/AvatarUpload.vue
+++ b/frontend/views/components/AvatarUpload.vue
@@ -27,7 +27,7 @@ import Avatar from '@components/Avatar.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import L, { LError } from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'AvatarUpload',
   props: {
     avatar: String,
@@ -65,7 +65,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/AvatarUser.vue
+++ b/frontend/views/components/AvatarUser.vue
@@ -11,7 +11,7 @@ import { mapGetters } from 'vuex'
 import sbp from '~/shared/sbp.js'
 import Avatar from '@components/Avatar.vue'
 
-export default {
+export default ({
   name: 'AvatarUser',
   components: { Avatar },
   props: {
@@ -57,5 +57,5 @@ export default {
       return this.profilePicture || this.ephemeral.url
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/Badge.vue
+++ b/frontend/views/components/Badge.vue
@@ -8,7 +8,7 @@ span.c-badge(
 </template>
 
 <script>
-export default {
+export default ({
   name: 'Badge',
   props: {
     type: {
@@ -16,7 +16,7 @@ export default {
       validator: (type) => ['default', 'compact'].indexOf(type) !== -1
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/ButtonSubmit.vue
+++ b/frontend/views/components/ButtonSubmit.vue
@@ -40,7 +40,7 @@ So, when pressing Enter, buttonSubmit(@click) gets called directly too.
 More details about this approach:
 https://github.com/okTurtles/group-income-simple/pull/854/files#r388638068
 */
-export default {
+export default ({
   name: 'ButtonSubmit',
   props: {
     disabled: Boolean
@@ -84,5 +84,5 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/CalloutCard.vue
+++ b/frontend/views/components/CalloutCard.vue
@@ -7,14 +7,14 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'CalloutCard',
   props: {
     title: String,
     svg: Object, // Svg file as component
     isCard: Boolean
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/GroupWelcome.vue
+++ b/frontend/views/components/GroupWelcome.vue
@@ -30,7 +30,7 @@ import Avatar from '@components/Avatar.vue'
 import ConfettiAnimation from '@components/confetti-animation/ConfettiAnimation.vue'
 import { mapGetters } from 'vuex'
 
-export default {
+export default ({
   name: 'GroupWelcome',
   components: {
     Avatar,
@@ -55,7 +55,7 @@ export default {
       this.$router.push({ path: '/dashboard' })
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/LinkToCopy.vue
+++ b/frontend/views/components/LinkToCopy.vue
@@ -26,7 +26,7 @@ component.c-wrapper(
 <script>
 import Tooltip from '@components/Tooltip.vue'
 
-export default {
+export default ({
   name: 'LinkToCopy',
   components: {
     Tooltip
@@ -65,7 +65,7 @@ export default {
       }, 1500)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/components/ListItem.vue
+++ b/frontend/views/components/ListItem.vue
@@ -19,7 +19,7 @@ li.c-item
 <script>
 import Badge from './Badge.vue'
 
-export default {
+export default ({
   name: 'ListItem',
   components: {
     Badge
@@ -46,7 +46,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/Loading.vue
+++ b/frontend/views/components/Loading.vue
@@ -8,7 +8,7 @@
 
 <script>
 import L from '@view-utils/translations.js'
-export default {
+export default ({
   name: 'Loading',
   props: {
     title: {
@@ -25,7 +25,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/Page.vue
+++ b/frontend/views/components/Page.vue
@@ -29,7 +29,7 @@ import Toggle from '@components/Toggle.vue'
 import { DESKTOP } from '@view-utils/breakpoints.js'
 import { debounce } from '@utils/giLodash.js'
 
-export default {
+export default ({
   name: 'Page',
   components: {
     Toggle
@@ -73,7 +73,7 @@ export default {
       this.ephemeral.isTouch = window.innerWidth < DESKTOP
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/PageSection.vue
+++ b/frontend/views/components/PageSection.vue
@@ -8,12 +8,12 @@ section.card
 </template>
 
 <script>
-export default {
+export default ({
   name: 'PageSection',
   props: {
     title: String
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/ProfileCard.vue
+++ b/frontend/views/components/ProfileCard.vue
@@ -91,7 +91,7 @@ import sbp from '~/shared/sbp.js'
 import { mapGetters } from 'vuex'
 import { PROFILE_STATUS } from '~/frontend/model/contracts/constants.js'
 
-export default {
+export default ({
   name: 'ProfileCard',
   props: {
     username: String,
@@ -154,7 +154,7 @@ export default {
       return !!this.ourContributionSummary.receivingMonetary
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/Search.vue
+++ b/frontend/views/components/Search.vue
@@ -29,7 +29,7 @@ form.c-search-form(
 <script>
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'Search',
 
   props: {
@@ -58,7 +58,7 @@ export default {
       this.$emit('input', this.value)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/Slider.vue
+++ b/frontend/views/components/Slider.vue
@@ -18,7 +18,7 @@
       span.slide-bar-separate-text(:class='{isActive: index===currentValue}') {{ r.label }}
 </template>
 <script>
-export default {
+export default ({
   name: 'AppSlider',
 
   data () {
@@ -306,7 +306,7 @@ export default {
     this.isComponentExists = false
     this.unbindEvents()
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/components/SliderContinuous.vue
+++ b/frontend/views/components/SliderContinuous.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'SliderContinuous',
   props: {
     /** Unique id to connect form and label */
@@ -62,7 +62,7 @@ export default {
       this.ephemeral.styleVars = `--percent: ${percent}%; --factor: ${this.getFactor(percent)};`
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/components/Toggle.vue
+++ b/frontend/views/components/Toggle.vue
@@ -9,7 +9,7 @@ button.c-toggle.is-unstyled(
 </template>
 
 <script>
-export default {
+export default ({
   name: 'Toggle',
   props: {
     element: {
@@ -18,7 +18,7 @@ export default {
       required: true
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -34,7 +34,7 @@ span.c-twrapper(
 import { TABLET } from '@view-utils/breakpoints.js'
 import trapFocus from '@utils/trapFocus.js'
 
-export default {
+export default ({
   name: 'Tooltip',
   mixins: [trapFocus],
   props: {
@@ -192,7 +192,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/TransitionExpand.vue
+++ b/frontend/views/components/TransitionExpand.vue
@@ -2,7 +2,7 @@
 import sbp from '~/shared/sbp.js'
 
 // From https://markus.oberlehner.net/blog/transition-to-height-auto-with-vue/
-export default {
+export default ({
   name: 'TransitionExpand',
   functional: true,
   render (createElement, context) {
@@ -56,7 +56,7 @@ export default {
     }
     return createElement('transition', data, context.children)
   }
-}
+}: Object)
 </script>
 
 <style scoped>

--- a/frontend/views/components/UserName.vue
+++ b/frontend/views/components/UserName.vue
@@ -10,7 +10,7 @@
 <script>
 import { mapGetters } from 'vuex'
 
-export default {
+export default ({
   name: 'UserName',
   props: {
     username: String
@@ -23,7 +23,7 @@ export default {
       return this.globalProfile(this.username).displayName
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/VotingRulesInput.vue
+++ b/frontend/views/components/VotingRulesInput.vue
@@ -29,7 +29,7 @@ import TransitionExpand from '@components/TransitionExpand.vue'
 
 const SUPERMAJORITY = 0.60
 
-export default {
+export default ({
   name: 'VotingRulesInput',
   components: {
     BannerSimple,
@@ -87,7 +87,7 @@ export default {
       this.$emit('update', value)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/banners/BannerGeneral.vue
+++ b/frontend/views/components/banners/BannerGeneral.vue
@@ -13,7 +13,7 @@
 <script>
 import TransitionExpand from '@components/TransitionExpand.vue'
 
-export default {
+export default ({
   name: 'BannerGeneral',
   components: {
     TransitionExpand
@@ -44,7 +44,7 @@ export default {
       this.ephemeral.severity = 'danger'
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/components/banners/BannerScoped.vue
+++ b/frontend/views/components/banners/BannerScoped.vue
@@ -17,7 +17,7 @@
 import BannerSimple from '@components/banners/BannerSimple.vue'
 import TransitionExpand from '@components/TransitionExpand.vue'
 
-export default {
+export default ({
   name: 'BannerScoped',
   components: {
     BannerSimple,
@@ -52,7 +52,7 @@ export default {
       this.ephemeral.severity = severity
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/banners/BannerSimple.vue
+++ b/frontend/views/components/banners/BannerSimple.vue
@@ -11,7 +11,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'Message',
   props: {
     severity: {
@@ -33,7 +33,7 @@ export default {
       }[this.severity]
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/confetti-animation/ConfettiAnimation.vue
+++ b/frontend/views/components/confetti-animation/ConfettiAnimation.vue
@@ -15,10 +15,10 @@ svg.c-svg(
 
 <script>
 import animationMixins from './AnimationMixins.js'
-export default {
+export default ({
   mixins: [animationMixins],
   name: 'ConfettiAnimation'
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/confetti-animation/confettiComponents/ConfettiCircle.vue
+++ b/frontend/views/components/confetti-animation/confettiComponents/ConfettiCircle.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'ConfettiCircle',
   inheritAttrs: false,
   props: {
@@ -30,5 +30,5 @@ export default {
     transforms: Object,
     color: String
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/confetti-animation/confettiComponents/ConfettiLogo.vue
+++ b/frontend/views/components/confetti-animation/confettiComponents/ConfettiLogo.vue
@@ -27,7 +27,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'ConfettiLogo',
   inheritAttrs: false,
   data () {
@@ -45,7 +45,7 @@ export default {
     opacity: [Number, String],
     transforms: Object
   }
-}
+}: Object)
 </script>
 
 <style scoped lang="scss">

--- a/frontend/views/components/confetti-animation/confettiComponents/ConfettiRectangle.vue
+++ b/frontend/views/components/confetti-animation/confettiComponents/ConfettiRectangle.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'ConfettiRectangle',
   inheritAttrs: false,
   props: {
@@ -30,5 +30,5 @@ export default {
     transforms: Object,
     color: String
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/confetti-animation/confettiComponents/ConfettiTriangle.vue
+++ b/frontend/views/components/confetti-animation/confettiComponents/ConfettiTriangle.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'ConfettiTriangle',
   inheritAttrs: false,
   props: {
@@ -30,5 +30,5 @@ export default {
     transforms: Object,
     color: String
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/graphs/Bars.vue
+++ b/frontend/views/components/graphs/Bars.vue
@@ -65,7 +65,7 @@ import { debounce } from '@utils/giLodash.js'
 import { TABLET } from '@view-utils/breakpoints.js'
 import currencies from '@view-utils/currencies.js'
 
-export default {
+export default ({
   name: 'Bars',
   props: {
     totals: Array,
@@ -257,7 +257,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/graphs/GraphLegendItem.vue
+++ b/frontend/views/components/graphs/GraphLegendItem.vue
@@ -11,7 +11,7 @@ li.c-wlegend(:class='`c-wlegend-${variant}`')
 </template>
 
 <script>
-export default {
+export default ({
   name: 'GraphLegendItem',
   props: {
     amount: {
@@ -27,7 +27,7 @@ export default {
       default: 'side'
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/graphs/Overview.vue
+++ b/frontend/views/components/graphs/Overview.vue
@@ -37,7 +37,7 @@ import { mapGetters } from 'vuex'
 import currencies from '@view-utils/currencies.js'
 import { GraphLegendItem, Bars } from '@components/graphs/index.js'
 
-export default {
+export default ({
   name: 'Overview',
   components: {
     GraphLegendItem,
@@ -126,7 +126,7 @@ export default {
       return list
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/graphs/PieChart.vue
+++ b/frontend/views/components/graphs/PieChart.vue
@@ -36,7 +36,7 @@
 
 import { debounce } from '@utils/giLodash.js'
 
-export default {
+export default ({
   name: 'PieChart',
   props: {
     slices: {
@@ -117,7 +117,7 @@ export default {
       this.ephemeral.isLabelVisible = false
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/graphs/Progress.vue
+++ b/frontend/views/components/graphs/Progress.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'ProgressBar',
   props: {
     max: Number,
@@ -58,7 +58,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/graphs/SupportHistory.vue
+++ b/frontend/views/components/graphs/SupportHistory.vue
@@ -19,7 +19,7 @@ div
 <script>
 import { toPercent } from '@view-utils/filters.js'
 
-export default {
+export default ({
   name: 'GroupSupportHistory',
   props: {
     history: {
@@ -47,7 +47,7 @@ export default {
   filters: {
     toPercent
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/group-creation-steps/GroupMincome.vue
+++ b/frontend/views/components/group-creation-steps/GroupMincome.vue
@@ -44,7 +44,7 @@
 <script>
 import currencies from '@view-utils/currencies.js'
 
-export default {
+export default ({
   name: 'GroupMincome',
   props: {
     group: { type: Object },
@@ -74,5 +74,5 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/group-creation-steps/GroupName.vue
+++ b/frontend/views/components/group-creation-steps/GroupName.vue
@@ -40,7 +40,7 @@
 import Avatar from '@components/Avatar.vue'
 import { imageDataURItoBlob } from '@utils/image.js'
 
-export default {
+export default ({
   name: 'GroupName',
   props: {
     group: { type: Object },
@@ -116,7 +116,7 @@ export default {
       this.$assistant.ephemeral.groupPictureType = 'image'
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/components/group-creation-steps/GroupPrivacy.vue
+++ b/frontend/views/components/group-creation-steps/GroupPrivacy.vue
@@ -9,7 +9,7 @@ div
 </template>
 
 <script>
-export default {
+export default ({
   name: 'GroupPrivacy',
   props: {
     group: { type: Object }
@@ -17,5 +17,5 @@ export default {
   mounted () {
     this.$emit('focusref', 'next')
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/group-creation-steps/GroupPurpose.vue
+++ b/frontend/views/components/group-creation-steps/GroupPurpose.vue
@@ -21,7 +21,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'GroupPurpose',
   props: {
     group: { type: Object },
@@ -40,5 +40,5 @@ export default {
       })
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/group-creation-steps/GroupRules.vue
+++ b/frontend/views/components/group-creation-steps/GroupRules.vue
@@ -35,7 +35,7 @@ import L from '@view-utils/translations.js'
 import TransitionExpand from '@components/TransitionExpand.vue'
 import VotingRulesInput from '@components/VotingRulesInput.vue'
 
-export default {
+export default ({
   name: 'GroupRules',
   props: {
     group: { type: Object },
@@ -86,7 +86,7 @@ export default {
       })
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/menu/MenuContent.vue
+++ b/frontend/views/components/menu/MenuContent.vue
@@ -10,7 +10,7 @@
 <script>
 import { mixin as clickaway } from 'vue-clickaway'
 
-export default {
+export default ({
   name: 'MenuOptions',
   mixins: [
     clickaway
@@ -26,7 +26,7 @@ export default {
       this.Menu.closeMenu()
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/menu/MenuHeader.vue
+++ b/frontend/views/components/menu/MenuHeader.vue
@@ -4,9 +4,9 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'MenuHeader'
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/menu/MenuItem.vue
+++ b/frontend/views/components/menu/MenuItem.vue
@@ -9,7 +9,7 @@ list-item.c-menuItem(disable-radius='' v-bind='$attrs' on='$listeners' @click='h
 </template>
 <script>
 import ListItem from '@components/ListItem.vue'
-export default {
+export default ({
   name: 'MenuItem',
   inject: ['Menu'],
   components: { ListItem },
@@ -20,7 +20,7 @@ export default {
       this.Menu.handleSelect(this.$attrs['item-id']) // Use $attrs to access passed props
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/components/menu/MenuParent.vue
+++ b/frontend/views/components/menu/MenuParent.vue
@@ -4,7 +4,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'MenuSelect',
   data () {
     return {
@@ -42,7 +42,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/menu/MenuTrigger.vue
+++ b/frontend/views/components/menu/MenuTrigger.vue
@@ -9,7 +9,7 @@ button(
   slot
 </template>
 <script>
-export default {
+export default ({
   name: 'MenuTrigger',
   props: {
     hideWhenActive: Boolean
@@ -25,5 +25,5 @@ export default {
       this.Menu.handleTrigger()
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/modal/Modal.vue
+++ b/frontend/views/components/modal/Modal.vue
@@ -7,7 +7,7 @@
 import sbp from '~/shared/sbp.js'
 import { OPEN_MODAL, REPLACE_MODAL, CLOSE_MODAL, SET_MODAL_QUERIES } from '@utils/events.js'
 
-export default {
+export default ({
   name: 'Modal',
   data () {
     return {
@@ -141,5 +141,5 @@ export default {
       this.queries[componentName] = queries
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/components/modal/ModalBaseTemplate.vue
+++ b/frontend/views/components/modal/ModalBaseTemplate.vue
@@ -18,7 +18,7 @@
 import modalMixins from './ModalMixins.js'
 import trapFocus from '@utils/trapFocus.js'
 
-export default {
+export default ({
   name: 'ModalBaseTemplate',
   mixins: [modalMixins, trapFocus],
   props: {
@@ -31,7 +31,7 @@ export default {
       default: true
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/components/modal/ModalClose.vue
+++ b/frontend/views/components/modal/ModalClose.vue
@@ -10,13 +10,13 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'ModalClose',
   props: {
     backOnMobile: Boolean,
     fullscreen: Boolean
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/modal/ModalTemplate.vue
+++ b/frontend/views/components/modal/ModalTemplate.vue
@@ -32,10 +32,10 @@
 import modalMixins from './ModalMixins.js'
 import trapFocus from '@utils/trapFocus.js'
 
-export default {
+export default ({
   name: 'ModalTemplate',
   mixins: [modalMixins, trapFocus]
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/components/tabs/TabItems.vue
+++ b/frontend/views/components/tabs/TabItems.vue
@@ -16,9 +16,9 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'TabItem'
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/components/tabs/TabWrapper.vue
+++ b/frontend/views/components/tabs/TabWrapper.vue
@@ -34,7 +34,7 @@ import { mapGetters } from 'vuex'
 import sbp from '~/shared/sbp.js'
 import TabItem from '@components/tabs/TabItems.vue'
 
-export default {
+export default ({
   name: 'TabWrapper',
   components: {
     TabItem
@@ -119,7 +119,7 @@ export default {
   beforeDestroy () {
     this.$router.push(this.$route.query)
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/access/LoginForm.vue
+++ b/frontend/views/containers/access/LoginForm.vue
@@ -38,7 +38,7 @@ import ButtonSubmit from '@components/ButtonSubmit.vue'
 import L from '@view-utils/translations.js'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
-export default {
+export default ({
   name: 'LoginForm',
   mixins: [
     validationMixin,
@@ -98,7 +98,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/access/LoginModal.vue
+++ b/frontend/views/containers/access/LoginModal.vue
@@ -18,7 +18,7 @@ import { REPLACE_MODAL } from '@utils/events.js'
 import LoginForm from '@containers/access/LoginForm.vue'
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 
-export default {
+export default ({
   name: 'LoginModal',
   components: {
     ModalTemplate,
@@ -33,5 +33,5 @@ export default {
       sbp('okTurtles.events/emit', REPLACE_MODAL, 'SignupModal')
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/access/PasswordForm.vue
+++ b/frontend/views/containers/access/PasswordForm.vue
@@ -28,7 +28,7 @@ label.field
 <script>
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
-export default {
+export default ({
   name: 'PasswordForm',
   data () {
     return {
@@ -70,7 +70,7 @@ export default {
   created () {
     this.isLock = !this.showPassword
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/access/PasswordModal.vue
+++ b/frontend/views/containers/access/PasswordModal.vue
@@ -69,7 +69,7 @@ import { required, minLength } from 'vuelidate/lib/validators'
 import sameAs from 'vuelidate/lib/validators/sameAs.js'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'PasswordModal',
   mixins: [validationMixin],
   data () {
@@ -128,7 +128,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/access/SignupForm.vue
+++ b/frontend/views/containers/access/SignupForm.vue
@@ -49,7 +49,7 @@ import ButtonSubmit from '@components/ButtonSubmit.vue'
 import L from '@view-utils/translations.js'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
-export default {
+export default ({
   name: 'SignupForm',
   mixins: [
     validationMixin,
@@ -137,5 +137,5 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/access/SignupModal.vue
+++ b/frontend/views/containers/access/SignupModal.vue
@@ -18,7 +18,7 @@ import sbp from '~/shared/sbp.js'
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import SignupForm from '@containers/access/SignupForm.vue'
 
-export default {
+export default ({
   name: 'Signup',
   components: {
     ModalTemplate,
@@ -40,5 +40,5 @@ export default {
       sbp('okTurtles.events/emit', REPLACE_MODAL, 'LoginModal')
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -71,7 +71,7 @@ import Emoticons from './Emoticons.vue'
 import { currentUserId, messageTypes, fakeEvents } from '@containers/chatroom/fakeStore.js'
 import { proximityDate } from '@utils/time.js'
 
-export default {
+export default ({
   name: 'ChatMain',
   components: {
     Avatar,
@@ -285,7 +285,7 @@ export default {
       this.$forceUpdate()
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/ChatNav.vue
+++ b/frontend/views/containers/chatroom/ChatNav.vue
@@ -23,7 +23,7 @@
 import MainHeader from './MainHeader.vue'
 import { MenuParent, MenuTrigger, MenuContent, MenuItem } from '@components/menu/index.js'
 
-export default {
+export default ({
   name: 'ChatNav',
   components: {
     MainHeader,
@@ -39,7 +39,7 @@ export default {
   },
   computed: {},
   methods: {}
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/Chatroom.vue
+++ b/frontend/views/containers/chatroom/Chatroom.vue
@@ -17,7 +17,7 @@
 // import ChatMain from './ChatMain.vue'
 // import ChatNav from './ChatNav.vue'
 
-// export default {
+// export default ({
 //   name: 'Chatroom',
 //   components: {
 //     ChatMain,
@@ -156,7 +156,7 @@
 //       })
 //     }
 //   }
-// }
+// }: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/ConversationGreetings.vue
+++ b/frontend/views/containers/chatroom/ConversationGreetings.vue
@@ -26,7 +26,7 @@ import L from '@view-utils/translations.js'
 import { OPEN_MODAL } from '@utils/events.js'
 import sbp from '~/shared/sbp.js'
 
-export default {
+export default ({
   name: 'ConversationGreetings',
   components: {
     MessageNotification,
@@ -57,7 +57,7 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, modal, props)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/ConversationsList.vue
+++ b/frontend/views/containers/chatroom/ConversationsList.vue
@@ -35,7 +35,7 @@ import sbp from '~/shared/sbp.js'
 import ListItem from '@components/ListItem.vue'
 import Avatar from '@components/Avatar.vue'
 
-export default {
+export default ({
   name: 'ConversationsList',
   components: {
     ListItem,
@@ -78,7 +78,7 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, modal, queries)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/CreateNewChannelModal.vue
+++ b/frontend/views/containers/chatroom/CreateNewChannelModal.vue
@@ -76,7 +76,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import L from '@view-utils/translations.js'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
-export default {
+export default ({
   name: 'CreateNewChannelModal',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -112,7 +112,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/DeleteChannelModal.vue
+++ b/frontend/views/containers/chatroom/DeleteChannelModal.vue
@@ -45,7 +45,7 @@ import ButtonSubmit from '@components/ButtonSubmit.vue'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'DeleteChannelModal',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -90,7 +90,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/EditChannelDescriptionModal.vue
+++ b/frontend/views/containers/chatroom/EditChannelDescriptionModal.vue
@@ -44,7 +44,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import L from '@view-utils/translations.js'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
-export default {
+export default ({
   name: 'EditChannelDescriptionModal',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -84,7 +84,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/EditChannelNameModal.vue
+++ b/frontend/views/containers/chatroom/EditChannelNameModal.vue
@@ -43,7 +43,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import L from '@view-utils/translations.js'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
-export default {
+export default ({
   name: 'EditChannelNameModal',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -81,7 +81,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/Emoticons.vue
+++ b/frontend/views/containers/chatroom/Emoticons.vue
@@ -12,7 +12,7 @@ import sbp from '~/shared/sbp.js'
 import { TABLET, DESKTOP } from '@view-utils/breakpoints.js'
 import { OPEN_EMOTICON, CLOSE_EMOTICON, SELECT_EMOTICON } from '@utils/events.js'
 
-export default {
+export default ({
   name: 'Chatroom',
   components: {
     Picker
@@ -87,7 +87,7 @@ export default {
       sbp('okTurtles.events/emit', CLOSE_EMOTICON)
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss">
 @import "@assets/style/components/_emoji-mart.scss";

--- a/frontend/views/containers/chatroom/GroupMembersDirectMessages.vue
+++ b/frontend/views/containers/chatroom/GroupMembersDirectMessages.vue
@@ -65,7 +65,7 @@ import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import Search from '@components/Search.vue'
 import AvatarUser from '@components/AvatarUser.vue'
 
-export default {
+export default ({
   name: 'GroupMembersAllModal',
   components: {
     ModalBaseTemplate,
@@ -114,7 +114,7 @@ export default {
       this.$refs.modal.close()
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/GroupsShortcut.vue
+++ b/frontend/views/containers/chatroom/GroupsShortcut.vue
@@ -26,7 +26,7 @@
 import Avatar from '@components/Avatar.vue'
 import Badge from '@components/Badge.vue'
 
-export default {
+export default ({
   // NOTE - maybe this approach should be used in the sidebar to switch between groups instead of a dropdown...
   name: 'GroupsShortcut',
   components: {
@@ -47,7 +47,7 @@ export default {
       return ['#958cfd', '#fd978c', '#62d27d'][index] || ''
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/LeaveChannelModal.vue
+++ b/frontend/views/containers/chatroom/LeaveChannelModal.vue
@@ -26,7 +26,7 @@ import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 import { mapGetters } from 'vuex'
 
-export default {
+export default ({
   name: 'ChannelLeaveModal',
   components: {
     ModalTemplate,
@@ -46,7 +46,7 @@ export default {
       console.log('Todo')
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/LinkPreview.vue
+++ b/frontend/views/containers/chatroom/LinkPreview.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'link-preview',
   props: {
     url: {
@@ -55,5 +55,5 @@ export default {
       return this.validUrl
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/chatroom/MainHeader.vue
+++ b/frontend/views/containers/chatroom/MainHeader.vue
@@ -30,7 +30,7 @@ header.c-header(
 <script>
 import Avatar from '@components/Avatar.vue'
 
-export default {
+export default ({
   // TODO later - apply & adapt this MainHeader to all other pages
   // - maybe create ChatHeader that consumes MainHeader
   name: 'MainHeader',
@@ -42,7 +42,7 @@ export default {
     description: String,
     routerBack: String
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/Message.vue
+++ b/frontend/views/containers/chatroom/Message.vue
@@ -16,7 +16,7 @@ const variants = {
   FAILED: 'failed'
 }
 
-export default {
+export default ({
   name: 'Message',
   components: {
     MessageBase
@@ -64,7 +64,7 @@ export default {
       this.$emit('add-emoticon', emoticon)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -93,7 +93,7 @@ menu-parent(ref='menu')
 import { MenuParent, MenuTrigger, MenuContent, MenuItem } from '@components/menu/index.js'
 import Tooltip from '@components/Tooltip.vue'
 
-export default {
+export default ({
   name: 'MessageActions',
   components: {
     MenuParent,
@@ -112,7 +112,7 @@ export default {
       this.$emit(type, e)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -60,7 +60,7 @@ import MessageActions from './MessageActions.vue'
 import MessageReactions from './MessageReactions.vue'
 import SendArea from './SendArea.vue'
 
-export default {
+export default ({
   name: 'MessageBase',
   mixins: [emoticonsMixins],
   components: {
@@ -123,7 +123,7 @@ export default {
       this.$refs.messageAction.$refs.menu.handleTrigger()
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/MessageInteractive.vue
+++ b/frontend/views/containers/chatroom/MessageInteractive.vue
@@ -67,7 +67,7 @@ const interactiveMessage = (interaction, summary = null) => {
   }
 }
 
-export default {
+export default ({
   name: 'MessageInteractive',
   props: {
     id: String,
@@ -136,7 +136,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/MessageNotification.vue
+++ b/frontend/views/containers/chatroom/MessageNotification.vue
@@ -11,7 +11,7 @@ import { interactionType, fakeEvents, users } from '@containers/chatroom/fakeSto
 import chatroom from '@containers/chatroom/chatroom.js'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'MessageNotification',
   components: {
     MessageBase
@@ -79,7 +79,7 @@ export default {
       this.$emit('add-emoticon', emoticon)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/MessageReactions.vue
+++ b/frontend/views/containers/chatroom/MessageReactions.vue
@@ -29,7 +29,7 @@ import Tooltip from '@components/Tooltip.vue'
 import { users } from '@containers/chatroom/fakeStore.js'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'MessageReactions',
   mixins: [emoticonsMixins],
   components: {
@@ -58,7 +58,7 @@ export default {
       return L('{userList} reacted with {emotiName}', data)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -74,7 +74,7 @@
 import emoticonsMixins from './EmoticonsMixins.js'
 import Tooltip from '@components/Tooltip.vue'
 
-export default {
+export default ({
   name: 'Chatroom',
   mixins: [emoticonsMixins],
   components: {
@@ -214,7 +214,7 @@ export default {
       this.updateTextWithLines()
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/contributions/AddIncomeDetailsWidget.vue
+++ b/frontend/views/containers/contributions/AddIncomeDetailsWidget.vue
@@ -22,7 +22,7 @@ import SvgHello from '@svgs/hello.svg'
 import SvgContributions from '@svgs/contributions.svg'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'AddIncomeDetailsWidget',
   components: {
     CalloutCard
@@ -60,5 +60,5 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, name)
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/contributions/Contribution.vue
+++ b/frontend/views/containers/contributions/Contribution.vue
@@ -69,7 +69,7 @@ import { required } from 'vuelidate/lib/validators'
 import L from '@view-utils/translations.js'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 
-export default {
+export default ({
   name: 'Contribution',
   mixins: [validationMixin],
   components: {
@@ -187,7 +187,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/contributions/ContributionItem.vue
+++ b/frontend/views/containers/contributions/ContributionItem.vue
@@ -32,7 +32,7 @@
 <script>
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'ContributionItem',
   props: {
     who: [String, Array],
@@ -136,7 +136,7 @@ export default {
       return `icon-${style[this.type].icon} icon-round has-background-${style[this.type].color} has-text-${style[this.type].color}`
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/contributions/ContributionsOverviewWidget.vue
+++ b/frontend/views/containers/contributions/ContributionsOverviewWidget.vue
@@ -19,7 +19,7 @@ import Overview from '@components/graphs/Overview.vue'
 import SupportHistory from '@components/graphs/SupportHistory.vue'
 import PageSection from '@components/PageSection.vue'
 
-export default {
+export default ({
   name: 'ContributionsOverview',
   data () {
     return {
@@ -36,7 +36,7 @@ export default {
       this.showHistory = !this.showHistory
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/contributions/ContributionsWidget.vue
+++ b/frontend/views/containers/contributions/ContributionsWidget.vue
@@ -47,7 +47,7 @@ import ProgressBar from '@components/graphs/Progress.vue'
 import L, { LTags } from '@view-utils/translations.js'
 import currencies from '@view-utils/currencies.js'
 
-export default {
+export default ({
   name: 'ContributionsWidget',
   components: {
     PageSection,
@@ -175,7 +175,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/containers/contributions/GroupPledgesGraph.vue
+++ b/frontend/views/containers/contributions/GroupPledgesGraph.vue
@@ -51,7 +51,7 @@ import Tooltip from '@components/Tooltip.vue'
 import currencies from '@view-utils/currencies.js'
 import distributeIncome from '@utils/distribution/mincome-proportional.js'
 
-export default {
+export default ({
   name: 'GroupPledgesGraph',
   components: {
     PieChart,
@@ -201,7 +201,7 @@ export default {
       return Math.min(Math.max(0, perc), 1)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -84,7 +84,7 @@ import ButtonSubmit from '@components/ButtonSubmit.vue'
 import TransitionExpand from '@components/TransitionExpand.vue'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'IncomeDetails',
   mixins: [validationMixin],
   components: {
@@ -226,7 +226,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/contributions/PaymentMethods.vue
+++ b/frontend/views/containers/contributions/PaymentMethods.vue
@@ -50,7 +50,7 @@ import { mapGetters } from 'vuex'
 import Vue from 'vue'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'PaymentMethods',
   components: {},
   data: () => ({
@@ -121,7 +121,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/dashboard/GroupMembers.vue
+++ b/frontend/views/containers/dashboard/GroupMembers.vue
@@ -47,7 +47,7 @@ import ProfileCard from '@components/ProfileCard.vue'
 import GroupMembersTooltipPending from '@containers/dashboard/GroupMembersTooltipPending.vue'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'GroupMembers',
   components: {
     Avatar,
@@ -97,7 +97,7 @@ export default {
       this.openModal(modalAction)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/dashboard/GroupMembersAllModal.vue
+++ b/frontend/views/containers/dashboard/GroupMembersAllModal.vue
@@ -114,7 +114,7 @@ import AvatarUser from '@components/AvatarUser.vue'
 import ProfileCard from '@components/ProfileCard.vue'
 import GroupMembersTooltipPending from '@containers/dashboard/GroupMembersTooltipPending.vue'
 
-export default {
+export default ({
   name: 'GroupMembersAllModal',
   components: {
     ModalBaseTemplate,
@@ -177,7 +177,7 @@ export default {
       console.log('TODO addToChannel')
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/dashboard/GroupMembersTooltipPending.vue
+++ b/frontend/views/containers/dashboard/GroupMembersTooltipPending.vue
@@ -11,7 +11,7 @@ import { mapGetters } from 'vuex'
 import Tooltip from '@components/Tooltip.vue'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'GroupMembersTooltipPending',
   components: {
     Tooltip
@@ -32,5 +32,5 @@ export default {
         : L('This member did not use their invite link to join the group yet. This link should be given to them by {invitedBy}.', { invitedBy })
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/dashboard/GroupMincome.vue
+++ b/frontend/views/containers/dashboard/GroupMincome.vue
@@ -16,7 +16,7 @@ import sbp from '~/shared/sbp.js'
 import { OPEN_MODAL } from '@utils/events.js'
 import { mapGetters } from 'vuex'
 
-export default {
+export default ({
   name: 'GroupMincome',
   computed: {
     ...mapGetters([
@@ -29,7 +29,7 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, 'MincomeProposal')
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/dashboard/GroupPurpose.vue
+++ b/frontend/views/containers/dashboard/GroupPurpose.vue
@@ -24,7 +24,7 @@
 <script>
 import { mapGetters } from 'vuex'
 
-export default {
+export default ({
   name: 'GroupPurpose',
   computed: {
     ...mapGetters([
@@ -37,7 +37,7 @@ export default {
       console.log('Open shared value form')
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/dashboard/StartInvitingWidget.vue
+++ b/frontend/views/containers/dashboard/StartInvitingWidget.vue
@@ -14,7 +14,7 @@ import { OPEN_MODAL } from '@utils/events.js'
 import CalloutCard from '@components/CalloutCard.vue'
 import SvgConversation from '@svgs/conversation.svg'
 
-export default {
+export default ({
   name: 'StartInvitingWidget',
   components: {
     CalloutCard,
@@ -30,5 +30,5 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, 'InvitationLinkModal')
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/design-system/DSModalFullscreen.vue
+++ b/frontend/views/containers/design-system/DSModalFullscreen.vue
@@ -33,7 +33,7 @@ import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import sbp from '~/shared/sbp.js'
 import { OPEN_MODAL } from '@utils/events.js'
 
-export default {
+export default ({
   name: 'ModalDSNestedExample',
   components: {
     ModalBaseTemplate
@@ -51,7 +51,7 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, mode)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/design-system/DSModalNested.vue
+++ b/frontend/views/containers/design-system/DSModalNested.vue
@@ -50,7 +50,7 @@ import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import sbp from '~/shared/sbp.js'
 import { OPEN_MODAL } from '@utils/events.js'
 
-export default {
+export default ({
   name: 'DSModalSimple',
   data () {
     return {
@@ -77,5 +77,5 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, mode)
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/design-system/DSModalQuery.vue
+++ b/frontend/views/containers/design-system/DSModalQuery.vue
@@ -15,7 +15,7 @@ import { OPEN_MODAL, CLOSE_MODAL, SET_MODAL_QUERIES } from '@utils/events.js'
 import LoginForm from '@containers/access/LoginForm.vue'
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 
-export default {
+export default ({
   name: 'LoginModal',
   components: {
     ModalTemplate,
@@ -40,5 +40,5 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, name)
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -74,7 +74,7 @@ import {
 // but then the browser complains about "require is not defined"
 import { required, requiredIf, between } from 'vuelidate/lib/validators'
 
-export default {
+export default ({
   name: 'GroupCreationModal',
   mixins: [
     StepAssistant,
@@ -214,7 +214,7 @@ export default {
       ]
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/group-settings/GroupDeletionModal.vue
+++ b/frontend/views/containers/group-settings/GroupDeletionModal.vue
@@ -48,7 +48,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import L from '@view-utils/translations.js'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 
-export default {
+export default ({
   name: 'GroupDeletionModal',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -89,7 +89,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/group-settings/GroupJoinModal.vue
+++ b/frontend/views/containers/group-settings/GroupJoinModal.vue
@@ -43,7 +43,7 @@ import SvgAccess from '@svgs/access.svg'
 import SvgInvitation from '@svgs/invitation.svg'
 import SvgProposal from '@svgs/proposal.svg'
 
-export default {
+export default ({
   name: 'GroupJoinModal',
   components: {
     ModalBaseTemplate,
@@ -100,7 +100,7 @@ export default {
       history.pushState(null, null, `#${this.config[i]}`)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/group-settings/GroupLeaveModal.vue
+++ b/frontend/views/containers/group-settings/GroupLeaveModal.vue
@@ -64,7 +64,7 @@ import ButtonSubmit from '@components/ButtonSubmit.vue'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'GroupLeaveModal',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -129,7 +129,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/group-settings/GroupRulesSettings.vue
+++ b/frontend/views/containers/group-settings/GroupRulesSettings.vue
@@ -41,7 +41,7 @@ import { OPEN_MODAL } from '@utils/events.js'
 import L from '@view-utils/translations.js'
 import BannerSimple from '@components/banners/BannerSimple.vue'
 
-export default {
+export default ({
   name: 'GroupVotingSystem',
   components: {
     BannerSimple
@@ -137,7 +137,7 @@ export default {
       }[ruleName]
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/group-settings/InvitationLinkModal.vue
+++ b/frontend/views/containers/group-settings/InvitationLinkModal.vue
@@ -20,7 +20,7 @@ import LinkToCopy from '@components/LinkToCopy.vue'
 import { INVITE_INITIAL_CREATOR } from '@model/contracts/constants.js'
 import { buildInvitationUrl } from '@model/contracts/voting/proposals.js'
 
-export default {
+export default ({
   name: 'InvitationLinkModal',
   components: {
     ModalTemplate,
@@ -48,7 +48,7 @@ export default {
       this.$refs.modal.close()
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/containers/group-settings/InvitationsTable.vue
+++ b/frontend/views/containers/group-settings/InvitationsTable.vue
@@ -118,7 +118,7 @@ import { INVITE_INITIAL_CREATOR, INVITE_STATUS } from '@model/contracts/constant
 import { mapGetters, mapState } from 'vuex'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'InvitationsTable',
   components: {
     BannerScoped,
@@ -270,7 +270,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/loading-error/ErrorModal.vue
+++ b/frontend/views/containers/loading-error/ErrorModal.vue
@@ -18,7 +18,7 @@
 <script>
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 
-export default {
+export default ({
   name: 'LoadingModal',
   components: {
     ModalTemplate
@@ -29,7 +29,7 @@ export default {
       default: 500
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/loading-error/ErrorPage.vue
+++ b/frontend/views/containers/loading-error/ErrorPage.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'ErrorPage',
   props: {
     type: {
@@ -21,7 +21,7 @@ export default {
       default: 500
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/loading-error/LoadingBaseModal.vue
+++ b/frontend/views/containers/loading-error/LoadingBaseModal.vue
@@ -10,12 +10,12 @@
 <script>
 import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 
-export default {
+export default ({
   name: 'LoadingModal',
   components: {
     ModalBaseTemplate
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/loading-error/LoadingModal.vue
+++ b/frontend/views/containers/loading-error/LoadingModal.vue
@@ -9,12 +9,12 @@
 <script>
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 
-export default {
+export default ({
   name: 'LoadingModal',
   components: {
     ModalTemplate
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/loading-error/LoadingPage.vue
+++ b/frontend/views/containers/loading-error/LoadingPage.vue
@@ -15,9 +15,9 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'LoadingPage'
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/navigation/Activity.vue
+++ b/frontend/views/containers/navigation/Activity.vue
@@ -23,7 +23,7 @@ menu-parent
 import { MenuParent, MenuTrigger, MenuContent, MenuHeader, MenuItem } from '@components/menu/index.js'
 import Badge from '@components/Badge.vue'
 
-export default {
+export default ({
   name: 'Activity',
   props: {
     activityCount: Number
@@ -37,7 +37,7 @@ export default {
     MenuHeader,
     MenuItem
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/navigation/CypressBypassUI.vue
+++ b/frontend/views/containers/navigation/CypressBypassUI.vue
@@ -9,7 +9,7 @@
 <script>
 import { humanDate } from '@utils/time.js'
 
-export default {
+export default ({
   name: 'CypressBypassUI',
   methods: {
     humanDate,
@@ -20,7 +20,7 @@ export default {
       this.$router.push({ path })
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/navigation/GroupsList.vue
+++ b/frontend/views/containers/navigation/GroupsList.vue
@@ -34,7 +34,7 @@ import Tooltip from '@components/Tooltip.vue'
 import sbp from '~/shared/sbp.js'
 import { OPEN_MODAL } from '@utils/events.js'
 
-export default {
+export default ({
   name: 'GroupsList',
   components: {
     Avatar,
@@ -59,7 +59,7 @@ export default {
       this.$store.commit('setCurrentGroupId', hash)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/navigation/Navigation.vue
+++ b/frontend/views/containers/navigation/Navigation.vue
@@ -91,7 +91,7 @@ import { OPEN_MODAL } from '@utils/events.js'
 import { DESKTOP } from '@view-utils/breakpoints.js'
 import { debounce } from '@utils/giLodash.js'
 
-export default {
+export default ({
   name: 'Navigation',
   components: {
     Toggle,
@@ -165,7 +165,7 @@ export default {
       this.ephemeral.isTouch = window.innerWidth < DESKTOP
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/navigation/Profile.vue
+++ b/frontend/views/containers/navigation/Profile.vue
@@ -30,7 +30,7 @@ import sbp from '~/shared/sbp.js'
 import { OPEN_MODAL } from '@utils/events.js'
 import { mapGetters } from 'vuex'
 
-export default {
+export default ({
   name: 'Profile',
   components: {
     AvatarUser,
@@ -50,7 +50,7 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, mode)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/navigation/TimeTravel.vue
+++ b/frontend/views/containers/navigation/TimeTravel.vue
@@ -19,7 +19,7 @@ import { cloneDeep } from '@utils/giLodash.js'
 import '~/shared/domains/okTurtles/data.js'
 import '~/shared/domains/okTurtles/events.js'
 const disableTimeTravel = false
-export default {
+export default ({
   name: 'TimeTravel',
   components: { VueSlider },
   created () {
@@ -74,7 +74,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/MonthOverview.vue
+++ b/frontend/views/containers/payments/MonthOverview.vue
@@ -38,7 +38,7 @@ import ProgressBar from '@components/graphs/Progress.vue'
 import L from '@view-utils/translations.js'
 import { humanDate } from '@utils/time.js'
 
-export default {
+export default ({
   name: 'MonthOverview',
   components: {
     ProgressBar
@@ -112,7 +112,7 @@ export default {
       return this.ourGroupProfile.incomeDetailsType === 'incomeAmount'
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/PaymentDetail.vue
+++ b/frontend/views/containers/payments/PaymentDetail.vue
@@ -37,7 +37,7 @@ import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import currencies from '@view-utils/currencies.js'
 import { ISOStringToMonthstamp, dateFromMonthstamp, humanDate } from '@utils/time.js'
 
-export default {
+export default ({
   name: 'PaymentDetail',
   components: {
     ModalTemplate
@@ -90,7 +90,7 @@ export default {
   validations: {
     form: {}
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/PaymentRowReceived.vue
+++ b/frontend/views/containers/payments/PaymentRowReceived.vue
@@ -39,7 +39,7 @@ import L from '@view-utils/translations.js'
 
 // TODO: handle showing PAYMENT_CANCELLED ?
 
-export default {
+export default ({
   name: 'PaymentRowReceived',
   components: {
     MenuItem,
@@ -88,7 +88,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/PaymentRowRecord.vue
+++ b/frontend/views/containers/payments/PaymentRowRecord.vue
@@ -30,7 +30,7 @@ import currencies from '@view-utils/currencies.js'
 import { humanDate } from '@utils/time.js'
 import PaymentRow from './payment-row/PaymentRow.vue'
 
-export default {
+export default ({
   name: 'PaymentRowRecord',
   components: {
     PaymentRow
@@ -78,7 +78,7 @@ export default {
       this.form.amount = this.config.initialAmount
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/PaymentRowSent.vue
+++ b/frontend/views/containers/payments/PaymentRowSent.vue
@@ -37,7 +37,7 @@ import PaymentRow from './payment-row/PaymentRow.vue'
 import PaymentActionsMenu from './payment-row/PaymentActionsMenu.vue'
 import PaymentNotReceivedTooltip from './payment-row/PaymentNotReceivedTooltip.vue'
 
-export default {
+export default ({
   name: 'PaymentRowSent',
   components: {
     AvatarUser,
@@ -84,7 +84,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/PaymentRowTodo.vue
+++ b/frontend/views/containers/payments/PaymentRowTodo.vue
@@ -36,7 +36,7 @@ import PaymentRow from './payment-row/PaymentRow.vue'
 import PaymentActionsMenu from './payment-row/PaymentActionsMenu.vue'
 import PaymentNotReceivedTooltip from './payment-row/PaymentNotReceivedTooltip.vue'
 
-export default {
+export default ({
   name: 'PaymentRowTodo',
   components: {
     MenuItem,
@@ -83,7 +83,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/PaymentsHistoryModal.vue
+++ b/frontend/views/containers/payments/PaymentsHistoryModal.vue
@@ -6,7 +6,7 @@ modal-base-template(:fullscreen='true' :a11yTitle='L("Payments History")')
 <script>
 import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 
-export default {
+export default ({
   name: 'PlaceHolder',
   components: {
     ModalBaseTemplate
@@ -14,5 +14,5 @@ export default {
   props: {
     name: String
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/payments/PaymentsList.vue
+++ b/frontend/views/containers/payments/PaymentsList.vue
@@ -21,7 +21,7 @@ import PaymentRowTodo from './PaymentRowTodo.vue'
 import PaymentRowSent from './PaymentRowSent.vue'
 import PaymentRowReceived from './PaymentRowReceived.vue'
 
-export default {
+export default ({
   name: 'PaymentsList',
   components: {
     AvatarUser,
@@ -45,7 +45,7 @@ export default {
       required: true
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/PaymentsPagination.vue
+++ b/frontend/views/containers/payments/PaymentsPagination.vue
@@ -46,7 +46,7 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'PaymentsPagination',
   props: {
     count: Number,
@@ -84,7 +84,7 @@ export default {
       this.$emit('change-page', 'next')
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/RecordPayment.vue
+++ b/frontend/views/containers/payments/RecordPayment.vue
@@ -83,7 +83,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import BannerSimple from '@components/banners/BannerSimple.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 
-export default {
+export default ({
   name: 'RecordPayment',
   mixins: [validationMixin],
   components: {
@@ -252,7 +252,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/RecordPaymentsList.vue
+++ b/frontend/views/containers/payments/RecordPaymentsList.vue
@@ -26,7 +26,7 @@ import AvatarUser from '@components/AvatarUser.vue'
 import Tooltip from '@components/Tooltip.vue'
 import PaymentRowRecord from './PaymentRowRecord.vue'
 
-export default {
+export default ({
   name: 'RecordPaymentsList',
   components: {
     AvatarUser,
@@ -63,7 +63,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/payment-row/PaymentActionsMenu.vue
+++ b/frontend/views/containers/payments/payment-row/PaymentActionsMenu.vue
@@ -10,7 +10,7 @@
 <script>
 import { MenuParent, MenuTrigger, MenuContent, MenuItem } from '@components/menu/index.js'
 
-export default {
+export default ({
   name: 'PaymentNotReceivedTooltip',
   components: {
     MenuParent,
@@ -21,7 +21,7 @@ export default {
   props: {
     member: String
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/payment-row/PaymentNotReceivedTooltip.vue
+++ b/frontend/views/containers/payments/payment-row/PaymentNotReceivedTooltip.vue
@@ -12,7 +12,7 @@
 <script>
 import Tooltip from '@components/Tooltip.vue'
 
-export default {
+export default ({
   name: 'PaymentNotReceivedTooltip',
   components: {
     Tooltip
@@ -20,7 +20,7 @@ export default {
   props: {
     member: String
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/payments/payment-row/PaymentRow.vue
+++ b/frontend/views/containers/payments/payment-row/PaymentRow.vue
@@ -25,7 +25,7 @@ import AvatarUser from '@components/AvatarUser.vue'
 import { humanDate } from '@utils/time.js'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'PaymentRowSent',
   components: {
     AvatarUser
@@ -51,7 +51,7 @@ export default {
   methods: {
     humanDate
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/proposals/AddMembers.vue
+++ b/frontend/views/containers/proposals/AddMembers.vue
@@ -52,7 +52,7 @@ import sbp from '~/shared/sbp.js'
 import { PROPOSAL_INVITE_MEMBER } from '@model/contracts/voting/constants.js'
 import ProposalTemplate from './ProposalTemplate.vue'
 
-export default {
+export default ({
   name: 'AddMembers',
   mixins: [validationMixin],
   components: {
@@ -141,7 +141,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/containers/proposals/ChangeVotingRules.vue
+++ b/frontend/views/containers/proposals/ChangeVotingRules.vue
@@ -37,7 +37,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import ProposalTemplate from './ProposalTemplate.vue'
 import VotingRulesInput from '@components/VotingRulesInput.vue'
 
-export default {
+export default ({
   name: 'ChangeVotingRules',
   components: {
     BannerScoped,
@@ -190,7 +190,7 @@ export default {
       ]
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/proposals/Mincome.vue
+++ b/frontend/views/containers/proposals/Mincome.vue
@@ -37,7 +37,7 @@ import ProposalTemplate from './ProposalTemplate.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import { PROPOSAL_GROUP_SETTING_CHANGE } from '@model/contracts/voting/constants.js'
 
-export default {
+export default ({
   name: 'MincomeProposal',
   components: {
     ProposalTemplate,
@@ -152,7 +152,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/containers/proposals/ProposalBox.vue
+++ b/frontend/views/containers/proposals/ProposalBox.vue
@@ -25,7 +25,7 @@ import ProposalItem from './ProposalItem.vue'
 import { STATUS_OPEN } from '@model/contracts/voting/constants.js'
 import { TABLET } from '@view-utils/breakpoints.js'
 
-export default {
+export default ({
   name: 'ProposalBox',
   props: {
     proposalHashes: Array // [hash1, hash2, ...]
@@ -107,7 +107,7 @@ export default {
       this.ephemeral.isReasonHidden = !this.ephemeral.isReasonHidden
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/proposals/ProposalItem.vue
+++ b/frontend/views/containers/proposals/ProposalItem.vue
@@ -58,7 +58,7 @@ import LinkToCopy from '@components/LinkToCopy.vue'
 import Tooltip from '@components/Tooltip.vue'
 import { INVITE_STATUS } from '@model/contracts/constants.js'
 
-export default {
+export default ({
   name: 'ProposalItem',
   props: {
     proposalHash: String
@@ -207,7 +207,7 @@ export default {
       return false
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/proposals/ProposalTemplate.vue
+++ b/frontend/views/containers/proposals/ProposalTemplate.vue
@@ -94,7 +94,7 @@ import ButtonSubmit from '@components/ButtonSubmit.vue'
 import ModalTemplate from '@components/modal/ModalTemplate.vue'
 import SvgProposal from '@svgs/proposal.svg'
 
-export default {
+export default ({
   name: 'ModalForm',
   components: {
     ModalTemplate,
@@ -207,7 +207,7 @@ export default {
       await this.$listeners.submit(form)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/containers/proposals/ProposalVoteOptions.vue
+++ b/frontend/views/containers/proposals/ProposalVoteOptions.vue
@@ -32,7 +32,7 @@ import { PROPOSAL_INVITE_MEMBER, PROPOSAL_REMOVE_MEMBER } from '@model/contracts
 import { createInvite } from '@model/contracts/group.js'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 
-export default {
+export default ({
   name: 'Vote',
   props: {
     proposalHash: String
@@ -157,7 +157,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/containers/proposals/ProposalsWidget.vue
+++ b/frontend/views/containers/proposals/ProposalsWidget.vue
@@ -30,7 +30,7 @@ import ProposalBox from '@containers/proposals/ProposalBox.vue'
 import PageSection from '@components/PageSection.vue'
 import { STATUS_OPEN } from '@model/contracts/voting/constants.js'
 
-export default {
+export default ({
   name: 'ProposalsWidget',
   components: {
     ProposalBox,
@@ -106,5 +106,5 @@ export default {
       return proposal.votes[this.ourUserIdentityContract.attributes.username] || proposal.status !== STATUS_OPEN
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/proposals/RemoveMember.vue
+++ b/frontend/views/containers/proposals/RemoveMember.vue
@@ -112,7 +112,7 @@ export default ({
         })
         this.$refs.proposal.close()
       } catch (e) {
-        console.error(`Failed to remove member ${member}.`, e)
+        console.error('Failed to remove member %s:', member, e.message)
         this.$refs.formMsg.danger(e.message)
       }
     }

--- a/frontend/views/containers/proposals/RemoveMember.vue
+++ b/frontend/views/containers/proposals/RemoveMember.vue
@@ -25,7 +25,7 @@ import { PROPOSAL_REMOVE_MEMBER } from '@model/contracts/voting/constants.js'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import ProposalTemplate from './ProposalTemplate.vue'
 
-export default {
+export default ({
   name: 'RemoveMember',
   components: {
     Avatar,
@@ -117,7 +117,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -41,7 +41,7 @@ import sbp from '~/shared/sbp.js'
 import { CAPTURED_LOGS, SET_APP_LOGS_FILTER } from '@utils/events.js'
 import { downloadLogs, getLog } from '@model/captureLogs.js'
 
-export default {
+export default ({
   name: 'AppLogs',
   data () {
     return {
@@ -126,7 +126,7 @@ export default {
       downloadLogs(this.$refs.linkDownload)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/user-settings/Appearence.vue
+++ b/frontend/views/containers/user-settings/Appearence.vue
@@ -40,7 +40,7 @@ import { mapMutations } from 'vuex'
 import SelectorTheme from './Theme.vue'
 import SelectorFontSize from './FontSize.vue'
 
-export default {
+export default ({
   name: 'SettingsAppearence',
   components: {
     SelectorTheme,
@@ -58,7 +58,7 @@ export default {
       this.setReducedMotion(e.target.checked)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/user-settings/FontSize.vue
+++ b/frontend/views/containers/user-settings/FontSize.vue
@@ -12,7 +12,7 @@ Slider(
 import { mapGetters, mapMutations } from 'vuex'
 import Slider from '@components/Slider.vue'
 
-export default {
+export default ({
   name: 'FontSize',
 
   data () {
@@ -58,5 +58,5 @@ export default {
       })
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/containers/user-settings/Placeholder.vue
+++ b/frontend/views/containers/user-settings/Placeholder.vue
@@ -5,9 +5,9 @@
 </template>
 
 <script>
-export default {
+export default ({
   name: 'PlaceHolder'
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/user-settings/Theme.vue
+++ b/frontend/views/containers/user-settings/Theme.vue
@@ -25,7 +25,7 @@ import { mapGetters, mapMutations } from 'vuex'
 import Themes from '@model/colors.js'
 import colorsMixins from '@view-utils/colorsManipulation.js'
 
-export default {
+export default ({
   name: 'SelectorTheme',
 
   mixins: [colorsMixins],
@@ -47,7 +47,7 @@ export default {
       'colors'
     ])
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/user-settings/Troubleshooting.vue
+++ b/frontend/views/containers/user-settings/Troubleshooting.vue
@@ -44,7 +44,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import BannerSimple from '@components/banners/BannerSimple.vue'
 import ProgressBar from '@components/graphs/Progress.vue'
 
-export default {
+export default ({
   name: 'Troubleshooting',
   components: {
     BannerScoped,
@@ -144,7 +144,7 @@ export default {
       this.ephemeral.progress.percentage = percentage
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -88,7 +88,7 @@ import ButtonSubmit from '@components/ButtonSubmit.vue'
 import sbp from '~/shared/sbp.js'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'UserProfile',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -157,7 +157,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/containers/user-settings/UserSettingsModal.vue
+++ b/frontend/views/containers/user-settings/UserSettingsModal.vue
@@ -16,7 +16,7 @@ import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import TabWrapper from '@components/tabs/TabWrapper.vue'
 import settings from './settings.js'
 
-export default {
+export default ({
   name: 'SettingsWrapper',
   components: {
     ModalBaseTemplate,
@@ -28,7 +28,7 @@ export default {
   created () {
     sbp('okTurtles.events/emit', SET_MODAL_QUERIES, 'UserSettingsModal', { section: true })
   }
-}
+}: Object)
 </script>
 
 <style lang='scss' scoped>

--- a/frontend/views/pages/BypassUI.vue
+++ b/frontend/views/pages/BypassUI.vue
@@ -34,7 +34,7 @@ import sbp from '~/shared/sbp.js'
 import Page from '@components/Page.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 
-export default {
+export default ({
   name: 'BypassUI',
   components: {
     Page,
@@ -136,7 +136,7 @@ export default {
       return this.actions[action].finalize()
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/pages/Contributions.vue
+++ b/frontend/views/pages/Contributions.vue
@@ -141,7 +141,7 @@ import Contribution from '@containers/contributions/Contribution.vue'
 import ContributionItem from '@containers/contributions/ContributionItem.vue'
 import AddIncomeDetailsWidget from '@containers/contributions/AddIncomeDetailsWidget.vue'
 
-export default {
+export default ({
   name: 'Contributions',
   components: {
     Page,
@@ -245,7 +245,7 @@ export default {
       return this.currency.displayWithCurrency(amount)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss">

--- a/frontend/views/pages/DesignSystem.vue
+++ b/frontend/views/pages/DesignSystem.vue
@@ -1228,7 +1228,7 @@ import SvgVote from '@svgs/vote.svg'
 import { mapGetters, mapMutations } from 'vuex'
 import { THEME_LIGHT, THEME_DARK } from '~/frontend/utils/themes.js'
 
-export default {
+export default ({
   name: 'DesignSystemView',
   data () {
     return {
@@ -1419,7 +1419,7 @@ export default {
       'isDarkTheme'
     ])
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/pages/ErrorTesting.vue
+++ b/frontend/views/pages/ErrorTesting.vue
@@ -28,7 +28,7 @@ import PageSection from '@components/PageSection.vue'
 import { EVENT_HANDLED } from '@utils/events.js'
 import * as Errors from '@model/errors.js'
 
-export default {
+export default ({
   name: 'ErrorTesting',
   components: {
     Page,
@@ -71,5 +71,5 @@ export default {
       })
     }
   }
-}
+}: Object)
 </script>

--- a/frontend/views/pages/GroupChat.vue
+++ b/frontend/views/pages/GroupChat.vue
@@ -84,7 +84,7 @@ import { OPEN_MODAL } from '@utils/events.js'
 import sbp from '~/shared/sbp.js'
 import { MenuParent, MenuTrigger, MenuContent, MenuItem, MenuHeader } from '@components/menu/index.js'
 
-export default {
+export default ({
   name: 'GroupChat',
   mixins: [
     chatroom
@@ -130,7 +130,7 @@ export default {
       sbp('okTurtles.events/emit', OPEN_MODAL, modal, props)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/pages/GroupDashboard.vue
+++ b/frontend/views/pages/GroupDashboard.vue
@@ -36,7 +36,7 @@ import GroupMembers from '@containers/dashboard/GroupMembers.vue'
 import GroupPurpose from '@containers/dashboard/GroupPurpose.vue'
 // import GroupSettings from '@components/GroupSettings.vue'
 
-export default {
+export default ({
   name: 'GroupDashboard',
   computed: {
     ...mapState([
@@ -73,5 +73,5 @@ export default {
     GroupPurpose
     // GroupSettings
   }
-}
+}: Object)
 </script>

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -107,7 +107,7 @@ import BannerScoped from '@components/banners/BannerScoped.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'GroupSettings',
   mixins: [validationMixin, validationsDebouncedMixins],
   components: {
@@ -190,7 +190,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/pages/Home.vue
+++ b/frontend/views/pages/Home.vue
@@ -73,7 +73,7 @@ import { OPEN_MODAL } from '@utils/events.js'
 import SvgCreateGroup from '@svgs/create-group.svg'
 import SvgJoinGroup from '@svgs/join-group.svg'
 
-export default {
+export default ({
   name: 'Home',
   components: {
     SvgJoinGroup,
@@ -92,7 +92,7 @@ export default {
       sbp('state/vuex/dispatch', 'logout')
     }
   }
-}
+}: Object)
 </script>
 
 <style scoped lang="scss">

--- a/frontend/views/pages/Join.vue
+++ b/frontend/views/pages/Join.vue
@@ -52,7 +52,7 @@ import GroupWelcome from '@components/GroupWelcome.vue'
 import SvgBrokenLink from '@svgs/broken-link.svg'
 import L from '@view-utils/translations.js'
 
-export default {
+export default ({
   name: 'Join',
   components: {
     Loading,
@@ -157,7 +157,7 @@ export default {
       sbp('okTurtles.data/set', 'JOINING_GROUP', false)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/pages/Mailbox.vue
+++ b/frontend/views/pages/Mailbox.vue
@@ -169,7 +169,7 @@ const criteria = (msg) => msg.meta.createdDate
 
 // TODO: this whole file needs to be improved/rewritten
 
-export default {
+export default ({
   name: 'Mailbox',
 
   components: {
@@ -310,7 +310,7 @@ export default {
       }
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/pages/Messages.vue
+++ b/frontend/views/pages/Messages.vue
@@ -29,7 +29,7 @@ import chatroom from '@containers/chatroom/chatroom.js'
 import GroupsShortcut from '@containers/chatroom/GroupsShortcut.vue'
 import ConversationsList from '@containers/chatroom/ConversationsList.vue'
 
-export default {
+export default ({
   name: 'Messages',
   mixins: [
     chatroom
@@ -68,7 +68,7 @@ export default {
       this.$store.commit('setCurrentGroupId', hash)
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -105,7 +105,7 @@ import { PAYMENT_NOT_RECEIVED } from '@model/contracts/payments/index.js'
 import L, { LTags } from '@view-utils/translations.js'
 import { ISOStringToMonthstamp, humanDate } from '@utils/time.js'
 
-export default {
+export default ({
   name: 'Payments',
   components: {
     Page,
@@ -347,7 +347,7 @@ export default {
       this.ephemeral.currentPage = 0 // go back to first page.
     }
   }
-}
+}: Object)
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/views/utils/vueComponentStub.js.flow
+++ b/frontend/views/utils/vueComponentStub.js.flow
@@ -1,0 +1,3 @@
+const x: Object = {}
+export default x
+

--- a/shared/declarations.js
+++ b/shared/declarations.js
@@ -15,9 +15,9 @@
 //       banging-head-on-desk timesink (literally those words).
 //       Have the script explain which files represent what.
 
-// our globals
+// Our globals.
 declare function logger(err: Error): void
-// nodejs globals
+// Nodejs globals.
 declare var process: any
 
 // =======================
@@ -33,6 +33,8 @@ declare module 'blakejs' { declare module.exports: any }
 declare module 'buffer' { declare module.exports: any }
 declare module 'chalk' { declare module.exports: any }
 declare module 'dompurify' { declare module.exports: any }
+declare module 'emoji-mart-vue-fast' { declare module.exports: any }
+declare module 'emoji-mart-vue-fast/data/apple.json' { declare module.exports: any }
 declare module 'form-data' { declare module.exports: any }
 declare module 'localforage' { declare module.exports: any }
 declare module 'multihashes' { declare module.exports: any }
@@ -44,167 +46,17 @@ declare module 'vue-clickaway' { declare module.exports: any }
 declare module 'vue-router' { declare module.exports: any }
 declare module 'vue-slider-component' { declare module.exports: any }
 declare module 'vuelidate' { declare module.exports: any }
+declare module 'vuelidate/lib/validators' { declare module.exports: any }
+declare module 'vuelidate/lib/validators/maxLength' { declare module.exports: any }
+declare module 'vuelidate/lib/validators/required' { declare module.exports: any }
+declare module 'vuelidate/lib/validators/sameAs.js' { declare module.exports: any }
 declare module 'vuex' { declare module.exports: any }
 declare module 'vue2-touch-events' { declare module.exports: any }
 declare module 'wicg-inert' { declare module.exports: any }
 declare module 'ws' { declare module.exports: any }
 
-// .js files
+// Only necessary because `AppStyles.vue` imports it from its script tag rather than its style tag.
+declare module '@assets/style/main.scss' { declare module.exports: any }
+// Other .js files.
 declare module '@utils/blockies.js' { declare module.exports: Object }
 declare module '~/frontend/utils/flowTyper.js' { declare module.exports: Object }
-
-// .vue files
-declare module '../views/Contributions.vue' { declare module.exports: Object }
-declare module '../views/CreateGroup.vue' { declare module.exports: Object }
-declare module '../views/DesignSystem.vue' { declare module.exports: Object }
-declare module '../views/GroupChat.vue' { declare module.exports: Object }
-declare module '../views/GroupDashboard.vue' { declare module.exports: Object }
-declare module '../views/Home.vue' { declare module.exports: Object }
-declare module '../views/Join.vue' { declare module.exports: Object }
-declare module '../views/Mailbox.vue' { declare module.exports: Object }
-declare module '../views/Messages.vue' { declare module.exports: Object }
-declare module '../views/Payments.vue' { declare module.exports: Object }
-declare module '../views/ProposeMember.vue' { declare module.exports: Object }
-declare module '../views/UserGroup.vue' { declare module.exports: Object }
-declare module '../views/UserProfile.vue' { declare module.exports: Object }
-declare module '../views/VueAssistant.vue' { declare module.exports: Object }
-declare module '../views/components/modal/Modal.vue' { declare module.exports: Object }
-declare module '../views/containers/access/LoginModal.vue' { declare module.exports: Object }
-declare module '../views/containers/access/PasswordModal.vue' { declare module.exports: Object }
-declare module '../views/containers/access/SignupModal.vue' { declare module.exports: Object }
-declare module '../views/containers/chatroom/CreateNewChannelModal.vue' { declare module.exports: Object }
-declare module '../views/containers/chatroom/DeleteChannelModal.vue' { declare module.exports: Object }
-declare module '../views/containers/chatroom/EditChannelDescriptionModal.vue' { declare module.exports: Object }
-declare module '../views/containers/chatroom/EditChannelModal.vue' { declare module.exports: Object }
-declare module '../views/containers/chatroom/EditChannelNameModal.vue' { declare module.exports: Object }
-declare module '../views/containers/chatroom/GroupMembersDirectMessages.vue' { declare module.exports: Object }
-declare module '../views/containers/chatroom/LeaveChannelModal.vue' { declare module.exports: Object }
-declare module '../views/containers/contributions/IncomeDetails.vue' { declare module.exports: Object }
-declare module '../views/containers/dashboard/GroupMembersAllModal.vue' { declare module.exports: Object }
-declare module '../views/containers/design-system/DSModalFullscreen.vue' { declare module.exports: Object }
-declare module '../views/containers/design-system/DSModalNested.vue' { declare module.exports: Object }
-declare module '../views/containers/design-system/DSModalQuery.vue' { declare module.exports: Object }
-declare module '../views/containers/design-system/DSModalSimple.vue' { declare module.exports: Object }
-declare module '../views/containers/group-settings/GroupCreationModal.vue' { declare module.exports: Object }
-declare module '../views/containers/group-settings/GroupDeletionModal.vue' { declare module.exports: Object }
-declare module '../views/containers/group-settings/GroupJoinModal.vue' { declare module.exports: Object }
-declare module '../views/containers/group-settings/GroupLeaveModal.vue' { declare module.exports: Object }
-declare module '../views/containers/group-settings/InvitationLinkModal.vue' { declare module.exports: Object }
-declare module '../views/containers/navigation/CypressBypassUI.vue' { declare module.exports: Object }
-declare module '../views/containers/navigation/TimeTravel.vue' { declare module.exports: Object }
-declare module '../views/containers/payments/PaymentDetail.vue' { declare module.exports: Object }
-declare module '../views/containers/payments/PaymentsHistoryModal.vue' { declare module.exports: Object }
-declare module '../views/containers/payments/RecordPayment.vue' { declare module.exports: Object }
-declare module '../views/containers/proposals/AddMember.vue' { declare module.exports: Object }
-declare module '../views/containers/proposals/AddMembers.vue' { declare module.exports: Object }
-declare module '../views/containers/proposals/ChangeVotingRules.vue' { declare module.exports: Object }
-declare module '../views/containers/proposals/Mincome.vue' { declare module.exports: Object }
-declare module '../views/containers/proposals/RemoveMember.vue' { declare module.exports: Object }
-declare module '../views/containers/user-settings/AppLogs.vue' { declare module.exports: Object }
-declare module '../views/containers/user-settings/Appearence.vue' { declare module.exports: Object }
-declare module '../views/containers/user-settings/Placeholder.vue' { declare module.exports: Object }
-declare module '../views/containers/user-settings/Troubleshooting.vue' { declare module.exports: Object }
-declare module '../views/containers/user-settings/UserProfile.vue' { declare module.exports: Object }
-declare module '../views/containers/user-settings/UserSettingsModal.vue' { declare module.exports: Object }
-declare module '../views/pages/ErrorTesting.vue' { declare module.exports: Object }
-declare module './Bars.vue' { declare module.exports: Object }
-declare module './ButtonCountdown.vue' { declare module.exports: Object }
-declare module './ConfettiCircle.vue' { declare module.exports: Object }
-declare module './ConfettiLogo.vue' { declare module.exports: Object }
-declare module './ConfettiRectangle.vue' { declare module.exports: Object }
-declare module './ConfettiTriangle.vue' { declare module.exports: Object }
-declare module './GraphLegendGroup.vue' { declare module.exports: Object }
-declare module './GraphLegendItem.vue' { declare module.exports: Object }
-declare module './GroupMincome.vue' { declare module.exports: Object }
-declare module './GroupName.vue' { declare module.exports: Object }
-declare module './GroupPrivacy.vue' { declare module.exports: Object }
-declare module './GroupPurpose.vue' { declare module.exports: Object }
-declare module './GroupRules.vue' { declare module.exports: Object }
-declare module './MaskToModal.vue' { declare module.exports: Object }
-declare module './Masker.vue' { declare module.exports: Object }
-declare module './MenuContent.vue' { declare module.exports: Object }
-declare module './MenuHeader.vue' { declare module.exports: Object }
-declare module './MenuItem.vue' { declare module.exports: Object }
-declare module './MenuParent.vue' { declare module.exports: Object }
-declare module './MenuTrigger.vue' { declare module.exports: Object }
-declare module './ModalClose.vue' { declare module.exports: Object }
-declare module './PieChart.vue' { declare module.exports: Object }
-declare module './Progress.vue' { declare module.exports: Object }
-declare module './SupportHistory.vue' { declare module.exports: Object }
-declare module './Target.vue' { declare module.exports: Object }
-declare module './Trigger.vue' { declare module.exports: Object }
-declare module './Voting.vue' { declare module.exports: Object }
-declare module './views/Contributions.vue' { declare module.exports: Object }
-declare module './views/CreateGroup.vue' { declare module.exports: Object }
-declare module './views/DesignSystem.vue' { declare module.exports: Object }
-declare module './views/GroupChat.vue' { declare module.exports: Object }
-declare module './views/GroupDashboard.vue' { declare module.exports: Object }
-declare module './views/Home.vue' { declare module.exports: Object }
-declare module './views/Join.vue' { declare module.exports: Object }
-declare module './views/Mailbox.vue' { declare module.exports: Object }
-declare module './views/Messages.vue' { declare module.exports: Object }
-declare module './views/Payments.vue' { declare module.exports: Object }
-declare module './views/ProposeMember.vue' { declare module.exports: Object }
-declare module './views/UserGroup.vue' { declare module.exports: Object }
-declare module './views/UserProfile.vue' { declare module.exports: Object }
-declare module './views/VueAssistant.vue' { declare module.exports: Object }
-declare module './views/components/AppStyles.vue' { declare module.exports: Object }
-declare module './views/components/Modal/Modal.vue' { declare module.exports: Object }
-declare module './views/components/banners/BannerGeneral.vue' { declare module.exports: Object }
-declare module './views/components/modal/Modal.vue' { declare module.exports: Object }
-declare module './views/containers/LoginModal.vue' { declare module.exports: Object }
-declare module './views/containers/Signup.vue' { declare module.exports: Object }
-declare module './views/containers/access/LoginModal.vue' { declare module.exports: Object }
-declare module './views/containers/access/PasswordModal.vue' { declare module.exports: Object }
-declare module './views/containers/access/SignupModal.vue' { declare module.exports: Object }
-declare module './views/containers/contributions/IncomeDetails.vue' { declare module.exports: Object }
-declare module './views/containers/dashboard/GroupMembersAllModal.vue' { declare module.exports: Object }
-declare module './views/containers/design-system/DSModalFullscreen.vue' { declare module.exports: Object }
-declare module './views/containers/design-system/DSModalNested.vue' { declare module.exports: Object }
-declare module './views/containers/design-system/DSModalQuery.vue' { declare module.exports: Object }
-declare module './views/containers/design-system/DSModalSimple.vue' { declare module.exports: Object }
-declare module './views/containers/group-settings/GroupCreationModal.vue' { declare module.exports: Object }
-declare module './views/containers/group-settings/GroupJoinModal.vue' { declare module.exports: Object }
-declare module './views/containers/group-settings/GroupLeaveModal.vue' { declare module.exports: Object }
-declare module './views/containers/group-settings/InvitationLinkModal.vue' { declare module.exports: Object }
-declare module './views/containers/navigation/CypressBypassUI.vue' { declare module.exports: Object }
-declare module './views/containers/navigation/CypressBypassUI.vue' { declare module.exports: Object }
-declare module './views/containers/navigation/Navigation.vue' { declare module.exports: Object }
-declare module './views/containers/navigation/TimeTravel.vue' { declare module.exports: Object }
-declare module './views/containers/payments/PaymentDetail.vue' { declare module.exports: Object }
-declare module './views/containers/payments/PaymentsHistoryModal.vue' { declare module.exports: Object }
-declare module './views/containers/payments/RecordPayment.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/AddMember.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/AddMembers.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/ChangeVotingRules.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/ChangeVotingRules.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/Mincome.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/RemoveMember.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/RuleAddMember.vue' { declare module.exports: Object }
-declare module './views/containers/proposals/RuleRemoveMember.vue' { declare module.exports: Object }
-declare module './views/containers/sidebar/Sidebar.vue' { declare module.exports: Object }
-declare module './views/containers/user-settings/AppLogs.vue' { declare module.exports: Object }
-declare module './views/containers/user-settings/Appearance.vue' { declare module.exports: Object }
-declare module './views/containers/user-settings/Placeholder.vue' { declare module.exports: Object }
-declare module './views/containers/user-settings/Troubleshooting.vue' { declare module.exports: Object }
-declare module './views/containers/user-settings/UserProfile.vue' { declare module.exports: Object }
-declare module './views/containers/user-settings/UserSettingsModal.vue' { declare module.exports: Object }
-declare module '@components/ListItem.vue' { declare module.exports: Object }
-declare module '@components/MembersCircle.vue' { declare module.exports: Object }
-declare module '@components/i18n.vue' { declare module.exports: Object }
-declare module '@pages/BypassUI.vue' { declare module.exports: Object }
-declare module '@pages/Contributions.vue' { declare module.exports: Object }
-declare module '@pages/DesignSystem.vue' { declare module.exports: Object }
-declare module '@pages/GroupChat.vue' { declare module.exports: Object }
-declare module '@pages/GroupDashboard.vue' { declare module.exports: Object }
-declare module '@pages/GroupSettings.vue' { declare module.exports: Object }
-declare module '@pages/Home.vue' { declare module.exports: Object }
-declare module '@pages/Join.vue' { declare module.exports: Object }
-declare module '@pages/Mailbox.vue' { declare module.exports: Object }
-declare module '@pages/Messages.vue' { declare module.exports: Object }
-declare module '@pages/Payments.vue' { declare module.exports: Object }
-declare module '@views/containers/loading-error/ErrorModal.vue' { declare module.exports: Object }
-declare module '@views/containers/loading-error/ErrorPage.vue' { declare module.exports: Object }
-declare module '@views/containers/loading-error/LoadingBaseModal.vue' { declare module.exports: Object }
-declare module '@views/containers/loading-error/LoadingModal.vue' { declare module.exports: Object }
-declare module '@views/containers/loading-error/LoadingPage.vue' { declare module.exports: Object }


### PR DESCRIPTION
Closes #1104

### Summary of changes:
#### Pros:
- The default export of every .vue file has been annotated with `: Object` so that Flow no longer complains about untyped module interfaces. A more specific type could be used in the future though.
- The Flow config file has been updated to use the `module.name_mapper.extension` option, which makes no longer necessary to update `shared/declarations.js` every time a .vue file is added, removed or renamed.
- The `shared/declarations.js` file has also been updated and greatly simplified thanks to the above option.
#### Cons:
- A small `vueComponentStub.js.flow` file has been added in the `@view-utils` directory to act as a stub for Vue component imports. The  `module.name_mapper.extension` option tells Flow's module resolution to use this stub when encountering a  `*.vue` or `*.svg` import statement.
