### PR TITLE
Use nomodule script as fallback in main.html

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="/assets/images/group-income-icon-transparent.png" sizes="32x32">
   </head>
   <body>
-    <div class="modal is-active" id="fallback" style="visibility: hidden;">
+    <div class="modal is-active" id="fallback" style="display: none;">
       <div class="modal-content">
         <h1>Outdated browser</h1>
         <p>You are using an <strong>outdated</strong> or unsupported browser. Please upgrade your browser to improve your experience.</p>
@@ -31,10 +31,9 @@
       <!-- we no longer use cypress-bypass-ui -->
       <!-- <cypress-bypass-ui v-if="isInCypress"></cypress-bypass-ui> -->
     </div>
-    <!-- If main.js loads properly it will remove the fallback element. -->
     <script type="module" src="/assets/js/main.js"></script>
-    <!-- Makes the fallback element visible if JS is enabled. -->
-    <script type="text/javascript">document.getElementById('fallback').style.visibility = ''</script>
+    <!-- Makes the fallback element visible if JS is enabled but modules aren't supported. -->
+    <script type="text/javascript" nomodule>document.getElementById('fallback').style.display = ''</script>
     <noscript>
       <section class="hero is-fullheight">
         <div class="hero-body">

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -41,8 +41,6 @@ import './utils/touchInteractions.js'
 
 const { Vue, L } = Common
 
-document.getElementById('fallback')?.remove()
-
 console.info('GI_VERSION:', process.env.GI_VERSION)
 console.info('NODE_ENV:', process.env.NODE_ENV)
 

--- a/test/cypress/integration/group-chat-message.spec.js
+++ b/test/cypress/integration/group-chat-message.spec.js
@@ -214,7 +214,7 @@ describe('Send/edit/remove messages & add/remove emoticons inside group chat', (
       cy.get('.c-message:nth-child(5) .c-emoticons-list>.c-emoticon-wrapper').should('have.length', 2)
     })
 
-    sendEmoticon(5, '+1', 1)
+    sendEmoticon(5, '+1', 2)
 
     cy.getByDT('conversationWrapper').within(() => {
       cy.get('.c-message:nth-child(5) .c-emoticons-list>.c-emoticon-wrapper').should('have.length', 3)


### PR DESCRIPTION
Closes #1460

### Summary of changes:
- Added an inline script tag with the `nomodule` attribute in `main.html`: 
  -  Modern browsers with JS enabled should just run our main bundle and ignore the nomodule script.
  -  Browsers without ESM support will ignore the main bundle as it is a `type=module` script, and only run the nomodule script which will display an unsupported browser warning to the user.
  -  Browsers with JS disabled or without JS should just display the `noscript` contents.