### PR TITLE
Display a global banner message while syncing contracts

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -138,13 +138,12 @@ async function startApp () {
         // Make it possible for Cypress to wait for contracts to finish syncing.
         if (isSyncing) {
           this.ephemeral.syncs.push(contractID)
-        } else {
-          this.ephemeral.syncs = this.ephemeral.syncs.filter(id => id !== contractID)
-        }
-        if (this.ephemeral.syncs.length > 0) {
           this.$refs.bannerGeneral.show(this.L('Loading events from server...'), 'wifi')
         } else {
-          this.$refs.bannerGeneral.clean()
+          this.ephemeral.syncs = this.ephemeral.syncs.filter(id => id !== contractID)
+          if (!this.ephemeral.syncs.length) {
+            this.$refs.bannerGeneral.clean()
+          }
         }
       })
       sbp('okTurtles.events/on', LOGIN, () => {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -135,11 +135,16 @@ async function startApp () {
         this.setReducedMotion(true)
       }
       sbp('okTurtles.events/on', CONTRACT_IS_SYNCING, (contractID, isSyncing) => {
-        // make it possible for Cypress to wait for contracts to finish syncing
+        // Make it possible for Cypress to wait for contracts to finish syncing.
         if (isSyncing) {
           this.ephemeral.syncs.push(contractID)
         } else {
           this.ephemeral.syncs = this.ephemeral.syncs.filter(id => id !== contractID)
+        }
+        if (this.ephemeral.syncs.length > 0) {
+          this.$refs.bannerGeneral.show(this.L('Loading events from server...'), 'wifi')
+        } else {
+          this.$refs.bannerGeneral.clean()
         }
       })
       sbp('okTurtles.events/on', LOGIN, () => {


### PR DESCRIPTION
Closes #1185

### Summary of changes:
- A simple message is now displayed using BannerGeneral when contracts are syncing.
  Please note that this behavior only activates when contracts are actually syncing, not while the client just checks with the server whether sync is needed.

### Additional info:
- Special testing should be done to ensure the banner doesn't sometimes flash too quickly. If this happens then additional code will be necessary to throttle or debounce the banner visibility changes.