### PR TITLE
Issue #1352 - Make `grunt pin` run esbuild first

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -455,8 +455,8 @@ module.exports = (grunt) => {
     cypress[command](options).then(r => done(r.totalFailed === 0)).catch(done)
   })
 
-  grunt.registerTask('pin', async function (version) {
-    if (typeof version !== 'string') throw new Error('usage: grunt pin:<version>')
+  grunt.registerTask('_pin', async function (version) {
+    // a task internally executed in 'pin' task below
     const done = this.async()
     const dirPath = `contracts/${version}`
 
@@ -479,6 +479,13 @@ module.exports = (grunt) => {
     fs.writeFileSync('package.json', JSON.stringify(packageJSON, null, 2) + '\n', 'utf8')
     console.log(chalk.green('updated package.json "contractsVersion" to:'), version)
     done()
+  })
+
+  grunt.registerTask('pin', function (version) {
+    if (typeof version !== 'string') throw new Error('usage: grunt pin:<version>')
+
+    grunt.task.run('build')
+    grunt.task.run(`_pin:${version}`)
   })
 
   grunt.registerTask('default', ['dev'])


### PR DESCRIPTION
closes #1352 

@taoeffect 
I chose to run `build` because all the linters still need to be executed to clear possible syntax errors in the changed files but still wasn't 100% sure it is enough as the preparation of `pin` task.
please let me know of your opinion.

cheers,