### PR TITLE
Closes #1236 + updates vue-router

### DIFF
--- a/frontend/controller/router.js
+++ b/frontend/controller/router.js
@@ -8,9 +8,7 @@ import store from '@model/state.js'
 import Home from '@pages/Home.vue'
 import Join from '@pages/Join.vue'
 import L from '@view-utils/translations.js'
-import { logExceptNavigationDuplicated } from '@view-utils/misc.js'
 import { lazyPage } from '@utils/lazyLoadedView.js'
-import { VUE_LOADED } from '@utils/events.js'
 
 /*
  * Lazy load all the pages that are not necessary at initial loading of the app.
@@ -68,131 +66,112 @@ function createEnterGuards (...guards) {
     next()
   }
 }
-const routes = [
-  {
-    path: '/',
-    component: Home,
-    name: 'home',
-    meta: { title: L('Group Income') }, // page title. see issue #45
-    beforeEnter: createEnterGuards(homeGuard)
-  },
-  {
-    path: '/design-system',
-    component: lazyDesignSystem,
-    name: 'DesignSystem',
-    meta: { title: L('Design System') }
-    // beforeEnter: createEnterGuards(designGuard)
-  },
-  {
-    path: '/dashboard',
-    component: lazyGroupDashboard,
-    name: 'GroupDashboard',
-    meta: { title: L('Group Dashboard') },
-    beforeEnter: createEnterGuards(loginGuard, groupGuard)
-  },
-  {
-    path: '/contributions',
-    component: lazyContributions,
-    name: 'Contributions',
-    meta: { title: L('Contributions') },
-    beforeEnter: createEnterGuards(loginGuard, groupGuard)
-  },
-  {
-    path: '/payments',
-    component: lazyPayments,
-    name: 'Payments',
-    meta: { title: L('Payments') },
-    beforeEnter: createEnterGuards(loginGuard, groupGuard)
-  },
-  /* Guards need to be created for any route that should not be directly accessed by url */
-  {
-    path: '/messages',
-    component: lazyMessages,
-    name: 'Messages',
-    meta: { title: L('Messages') },
-    beforeEnter: createEnterGuards(loginGuard)
-  },
-  {
-    path: '/messages/:chatName',
-    component: lazyMessages,
-    name: 'MessagesConversation',
-    beforeEnter: createEnterGuards(loginGuard)
-    // BUG/REVIEW "CANNOT GET /:username" when username has "." in it
-    // ex: messages/joe.kim doesnt work but messages/joekim works fine.
-    // Possible Solution: https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations
-  },
-  {
-    path: '/group-chat',
-    component: lazyGroupChat,
-    name: 'GroupChat',
-    meta: { title: L('Group Chat') },
-    beforeEnter: createEnterGuards(loginGuard, groupGuard)
-  },
-  {
-    path: '/group-settings',
-    component: lazyGroupSettings,
-    name: 'GroupSettings',
-    meta: { title: L('Group Settings') },
-    beforeEnter: createEnterGuards(loginGuard, groupGuard)
-  },
-  {
-    path: '/group-chat/:chatRoomId',
-    component: lazyGroupChat,
-    name: 'GroupChatConversation',
-    beforeEnter: createEnterGuards(loginGuard, groupGuard)
-  },
-  {
-    path: '/join',
-    name: Join.name,
-    component: Join,
-    meta: { title: L('Join a Group') },
-    // beforeEnter: createEnterGuards(loginGuard, mailGuard)
-    beforeEnter: createEnterGuards(inviteGuard)
-  },
-  ...(process.env.NODE_ENV === 'development'
-    ? [{
-        path: '/error-testing',
-        name: 'ErrorTesting',
-        component: () => import('../views/pages/ErrorTesting.vue'),
-        meta: { title: L('Error Testing') }
-      }]
-    : []),
-  {
-    path: '*',
-    redirect: '/'
-  }
-]
+
 const router: any = new Router({
   mode: 'history',
   base: '/app',
-  routes,
   scrollBehavior (to, from, savedPosition) {
     return { x: 0, y: 0 }
-  }
+  },
+  routes: [
+    {
+      path: '/',
+      component: Home,
+      name: 'home',
+      meta: { title: L('Group Income') }, // page title. see issue #45
+      beforeEnter: createEnterGuards(homeGuard)
+    },
+    {
+      path: '/design-system',
+      component: lazyDesignSystem,
+      name: 'DesignSystem',
+      meta: { title: L('Design System') }
+      // beforeEnter: createEnterGuards(designGuard)
+    },
+    {
+      path: '/dashboard',
+      component: lazyGroupDashboard,
+      name: 'GroupDashboard',
+      meta: { title: L('Group Dashboard') },
+      beforeEnter: createEnterGuards(loginGuard, groupGuard)
+    },
+    {
+      path: '/contributions',
+      component: lazyContributions,
+      name: 'Contributions',
+      meta: { title: L('Contributions') },
+      beforeEnter: createEnterGuards(loginGuard, groupGuard)
+    },
+    {
+      path: '/payments',
+      component: lazyPayments,
+      name: 'Payments',
+      meta: { title: L('Payments') },
+      beforeEnter: createEnterGuards(loginGuard, groupGuard)
+    },
+    /* Guards need to be created for any route that should not be directly accessed by url */
+    {
+      path: '/messages',
+      component: lazyMessages,
+      name: 'Messages',
+      meta: { title: L('Messages') },
+      beforeEnter: createEnterGuards(loginGuard)
+    },
+    {
+      path: '/messages/:chatName',
+      component: lazyMessages,
+      name: 'MessagesConversation',
+      beforeEnter: createEnterGuards(loginGuard)
+      // BUG/REVIEW "CANNOT GET /:username" when username has "." in it
+      // ex: messages/joe.kim doesnt work but messages/joekim works fine.
+      // Possible Solution: https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations
+    },
+    {
+      path: '/group-chat',
+      component: lazyGroupChat,
+      name: 'GroupChat',
+      meta: { title: L('Group Chat') },
+      beforeEnter: createEnterGuards(loginGuard, groupGuard)
+    },
+    {
+      path: '/group-settings',
+      component: lazyGroupSettings,
+      name: 'GroupSettings',
+      meta: { title: L('Group Settings') },
+      beforeEnter: createEnterGuards(loginGuard, groupGuard)
+    },
+    {
+      path: '/group-chat/:chatRoomId',
+      component: lazyGroupChat,
+      name: 'GroupChatConversation',
+      beforeEnter: createEnterGuards(loginGuard, groupGuard)
+    },
+    {
+      path: '/join',
+      name: Join.name,
+      component: Join,
+      meta: { title: L('Join a Group') },
+      // beforeEnter: createEnterGuards(loginGuard, mailGuard)
+      beforeEnter: createEnterGuards(inviteGuard)
+    },
+    ...(process.env.NODE_ENV === 'development'
+      ? [{
+          path: '/error-testing',
+          name: 'ErrorTesting',
+          component: () => import('../views/pages/ErrorTesting.vue'),
+          meta: { title: L('Error Testing') }
+        }]
+      : []),
+    {
+      path: '*',
+      redirect: '/'
+    }
+  ]
 })
 
 router.beforeEach((to, from, next) => {
   document.title = to.meta.title
   next()
-})
-
-let startRoute
-router.beforeResolve((to, from, next) => {
-  if (!startRoute) startRoute = to
-  // console.warn(`beforeResolve to: ${to.path} from: ${from.path}`)
-  next()
-})
-
-// Sometimes beforeEnter will get triggered too early b/c of fix for #1192
-// and store.state isn't loaded yet, so we run it again after VUE_LOADED
-sbp('okTurtles.events/once', VUE_LOADED, function () {
-  const route = routes.find(r => r.path === startRoute.path)
-  // $FlowFixMe
-  const next = route?.beforeEnter?.(startRoute, null, (next) => next)
-  // console.warn(`started at ${startRoute.path} and got next of ${JSON.stringify(next)}`)
-  if (next) {
-    router.push(next).catch(logExceptNavigationDuplicated)
-  }
 })
 
 sbp('sbp/selectors/register', {

--- a/frontend/controller/router.js
+++ b/frontend/controller/router.js
@@ -8,7 +8,9 @@ import store from '@model/state.js'
 import Home from '@pages/Home.vue'
 import Join from '@pages/Join.vue'
 import L from '@view-utils/translations.js'
+import { logExceptNavigationDuplicated } from '@view-utils/misc.js'
 import { lazyPage } from '@utils/lazyLoadedView.js'
+import { VUE_LOADED } from '@utils/events.js'
 
 /*
  * Lazy load all the pages that are not necessary at initial loading of the app.
@@ -56,10 +58,6 @@ const groupGuard = {
 }
 
 // TODO: add state machine guard and redirect to critical error page if necessary
-// var mailGuard = {
-//   guard: (to, from) => from.name !== Mailbox.name,
-//   redirect: (to, from) => ({ path: '/mailbox' })
-// }
 function createEnterGuards (...guards) {
   return function (to, from, next) {
     for (const current of guards) {
@@ -70,111 +68,131 @@ function createEnterGuards (...guards) {
     next()
   }
 }
+const routes = [
+  {
+    path: '/',
+    component: Home,
+    name: 'home',
+    meta: { title: L('Group Income') }, // page title. see issue #45
+    beforeEnter: createEnterGuards(homeGuard)
+  },
+  {
+    path: '/design-system',
+    component: lazyDesignSystem,
+    name: 'DesignSystem',
+    meta: { title: L('Design System') }
+    // beforeEnter: createEnterGuards(designGuard)
+  },
+  {
+    path: '/dashboard',
+    component: lazyGroupDashboard,
+    name: 'GroupDashboard',
+    meta: { title: L('Group Dashboard') },
+    beforeEnter: createEnterGuards(loginGuard, groupGuard)
+  },
+  {
+    path: '/contributions',
+    component: lazyContributions,
+    name: 'Contributions',
+    meta: { title: L('Contributions') },
+    beforeEnter: createEnterGuards(loginGuard, groupGuard)
+  },
+  {
+    path: '/payments',
+    component: lazyPayments,
+    name: 'Payments',
+    meta: { title: L('Payments') },
+    beforeEnter: createEnterGuards(loginGuard, groupGuard)
+  },
+  /* Guards need to be created for any route that should not be directly accessed by url */
+  {
+    path: '/messages',
+    component: lazyMessages,
+    name: 'Messages',
+    meta: { title: L('Messages') },
+    beforeEnter: createEnterGuards(loginGuard)
+  },
+  {
+    path: '/messages/:chatName',
+    component: lazyMessages,
+    name: 'MessagesConversation',
+    beforeEnter: createEnterGuards(loginGuard)
+    // BUG/REVIEW "CANNOT GET /:username" when username has "." in it
+    // ex: messages/joe.kim doesnt work but messages/joekim works fine.
+    // Possible Solution: https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations
+  },
+  {
+    path: '/group-chat',
+    component: lazyGroupChat,
+    name: 'GroupChat',
+    meta: { title: L('Group Chat') },
+    beforeEnter: createEnterGuards(loginGuard, groupGuard)
+  },
+  {
+    path: '/group-settings',
+    component: lazyGroupSettings,
+    name: 'GroupSettings',
+    meta: { title: L('Group Settings') },
+    beforeEnter: createEnterGuards(loginGuard, groupGuard)
+  },
+  {
+    path: '/group-chat/:chatRoomId',
+    component: lazyGroupChat,
+    name: 'GroupChatConversation',
+    beforeEnter: createEnterGuards(loginGuard, groupGuard)
+  },
+  {
+    path: '/join',
+    name: Join.name,
+    component: Join,
+    meta: { title: L('Join a Group') },
+    // beforeEnter: createEnterGuards(loginGuard, mailGuard)
+    beforeEnter: createEnterGuards(inviteGuard)
+  },
+  ...(process.env.NODE_ENV === 'development'
+    ? [{
+        path: '/error-testing',
+        name: 'ErrorTesting',
+        component: () => import('../views/pages/ErrorTesting.vue'),
+        meta: { title: L('Error Testing') }
+      }]
+    : []),
+  {
+    path: '*',
+    redirect: '/'
+  }
+]
 const router: any = new Router({
   mode: 'history',
   base: '/app',
+  routes,
   scrollBehavior (to, from, savedPosition) {
     return { x: 0, y: 0 }
-  },
-  routes: [
-    {
-      path: '/',
-      component: Home,
-      name: 'home',
-      meta: { title: L('Group Income') }, // page title. see issue #45
-      beforeEnter: createEnterGuards(homeGuard)
-    },
-    {
-      path: '/design-system',
-      component: lazyDesignSystem,
-      name: 'DesignSystem',
-      meta: { title: L('Design System') }
-      // beforeEnter: createEnterGuards(designGuard)
-    },
-    {
-      path: '/dashboard',
-      component: lazyGroupDashboard,
-      name: 'GroupDashboard',
-      meta: { title: L('Group Dashboard') },
-      beforeEnter: createEnterGuards(loginGuard, groupGuard)
-    },
-    {
-      path: '/contributions',
-      component: lazyContributions,
-      name: 'Contributions',
-      meta: { title: L('Contributions') },
-      beforeEnter: createEnterGuards(loginGuard, groupGuard)
-    },
-    {
-      path: '/payments',
-      component: lazyPayments,
-      name: 'Payments',
-      meta: { title: L('Payments') },
-      beforeEnter: createEnterGuards(loginGuard, groupGuard)
-    },
-    /* Guards need to be created for any route that should not be directly accessed by url */
-    {
-      path: '/messages',
-      component: lazyMessages,
-      name: 'Messages',
-      meta: { title: L('Messages') },
-      beforeEnter: createEnterGuards(loginGuard)
-    },
-    {
-      path: '/messages/:chatName',
-      component: lazyMessages,
-      name: 'MessagesConversation',
-      beforeEnter: createEnterGuards(loginGuard)
-      // BUG/REVIEW "CANNOT GET /:username" when username has "." in it
-      // ex: messages/joe.kim doesnt work but messages/joekim works fine.
-      // Possible Solution: https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations
-    },
-    {
-      path: '/group-chat',
-      component: lazyGroupChat,
-      name: 'GroupChat',
-      meta: { title: L('Group Chat') },
-      beforeEnter: createEnterGuards(loginGuard, groupGuard)
-    },
-    {
-      path: '/group-settings',
-      component: lazyGroupSettings,
-      name: 'GroupSettings',
-      meta: { title: L('Group Settings') },
-      beforeEnter: createEnterGuards(loginGuard, groupGuard)
-    },
-    {
-      path: '/group-chat/:chatRoomId',
-      component: lazyGroupChat,
-      name: 'GroupChatConversation',
-      beforeEnter: createEnterGuards(loginGuard, groupGuard)
-    },
-    {
-      path: '/join',
-      name: Join.name,
-      component: Join,
-      meta: { title: L('Join a Group') },
-      // beforeEnter: createEnterGuards(loginGuard, mailGuard)
-      beforeEnter: createEnterGuards(inviteGuard)
-    },
-    ...(process.env.NODE_ENV === 'development'
-      ? [{
-          path: '/error-testing',
-          name: 'ErrorTesting',
-          component: () => import('../views/pages/ErrorTesting.vue'),
-          meta: { title: L('Error Testing') }
-        }]
-      : []),
-    {
-      path: '*',
-      redirect: '/'
-    }
-  ]
+  }
 })
 
 router.beforeEach((to, from, next) => {
   document.title = to.meta.title
   next()
+})
+
+let startRoute
+router.beforeResolve((to, from, next) => {
+  if (!startRoute) startRoute = to
+  // console.warn(`beforeResolve to: ${to.path} from: ${from.path}`)
+  next()
+})
+
+// Sometimes beforeEnter will get triggered too early b/c of fix for #1192
+// and store.state isn't loaded yet, so we run it again after VUE_LOADED
+sbp('okTurtles.events/once', VUE_LOADED, function () {
+  const route = routes.find(r => r.path === startRoute.path)
+  // $FlowFixMe
+  const next = route?.beforeEnter?.(startRoute, null, (next) => next)
+  // console.warn(`started at ${startRoute.path} and got next of ${JSON.stringify(next)}`)
+  if (next) {
+    router.push(next).catch(logExceptNavigationDuplicated)
+  }
 })
 
 sbp('sbp/selectors/register', {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -172,9 +172,6 @@ async function startApp () {
       })
       sbp('okTurtles.events/on', LOGIN, () => {
         this.ephemeral.finishedLogin = 'yes'
-        if (this.$store.getters.ourUsername) {
-          router.currentRoute.path === '/' && router.push({ path: '/dashboard' }).catch(console.error)
-        }
       })
       sbp('okTurtles.events/on', LOGOUT, () => {
         this.ephemeral.finishedLogin = 'no'

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -15,12 +15,13 @@ import router from './controller/router.js'
 import { PUBSUB_INSTANCE } from './controller/instance-keys.js'
 import store from './model/state.js'
 import { SETTING_CURRENT_USER } from './model/database.js'
-import { LOGIN, LOGOUT, VUE_LOADED } from './utils/events.js'
+import { LOGIN, LOGOUT } from './utils/events.js'
 import BannerGeneral from './views/components/banners/BannerGeneral.vue'
 import Navigation from './views/containers/navigation/Navigation.vue'
 import AppStyles from './views/components/AppStyles.vue'
 import Modal from './views/components/modal/Modal.vue'
 import L, { LError, LTags } from '@view-utils/translations.js'
+import ALLOWED_URLS from '@view-utils/allowedUrls.js'
 import './views/utils/allowedUrls.js'
 import './views/utils/translations.js'
 import './views/utils/avatar.js'
@@ -120,12 +121,48 @@ async function startApp () {
     }
   })
 
-  await sbp('translations/init', navigator.language)
-
-  if (process.env.NODE_ENV === 'development' || window.Cypress) {
+  // NOTE: setting 'EXPOSE_SBP' in production will make it easier for users to generate contract
+  //       actions that they shouldn't be generating, which can lead to bugs or trigger the automated
+  //       ban system. Only enable it if you know what you're doing and don't mind the risk.
+  if (process.env.NODE_ENV === 'development' || window.Cypress || process.env.EXPOSE_SBP === 'true') {
     // In development mode this makes the SBP API available in the devtools console.
     window.sbp = sbp
   }
+
+  try {
+    // must create the connection before we call login
+    sbp('okTurtles.data/set', PUBSUB_INSTANCE, sbp('chelonia/connect'))
+    await sbp('translations/init', navigator.language)
+
+    // TODO: move this into gi.actions/identity/login or something
+    // NOTE: important to do this before setting up Vue.js because a lot of that relies
+    //       on the router stuff which has guards that expect the contracts to be loaded
+    const username = await sbp('gi.db/settings/load', SETTING_CURRENT_USER)
+    if (username) {
+      const identityContractID = await sbp('namespace/lookup', username)
+      if (identityContractID) {
+        await sbp('state/vuex/dispatch', 'login', { username, identityContractID })
+      } else {
+        await sbp('state/vuex/dispatch', 'logout')
+        console.warn(`It looks like the local user '${username}' does not exist anymore on the server 😱 If this is unexpected, contact us at https://gitter.im/okTurtles/group-income`)
+        // TODO: do not delete the username like this! handle this better!
+        //       because of how await works, this exception handler can be triggered
+        //       even by random errors from Vue.js, example:
+        //
+        //         lookup failed! TypeError: "state[state.currentGroupId] is undefined"
+        //         memberUsernames state.js:231
+        //
+        //       Which doesn't mean that the lookup actually failed!
+        await sbp('gi.db/settings/delete', username)
+      }
+    }
+  } catch (e) {
+    const errMsg = `Fatal error${e.name} initializing Group Income: ${e.message}\n\nPlease report this bug here: ${ALLOWED_URLS.ISSUE_PAGE}`
+    console.error(errMsg, e)
+    alert(errMsg)
+    return
+  }
+
   /* eslint-disable no-new */
   new Vue({
     router: router,
@@ -146,7 +183,6 @@ async function startApp () {
       }
     },
     mounted () {
-      sbp('okTurtles.data/set', PUBSUB_INSTANCE, sbp('chelonia/connect'))
       const reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)') || {}
       if (reducedMotionQuery.matches || this.isInCypress) {
         this.setReducedMotion(true)
@@ -217,31 +253,6 @@ async function startApp () {
           'times-circle'
         )
       }
-      // TODO: move this into gi.actions/identity/login or something
-      (async function () {
-        const username = await sbp('gi.db/settings/load', SETTING_CURRENT_USER)
-        if (username) {
-          const identityContractID = await sbp('namespace/lookup', username)
-          if (identityContractID) {
-            await sbp('state/vuex/dispatch', 'login', { username, identityContractID })
-          } else {
-            await sbp('state/vuex/dispatch', 'logout')
-            console.warn(`It looks like the local user '${username}' does not exist anymore on the server 😱 If this is unexpected, contact us at https://gitter.im/okTurtles/group-income`)
-            // TODO: do not delete the username like this! handle this better!
-            //       because of how await works, this exception handler can be triggered
-            //       even by random errors from Vue.js, example:
-            //
-            //         lookup failed! TypeError: "state[state.currentGroupId] is undefined"
-            //         memberUsernames state.js:231
-            //
-            //       Which doesn't mean that the lookup actually failed!
-            await sbp('gi.db/settings/delete', username)
-          }
-        }
-        // useful to delay the initialization of various pages like Join.vue until
-        // we have finished setting up and logging in
-        sbp('okTurtles.events/emit', VUE_LOADED)
-      })()
     },
     computed: {
       showNav () {

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -504,7 +504,9 @@ const actions = {
       // but the state object in scope is a copy that becomes stale if something modifies it
       // like an outside dispatch
       const contracts = store.state.contracts
-      await sbp('chelonia/contract/sync', Object.keys(contracts))
+      // IMPORTANT: we avoid using 'await' on the syncs so that Vue.js can proceed
+      //            loading the website instead of stalling out.
+      sbp('chelonia/contract/sync', Object.keys(contracts))
       // it's insane, and I'm not sure how this can happen, but it did... and
       // the following steps actually fixed it...
       // TODO: figure out what happened and prevent it from happening again
@@ -514,12 +516,12 @@ const actions = {
       const currentGroupId = store.state.currentGroupId
       if (currentGroupId && !contracts[currentGroupId]) {
         console.error(`login: lost current group state somehow for ${currentGroupId}! attempting resync...`)
-        await sbp('chelonia/contract/sync', currentGroupId)
+        sbp('chelonia/contract/sync', currentGroupId) // again, make sure not to use 'await'
       }
       // TODO: resync for the chatroom contract, because current chatroom contract id could be what the user is not part of
       if (!contracts[user.identityContractID]) {
         console.error(`login: lost current identity state somehow for ${user.username} / ${user.identityContractID}! attempting resync...`)
-        await sbp('chelonia/contract/sync', user.identityContractID)
+        sbp('chelonia/contract/sync', user.identityContractID)
       }
     } else {
       captureLogsStart(user.username)

--- a/frontend/views/components/ProfileCard.vue
+++ b/frontend/views/components/ProfileCard.vue
@@ -139,15 +139,15 @@ export default ({
       return this.groupProfiles[this.username]
     },
     isActiveGroupMember () {
-      return this.userGroupProfile.status === PROFILE_STATUS.ACTIVE
+      return this.userGroupProfile?.status === PROFILE_STATUS.ACTIVE
     },
 
     paymentMethods () {
-      return this.userGroupProfile.paymentMethods
+      return this.userGroupProfile?.paymentMethods
     },
 
     hasIncomeDetails () {
-      return !!this.userGroupProfile.incomeDetailsType
+      return !!this.userGroupProfile?.incomeDetailsType
     },
 
     receivingMonetary () {

--- a/frontend/views/containers/access/SignupModal.vue
+++ b/frontend/views/containers/access/SignupModal.vue
@@ -28,10 +28,7 @@ export default ({
   methods: {
     submit () {
       if (this.$route.query.next) {
-        // TODO: get rid of this timeout and fix/update tests accordingly
-        setTimeout(() => {
-          this.$router.push({ path: this.$route.query.next })
-        }, 1000)
+        this.$router.push({ path: this.$route.query.next }).catch(logExceptNavigationDuplicated)
       } else {
         this.$router.push({ path: '/' }).catch(logExceptNavigationDuplicated)
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "tweetnacl-util": "0.15.1",
         "vue": "2.6.12",
         "vue-clickaway": "2.2.2",
-        "vue-router": "3.4.9",
+        "vue-router": "3.5.3",
         "vue-slider-component": "3.2.11",
         "vue2-touch-events": "3.0.0",
         "vuelidate": "0.7.6",
@@ -17299,9 +17299,9 @@
       }
     },
     "node_modules/vue-router": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.9.tgz",
-      "integrity": "sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.3.tgz",
+      "integrity": "sha512-FUlILrW3DGitS2h+Xaw8aRNvGTwtuaxrRkNSHWTizOfLUie7wuYwezeZ50iflRn8YPV5kxmU2LQuu3nM/b3Zsg=="
     },
     "node_modules/vue-slider-component": {
       "version": "3.2.11",
@@ -31617,9 +31617,9 @@
       "requires": {}
     },
     "vue-router": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.4.9.tgz",
-      "integrity": "sha512-CGAKWN44RqXW06oC+u4mPgHLQQi2t6vLD/JbGRDAXm0YpMv0bgpKuU5bBd7AvMgfTz9kXVRIWKHqRwGEb8xFkA=="
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-3.5.3.tgz",
+      "integrity": "sha512-FUlILrW3DGitS2h+Xaw8aRNvGTwtuaxrRkNSHWTizOfLUie7wuYwezeZ50iflRn8YPV5kxmU2LQuu3nM/b3Zsg=="
     },
     "vue-slider-component": {
       "version": "3.2.11",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "tweetnacl-util": "0.15.1",
     "vue": "2.6.12",
     "vue-clickaway": "2.2.2",
-    "vue-router": "3.4.9",
+    "vue-router": "3.5.3",
     "vue-slider-component": "3.2.11",
     "vue2-touch-events": "3.0.0",
     "vuelidate": "0.7.6",


### PR DESCRIPTION
Turns out closing #1192 was *a lot* trickier than expected.

+ Fixes `Error: Redirected when going from "/?modal=SignupModal" to "/dashboard" via a navigation guard.` (Closes #1236)
+ Fixes a few vue console errors
+ Updates vue-router to 3.5.3