### PR TITLE
Remove bypassUI option from cy.giLogin()

### DIFF
--- a/test/cypress/integration/group-chat.spec.js
+++ b/test/cypress/integration/group-chat.spec.js
@@ -472,7 +472,7 @@ describe('Group Chat Basic Features (Create & Join & Leave & Close)', () => {
   })
 
   it(`user1 checks if user2 and user3 are removed from all the channels including ${CHATROOM_GENERAL_NAME}`, () => {
-    cy.giLogin(user1, { bypassUI: true })
+    cy.giLogin(user1)
     me = user1
 
     cy.giRedirectToGroupChat()

--- a/test/cypress/integration/group-contributions.spec.js
+++ b/test/cypress/integration/group-contributions.spec.js
@@ -99,7 +99,7 @@ describe('Contributions', () => {
       })
     }
 
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
   })
 
   it('user1 fills their Income Details - pledges $500', () => {

--- a/test/cypress/integration/group-large.spec.js
+++ b/test/cypress/integration/group-large.spec.js
@@ -33,7 +33,7 @@ describe('Large group', () => {
         }
       })
     }
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
     cy.giAddRandomIncome()
     cy.get('.graph-bar')
       .should('have.length', groupLength)

--- a/test/cypress/integration/group-member-removal.spec.js
+++ b/test/cypress/integration/group-member-removal.spec.js
@@ -142,7 +142,7 @@ describe('Group - Removing a member', () => {
   })
 
   it('user1 proposes to remove userBot', () => {
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
 
     openRemoveMemberModal('userbot', 2)
 
@@ -205,7 +205,7 @@ describe('Group - Removing a member', () => {
   // ------- A member leaves the group.
 
   it('user2 leaves the groupA - is left with groupB', () => {
-    cy.giLogin(`user2-${userId}`, { bypassUI: true })
+    cy.giLogin(`user2-${userId}`)
 
     cy.getByDT('groupSettingsLink').click()
     cy.getByDT('leaveModalBtn').click()

--- a/test/cypress/integration/group-proposals.spec.js
+++ b/test/cypress/integration/group-proposals.spec.js
@@ -78,7 +78,7 @@ describe('Proposals - Add members', () => {
   })
 
   it('user1 proposes to add user4, user5 together to the group', () => {
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
 
     cy.giInviteMember([`user4-${userId}`, `user5-${userId}`])
   })
@@ -283,7 +283,7 @@ describe('Proposals - Add members', () => {
   it(`proposal-based invitation link has ${groupInviteLinkExpiry.proposal} days of expiry`, () => {
     // Expiry check in Group Settings page and Dashboard
     cy.visit('/')
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
 
     cy.clock(Date.now() + 1000 * 86400 * groupInviteLinkExpiry.proposal)
     cy.getByDT('groupSettingsLink').click()
@@ -337,7 +337,7 @@ describe('Proposals - Add members', () => {
   })
 
   it('user1 logins and sees all 5 proposals correctly and the new members', () => {
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
 
     // A quick checkup that each proposal state is correct.
     // OPTIMIZE: Maybe we should adopt Visual Testing in these cases

--- a/test/cypress/integration/group-settings.spec.js
+++ b/test/cypress/integration/group-settings.spec.js
@@ -162,7 +162,7 @@ describe('Group Voting Rules', () => {
       })
     }
 
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
 
     verifyRuleSelected('disagreement', {
       status: '4 (adjusted to 3*)',
@@ -178,7 +178,7 @@ describe('Group Voting Rules', () => {
       bypassUI: true
     })
 
-    cy.giLogin(`user1-${userId}`, { bypassUI: true })
+    cy.giLogin(`user1-${userId}`)
 
     verifyRuleSelected('disagreement', {
       status: '4',

--- a/test/cypress/integration/signup-and-login.js
+++ b/test/cypress/integration/signup-and-login.js
@@ -4,6 +4,7 @@ describe('Signup, Profile and Login', () => {
   // users and groups that are created during test...
   const userId = Math.floor(Math.random() * 10000)
   const username = `user1-${userId}`
+  const password = '123456789'
 
   it('user1 signups and creates a group', () => {
     cy.visit('/')
@@ -15,7 +16,22 @@ describe('Signup, Profile and Login', () => {
 
   it('user1 does logout and login again', () => {
     cy.giLogout()
-    cy.giLogin(username)
+    cy.getByDT('loginBtn').click()
+    cy.getByDT('loginName').clear().type(username)
+    cy.getByDT('password').clear().type(password)
+
+    cy.getByDT('loginSubmit').click()
+    cy.getByDT('closeModal').should('not.exist')
+
+    // We changed pages (to dashboard or create group), so there's no login button anymore.
+    cy.getByDT('loginBtn').should('not.exist')
+
+    // Wait for contracts to finish syncing.
+    cy.getByDT('app').then(([el]) => {
+      cy.get(el).should('have.attr', 'data-logged-in', 'yes')
+      cy.get(el).should('have.attr', 'data-sync', '')
+    })
+    cy.log('- logged in')
   })
 
   it('user1 changes avatar and profile settings', () => {


### PR DESCRIPTION
### Summary of changes:
- `cy.giLogin()` no longer uses the `bypassUI` option and always bypasses the UI.
- It's `password` option is now a positional parameter:
  ```js
  cy.giLogin(username, password) { ... }
  ```