### PR TITLE
Correct mistake of uploaded file path

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -139,7 +139,7 @@ route.POST('/file', {
       return Boom.badRequest('bad hash!')
     }
     await sbp('backend/db/writeFileOnce', hash, data)
-    return process.env.API_URL + '/file/' + hash
+    return '/file/' + hash
   } catch (err) {
     return logger(err)
   }

--- a/frontend/utils/image.js
+++ b/frontend/utils/image.js
@@ -38,7 +38,7 @@ export const imageUpload = async (imageFile: File): Promise<any> => {
         fetch(`${sbp('okTurtles.data/get', 'API_URL')}/file`, {
           method: 'POST',
           body: fd
-        }).then(handleFetchResult('text')).then(resolve).catch(reject)
+        }).then(handleFetchResult('text')).then(path => resolve(window.location.origin + path)).catch(reject)
       }
     }
     reader.readAsArrayBuffer(file)

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -370,7 +370,7 @@ describe('Full walkthrough', function () {
       })
       await fetch(`${process.env.API_URL}/file`, { method: 'POST', body: form })
         .then(handleFetchResult('text'))
-        .then(r => should(r).equal(`${process.env.API_URL}/file/${hash}`))
+        .then(r => should(r).equal(`/file/${hash}`))
     })
   })
 


### PR DESCRIPTION
Fixed
PS: it is not mobile platform issue. This happens when we use server hosted online (not local).
The reason of this issue is that there is a mistake to set uploaded file path.