### PR TITLE
#1242 -  Automated bans should make it clear they are client-generated

### DIFF
--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -436,7 +436,7 @@ export default (sbp('sbp/selectors/register', {
           if (!proposal.votes[getters.ourUsername]) {
             await sbp('gi.actions/group/proposalVote', {
               contractID: groupID,
-              data: { proposalHash, vote: VOTE_FOR, passPayload: { secret: '' } },
+              data: { proposalHash, vote: VOTE_FOR, passPayload: { secret: '', automated: true } },
               publishOptions: { maxAttempts: 3 }
             })
           }
@@ -449,6 +449,7 @@ export default (sbp('sbp/selectors/register', {
                 proposalType: PROPOSAL_REMOVE_MEMBER,
                 proposalData: {
                   member: username,
+                  automated: true,
                   reason: L("Automated ban because they're sending malformed messages resulting in: {error}", { error: error.message })
                 },
                 votingRule: contractState.settings.proposals[PROPOSAL_REMOVE_MEMBER].rule,

--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -432,7 +432,7 @@ export default (sbp('sbp/selectors/register', {
             prop.data.proposalData.member === username
           )) ?? ['', undefined]
         if (proposal) {
-          // cast our vote if we haven't already cast it
+          // cast our vote if we haven't already cast it.
           if (!proposal.votes[getters.ourUsername]) {
             await sbp('gi.actions/group/proposalVote', {
               contractID: groupID,

--- a/frontend/views/containers/proposals/ProposalItem.vue
+++ b/frontend/views/containers/proposals/ProposalItem.vue
@@ -147,9 +147,14 @@ export default ({
           user: this.proposal.data.proposalData.member
         }),
         [PROPOSAL_REMOVE_MEMBER]: () => {
-          const user = this.userDisplayName(this.proposal.data.proposalData.member)
-          return this.isToRemoveMe
-            ? L('Remove {user} (you) from the group.', { user })
+          const user = [
+            this.userDisplayName(this.proposal.data.proposalData.member),
+            this.isToRemoveMe && '(you)'
+          ].filter(Boolean).join(' ')
+          const isAutomatedBan = this.proposal.data.proposalData.automated
+
+          return isAutomatedBan
+            ? L('[Automated] Remove {user} from the group.', { user })
             : L('Remove {user} from the group.', { user })
         },
         [PROPOSAL_GROUP_SETTING_CHANGE]: () => {


### PR DESCRIPTION
closes #1242 

[summary]
- add `[Automated]` prefix string when a `remove-member` proposal is auto-generated.

<image src='https://user-images.githubusercontent.com/17641213/187061536-88193bdd-a677-40bc-991d-f5ec89bf9546.png' width='420'>
