### PR TITLE
Make notification text easier to highlight

### DIFF
--- a/frontend/model/notifications/templates.js
+++ b/frontend/model/notifications/templates.js
@@ -58,7 +58,7 @@ export default ({
       }),
       icon: 'coins',
       level: 'info',
-      linkTo: '/contributions/TODO-LINK-MODAL',
+      linkTo: '/contributions?modal=IncomeDetails',
       scope: 'user'
     }
   },


### PR DESCRIPTION
Closes #1315

### Additional info
- Hitting the back button after following a notification link no longer automatically re-opens the notifications, which might be inconvenient when manually checking many notifications in order.
Has someone any idea on how to fix that?