### PR TITLE
bug fix: translation fails when locale is not en-US

### DIFF
--- a/frontend/views/utils/translations.js
+++ b/frontend/views/utils/translations.js
@@ -59,7 +59,7 @@ sbp('sbp/selectors/register', {
       return
     }
     try {
-      currentTranslationTable = await sbp('backend/translations/get', language)
+      currentTranslationTable = (await sbp('backend/translations/get', language)) || defaultTranslationTable
 
       // Only set `currentLanguage` if there was no error fetching the ressource.
       currentLanguage = language


### PR DESCRIPTION
i18n.vue component fails to translate a string when the localization settings on the browser is different than en-US.
when there is no translation-table fetched from the back-end, it needs to resolve to the default table.

![image](https://user-images.githubusercontent.com/17641213/174222380-c474c31b-e2fc-42e3-b8ac-73a9931011a4.png)
