### PR TITLE
Add 'X-Frame-Options: deny' header to server responses

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -52,7 +52,7 @@ hapi.ext({
         request.response.output.headers['X-Frame-Options'] = 'deny'
       }
     } catch (err) {
-      console.warn('[backend] Could not set X-Frame-Options header:', err.message)
+      console.warn(chalk.yellow('[backend] Could not set X-Frame-Options header:', err.message))
     }
     return h.continue
   }

--- a/backend/server.js
+++ b/backend/server.js
@@ -38,6 +38,26 @@ const hapi = new Hapi.Server({
   }
 })
 
+// See https://stackoverflow.com/questions/26213255/hapi-set-header-before-sending-response
+hapi.ext({
+  type: 'onPreResponse',
+  method: function (request, h) {
+    try {
+      // Hapi Boom error responses don't have `.header()`,
+      // but custom headers can be manually added using `.output.headers`.
+      // See https://hapi.dev/module/boom/api/.
+      if (typeof request.response.header === 'function') {
+        request.response.header('X-Frame-Options', 'deny')
+      } else {
+        request.response.output.headers['X-Frame-Options'] = 'deny'
+      }
+    } catch (err) {
+      console.warn('[backend] Could not set X-Frame-Options header:', err.message)
+    }
+    return h.continue
+  }
+})
+
 sbp('okTurtles.data/set', SERVER_INSTANCE, hapi)
 
 sbp('sbp/selectors/register', {

--- a/test/avatar-caching.test.js
+++ b/test/avatar-caching.test.js
@@ -20,5 +20,6 @@ describe('avatar file serving', function () {
     assert.equal(headers.get('content-type'), 'application/octet-stream')
     assert.equal(headers.get('etag'), `"${hash}"`)
     assert(headers.has('last-modified'))
+    assert.equal(headers.get('x-frame-options'), 'deny')
   })
 })


### PR DESCRIPTION
Closes #1383

### Summary of changes:
- New `X-Frame-Options: deny` header add to every server response for increased security.
 Currently this also includes static asset responses and 404's, but that could be changed later.
 
 ### Additional information:
- This change has been implemented using an [`onPreResponse()`](https://hapi.dev/api/#request-lifecycle) server hook. This way there was no need to alter individual route handlers.