### PR TITLE
Fix pubsub breaking after sleep and other improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,7 +52,12 @@ const { resolve } = path
 // We will rather load it later, and only if necessary.
 // require('@babel/register')
 
-const { LIGHTWEIGHT_CLIENT = 'true', NODE_ENV = 'development', VUEX_STRICT = 'true' } = process.env
+const {
+  CI = '',
+  LIGHTWEIGHT_CLIENT = 'true',
+  NODE_ENV = 'development',
+  VUEX_STRICT = 'true'
+} = process.env
 
 const backendIndex = './backend/index.js'
 const distAssets = 'dist/assets'
@@ -118,6 +123,7 @@ module.exports = (grunt) => {
       bundle: true,
       define: {
         'process.env.BUILD': "'web'", // Required by Vuelidate.
+        'process.env.CI': `'${CI}'`,
         'process.env.LIGHTWEIGHT_CLIENT': LIGHTWEIGHT_CLIENT,
         'process.env.NODE_ENV': `'${NODE_ENV}'`,
         'process.env.VUEX_STRICT': VUEX_STRICT

--- a/backend/index.js
+++ b/backend/index.js
@@ -50,6 +50,9 @@ const shutdownFn = function (message) {
       }
     })
     pubsub.close()
+    // Since `ws` v8.0, `WebSocketServer.close()` no longer closes remaining connections.
+    // See https://github.com/websockets/ws/commit/df7de574a07115e2321fdb5fc9b2d0fea55d27e8
+    pubsub.clients.forEach(client => client.terminate())
   })
 }
 

--- a/backend/pubsub.js
+++ b/backend/pubsub.js
@@ -252,7 +252,7 @@ const defaultMessageHandlers = {
       subscribers.add(socket)
       // Broadcast a notification to every other open subscriber.
       const notification = createNotification(type, { contractID, socketID })
-      server.broadcast(notification, { to: subscribers })
+      server.broadcast(notification, { to: subscribers, except: socket })
     }
     socket.send(createResponse(SUCCESS, { type, contractID }))
   },
@@ -270,7 +270,7 @@ const defaultMessageHandlers = {
         subscribers.delete(socket)
         // Broadcast a notification to every remaining open subscriber.
         const notification = createNotification(type, { contractID, socketID })
-        server.broadcast(notification, { to: subscribers })
+        server.broadcast(notification, { to: subscribers, except: socket })
       }
     }
     socket.send(createResponse(SUCCESS, { type, contractID }))

--- a/backend/pubsub.js
+++ b/backend/pubsub.js
@@ -50,6 +50,8 @@ export function createResponse (type: ResponseTypeEnum, data: JSONType): string 
  *
  * @param {(http.Server|https.Server)} server - A Node.js HTTP/S server to attach to.
  * @param {Object?} options
+ * {boolean?} logPingRounds - Whether to log ping rounds.
+ * {boolean?} logPongMessages - Whether to log received pong messages.
  * {object?} messageHandlers - Custom handlers for different message types.
  * {object?} serverHandlers - Custom handlers for server events.
  * {object?} socketHandlers - Custom handlers for socket events.
@@ -68,8 +70,8 @@ export function createServer (httpServer: Object, options?: Object = {}): Object
     ...{ clientTracking: true },
     server: httpServer
   })
-  server.customServerEventHandlers = options.serverHandlers || {}
-  server.customSocketEventHandlers = options.socketHandlers || {}
+  server.customServerEventHandlers = { ...options.serverHandlers }
+  server.customSocketEventHandlers = { ...options.socketHandlers }
   server.messageHandlers = { ...defaultMessageHandlers, ...options.messageHandlers }
   server.pingIntervalID = undefined
   server.subscribersByContractID = Object.create(null)
@@ -95,10 +97,12 @@ export function createServer (httpServer: Object, options?: Object = {}): Object
   // Setup a ping interval if required.
   if (server.options.pingInterval > 0) {
     server.pingIntervalID = setInterval(() => {
-      console.debug('[pubsub] Pinging clients')
+      if (server.clients.length && server.options.logPingRounds) {
+        console.debug('[pubsub] Pinging clients')
+      }
       server.clients.forEach((client) => {
         if (client.pinged && !client.activeSinceLastPing) {
-          console.log(`[pubsub] Closing irresponsive client ${client.id}`)
+          console.log(`[pubsub] Disconnecting irresponsive client ${client.id}`)
           return client.terminate()
         }
         if (client.readyState === WebSocket.OPEN) {
@@ -114,6 +118,8 @@ export function createServer (httpServer: Object, options?: Object = {}): Object
 }
 
 const defaultOptions = {
+  logPingRounds: process.env.NODE_ENV === 'development' && !process.env.CI,
+  logPongMessages: false,
   maxPayload: 6 * 1024 * 1024,
   pingInterval: 30000
 }
@@ -147,7 +153,10 @@ const defaultServerHandlers = {
     // Add listeners for socket events, i.e. events emitted on a socket object.
     ;['close', 'error', 'message', 'ping', 'pong'].forEach((eventName) => {
       socket.on(eventName, (...args) => {
-        console.debug(`[pubsub] Event '${eventName}' on socket ${socket.id}`, ...args)
+        // Logging of 'message' events is handled in the default 'message' event handler.
+        if (eventName !== 'message') {
+          console.log(`[pubsub] Event '${eventName}' on socket ${socket.id}`, ...args)
+        }
         const customHandler = socket.server.customSocketEventHandlers[eventName]
         const defaultHandler = (defaultSocketEventHandlers: Object)[eventName]
 
@@ -206,6 +215,11 @@ const defaultSocketEventHandlers = {
       rejectMessageAndTerminateSocket(msg, socket)
       return
     }
+    // Now that we have successfully parsed the message, we can log it.
+    if (msg.type !== 'pong' || server.options.logPongMessages) {
+      console.log(`[pubsub] Received '${msg.type}' on socket ${socket.id}`, data)
+    }
+    // The socket can be marked as active since it just received a message.
     socket.activeSinceLastPing = true
     const handler = server.messageHandlers[msg.type]
 

--- a/backend/pubsub.js
+++ b/backend/pubsub.js
@@ -80,15 +80,9 @@ export function createServer (httpServer: Object, options?: Object = {}): Object
   Object.keys(defaultServerHandlers).forEach((name) => {
     server.on(name, (...args) => {
       try {
-        const customHandler = server.customServerEventHandlers[name]
-        const defaultHandler = defaultServerHandlers[name]
         // Always call the default handler first.
-        if (defaultHandler) {
-          defaultHandler.call(server, ...args)
-        }
-        if (customHandler) {
-          customHandler.call(server, ...args)
-        }
+        defaultServerHandlers[name]?.call(server, ...args)
+        server.customServerEventHandlers[name]?.call(server, ...args)
       } catch (error) {
         server.emit('error', error)
       }
@@ -157,16 +151,9 @@ const defaultServerHandlers = {
         if (eventName !== 'message') {
           console.log(`[pubsub] Event '${eventName}' on socket ${socket.id}`, ...args.map(arg => String(arg)))
         }
-        const customHandler = socket.server.customSocketEventHandlers[eventName]
-        const defaultHandler = (defaultSocketEventHandlers: Object)[eventName]
-
         try {
-          if (defaultHandler) {
-            defaultHandler.call(socket, ...args)
-          }
-          if (customHandler) {
-            customHandler.call(socket, ...args)
-          }
+          (defaultSocketEventHandlers: Object)[eventName]?.call(socket, ...args)
+          socket.server.customSocketEventHandlers[eventName]?.call(socket, ...args)
         } catch (error) {
           socket.server.emit('error', error)
           socket.terminate()

--- a/frontend/controller/backend.js
+++ b/frontend/controller/backend.js
@@ -53,12 +53,14 @@ sbp('okTurtles.events/on', CONTRACTS_MODIFIED, (contracts) => {
   const leaveSubscribed = intersection(subscribedIDs, currentIDs)
   const toUnsubscribe = difference(subscribedIDs, leaveSubscribed)
   const toSubscribe = difference(currentIDs, leaveSubscribed)
+  // There is currently no need to tell other clients about our sub/unsubscriptions.
+  const dontBroadcast = true
   try {
     for (const contractID of toUnsubscribe) {
-      client.unsub(contractID)
+      client.unsub(contractID, dontBroadcast)
     }
     for (const contractID of toSubscribe) {
-      client.sub(contractID)
+      client.sub(contractID, dontBroadcast)
     }
   } catch (e) {
     // TODO: handle any exceptions!

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "vuelidate": "0.7.6",
         "vuex": "3.6.0",
         "wicg-inert": "3.1.0",
-        "ws": "7.5.2"
+        "ws": "8.5.0"
       },
       "devDependencies": {
         "@babel/core": "7.12.9",
@@ -16372,11 +16372,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
-      "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
@@ -29666,9 +29666,9 @@
       }
     },
     "ws": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.2.tgz",
-      "integrity": "sha512-lkF7AWRicoB9mAgjeKbGqVUekLnSNO4VjKVnuPHpQeOxZOErX6BPXwJk70nFslRCEEA8EVW7ZjKwXaP9N+1sKQ==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
+      "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
       "requires": {}
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "vuelidate": "0.7.6",
     "vuex": "3.6.0",
     "wicg-inert": "3.1.0",
-    "ws": "7.5.2"
+    "ws": "8.5.0"
   },
   "devDependencies": {
     "@babel/core": "7.12.9",

--- a/shared/pubsub.js
+++ b/shared/pubsub.js
@@ -164,9 +164,9 @@ export function createClient (url: string, options?: Object = {}): PubSubClient 
   }
   // Add global event listeners before the first connection.
   if (typeof window === 'object') {
-    globalEventNames.forEach((name) => {
+    for (const name of globalEventNames) {
       window.addEventListener(name, client.listeners[name])
-    })
+    }
   }
   if (!client.options.manual) {
     client.connect()
@@ -305,6 +305,7 @@ const defaultClientEventHandlers = {
   open (event: Event) {
     console.log('[pubsub] Event: open')
     const client = this
+    const { options } = this
 
     if (!client.isNew) {
       sbp('okTurtles.events/emit', PUBSUB_RECONNECTION_SUCCEEDED, client)
@@ -315,10 +316,10 @@ const defaultClientEventHandlers = {
     client.isNew = false
     // Setup a ping timeout if required.
     // It will close the connection if we don't get any message from the server.
-    if (client.options.pingTimeout > 0 && client.options.pingTimeout < Infinity) {
+    if (options.pingTimeout > 0 && options.pingTimeout < Infinity) {
       client.pingTimeoutID = setTimeout(() => {
         client.socket?.close()
-      }, client.options.pingTimeout)
+      }, options.pingTimeout)
     }
     // We only need to handle contract resynchronization here when reconnecting.
     // Not on initial connection, since the login code already does it.


### PR DESCRIPTION
Closes #1127

### Summary of changes:
- Fix data synchronization issue after waking up from slep mode or somehow getting disconnected by the server.
- Less console output related to pings and pongs unless explicitly set in the options.
- `process.env.CI` is now available in shared and frontend files. Useful e.g. to enable or disable logging according to the environment.
- Updated `ws` dependency to v8.5.0.
- Socket `error` events are now logged using `console.log()` rather than `console.error()` to avoid possible confusion with runtime errors.
