### PR TITLE
Fix word wrapping in NotificationList.vue

### DIFF
--- a/frontend/views/containers/notifications/NotificationList.vue
+++ b/frontend/views/containers/notifications/NotificationList.vue
@@ -191,6 +191,11 @@ export default ({
   }
 }
 
+.c-item-text {
+  word-break: break-word;
+  word-wrap: break-word;
+}
+
 .c-thumbCircle {
   position: relative;
   display: inline-block;


### PR DESCRIPTION
Related to #1315

### Summary of changes:
- Word wrapping and text overflow issues in the notification modal should have been fixed.