### PR TITLE
Fix 'process is undefined' error breaking autorefresh on upgrade

### DIFF
--- a/frontend/controller/backend.js
+++ b/frontend/controller/backend.js
@@ -42,7 +42,7 @@ export function createGIPubSubClient (url: string, options: Object): Object {
         sbp('state/enqueueHandleEvent', GIMessage.deserialize(msg.data))
       },
       [NOTIFICATION_TYPE.APP_VERSION] (msg) {
-        const ourVersion = process.env.APP_VERSION
+        const ourVersion = process.env.GI_VERSION
         const theirVersion = msg.data
 
         if (ourVersion !== theirVersion) {
@@ -78,8 +78,8 @@ sbp('okTurtles.events/on', CONTRACTS_MODIFIED, (contracts) => {
 
 sbp('okTurtles.events/on', GI_UPDATE_AVAILABLE, (version) => {
   console.info('New Group Income version available:', version)
-  const client = sbp('okTurtles.data/get', PUBSUB_INSTANCE)
-  client.destroy()
+  // Prevent the client from trying to reconnect when the page starts unloading.
+  sbp('okTurtles.data/get', PUBSUB_INSTANCE).destroy()
   // TODO: allow the user to manually reload the page later.
   window.location.reload()
 })


### PR DESCRIPTION
Closes #1184

- Fix an error which was introduced in the `APP_VERSION` socket message handler when applying review feedback in PR #1195.