### PR TITLE
#1183 Fix behavior on reconnection failure

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -167,7 +167,7 @@ async function startApp () {
             banner.show(L('Trying to reconnect...'), 'wifi')
           },
           'reconnection-failed' () {
-            banner.show(L('Cannot connect to the server.'), 'wifi')
+            banner.show(L('We could not connect to the server. Please refresh the page.'), 'wifi')
           },
           'reconnection-succeeded' () {
             banner.clean()

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -75,6 +75,8 @@ async function startApp () {
   }
   sbp('okTurtles.data/set', PUBSUB_INSTANCE, createGIPubSubClient(
     pubsubURL, {
+      // See https://github.com/okTurtles/group-income/issues/1183
+      maxRetries: Infinity,
       // This option can be enabled since we are not doing auth via web sockets.
       reconnectOnTimeout: true,
       timeout: 5000


### PR DESCRIPTION
Closes #1183

### Summary of changes:
- The WebSocket client now keeps retrying to reconnect indefinetely.
- In case the retry behaviour is modified to become limited again (e.g. via the `maxRetry` option), the corresponding banner message should now be correct.