### PR TITLE
Fix clipboard copy Mac Safari corner case (#1255)

### DIFF
--- a/frontend/views/components/LinkToCopy.vue
+++ b/frontend/views/components/LinkToCopy.vue
@@ -47,13 +47,24 @@ export default ({
     }
   },
   methods: {
+    // FIXME: probably needs to be defined centrally somewhere else
+    isMacSafari () {
+      // NB: Chrome, Edge, Brave on Macintosh tacks on the 'Safari/537.36' string in its userAgent
+      // so we have to ensure that were not mistaking those browsers instead when matching for Safari on Macintosh
+      const userAgent = navigator.userAgent
+      const safari = /Macintosh.*Safari/
+      const chrome = /Macintosh.*Chrome/
+      const edge = /Macintosh.*Edg/
+      return userAgent.match(safari) &&
+              !(userAgent.match(chrome) || userAgent.match(edge))
+    },
     copyToClipboard () {
       // if the user is using the device that supports web share API, use it and then skip the other logics below.
-      if (navigator.share) {
+      if (navigator.share && !this.isMacSafari()) {
         navigator.share({
           title: this.L('Your invite'),
           url: this.link
-        })
+        }).catch((error) => console.error('navigator.share failed with:', error))
         return
       }
 


### PR DESCRIPTION
Defined function just for the corner case `isMacSafari` in `LinkToCopy.vue` itself using `navigator.userAgent`. 
In terms of UX might be a bit weird that the copy notification shows at the same time that the share context menu pops up

- Tested OSX Catalina 10.15.6
(`navigator.share` defined) Safari/605.1.15 (14.0); Edge/101.0.1210.39
(`navigator.share` undefined) Chrome/90.0.4430; Firefox/99.01;

- Tested Windows 10
(`navigator.share` defined) Chrome/101.0.4951.54; Edge/101.0.1210.39
(`navigator.share` undefined) Firefox/80.0;

_Issues_
- Defined function specifically in `LinkToCopy.vue`. Probably best to have a central useragent util somewhere and relocate that there
- No actual Mac Safari version was tested and will return true for ALL versions. We could actually test for version ranges with `/Macintosh.*Safari\/(.*)/` 
- Probably the regex for machine and application should be separate 
- Firefox doesnt seem to tack on `Safari` on to the useragent hence was not tested
