### PR TITLE
Enable info-level logging by default

### DIFF
--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -40,8 +40,8 @@ const initialState = {
   increasedContrast: false,
   fontSize: 16,
   appLogsFilter: process.env.NODE_ENV === 'development'
-    ? ['error', 'warn', 'debug', 'log']
-    : ['error', 'warn']
+    ? ['error', 'warn', 'info', 'debug', 'log']
+    : ['error', 'warn', 'info']
 }
 
 sbp('sbp/selectors/register', {

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -19,7 +19,10 @@
               input.input(type='checkbox' name='filter' v-model='form.filter' value='debug')
               i18n Debug
             label.checkbox
-              input.input(type='checkbox' name='filter' v-model='form.filter' value='log')
+              input.input(type='checkbox' name='filter' v-model='form.filter' value='info' checked)
+              i18n Info
+            label.checkbox
+              input.input(type='checkbox' name='filter' v-model='form.filter' value='log' checked)
               i18n Log
 
         button.is-small.c-download(@click='downloadLogs')


### PR DESCRIPTION
Closes #1268 

### Summary of changes:
- An `info` checkbox has been added in the Application Logs page. It is checked by default.

### Additional info:
- Note that `info` won't be retroactively added to `state.appLogsFilter` for older clients, as I didn't know how to determine whether it was missing or removed by the user via the Application Logs page.