### PR TITLE
Pass correct link to navigator.share in copyToClipboard (#1021)

### DIFF
--- a/frontend/views/components/LinkToCopy.vue
+++ b/frontend/views/components/LinkToCopy.vue
@@ -52,7 +52,7 @@ export default ({
       if (navigator.share) {
         navigator.share({
           title: this.L('Your invite'),
-          url: this.textToCopy
+          url: this.link
         })
         return
       }


### PR DESCRIPTION
Previously `copyToClipboard` was using a non existing variable `textToCopy`. Hence shared link was always undefined