### PR TITLE
Use key prefixes only in 'chel/db/get', not in actual DB keys

### DIFF
--- a/backend/database-fs.js
+++ b/backend/database-fs.js
@@ -2,8 +2,7 @@
 
 import { mkdir, readdir, readFile, unlink, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
-
-import { checkKey } from './database.js'
+import { checkKey } from '~/shared/domains/chelonia/db.js'
 
 // Initialized in `initStorage()`.
 let dataFolder = ''
@@ -19,28 +18,15 @@ export function clear (): Promise<void> {
     .then(keys => Promise.all(keys.map(key => unlink(join(dataFolder, key)))))
 }
 
-export function exportToJSON (): Promise<Object> {
-  return readdir(dataFolder)
-    .then(keys => Promise.all(keys.map(key => readData(key).then(value => ([key, value])))))
-    .then(Object.fromEntries)
-}
-
-export function importFromJSON (json: Object): Promise<void> {
-  // TODO: rollback the operation if an error occurs?
-  return Promise.all(Object.keys(json).map(key => writeData(key, json[key])))
-    .then(() => undefined)
-}
-
 // eslint-disable-next-line require-await
-export async function readData (key: string): Promise<Buffer | void> {
+export async function readData (key: string): Promise<Buffer | string | void> {
+  // Necessary here to thwart path traversal attacks.
   checkKey(key)
   return readFile(join(dataFolder, key))
-    .then(buffer => key.startsWith('blob=') ? buffer : buffer.toString('utf8'))
     .catch(err => undefined) // eslint-disable-line node/handle-callback-err
 }
 
 // eslint-disable-next-line require-await
 export async function writeData (key: string, value: Buffer | string): Promise<void> {
-  checkKey(key)
   return writeFile(join(dataFolder, key), value)
 }

--- a/backend/database-sqlite.js
+++ b/backend/database-sqlite.js
@@ -4,8 +4,6 @@ import { mkdir } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
 import sqlite3 from 'sqlite3'
 
-import { checkKey } from './database.js'
-
 let db: any = null
 let readStatement: any = null
 let writeStatement: any = null
@@ -51,37 +49,8 @@ export function clear (): Promise<void> {
   return run('DELETE FROM Data')
 }
 
-export function exportToJSON (): Promise<Object> {
-  return new Promise((resolve, reject) => {
-    db.all('SELECT key, value FROM Data', [], (err, rows) => {
-      if (err) {
-        reject(err)
-      } else {
-        resolve(Object.fromEntries(rows.map(row => ([row.key, row.value]))))
-      }
-    })
-  })
-}
-
-export function importFromJSON (json: Object): Promise<void> {
-  return new Promise((resolve, reject) => {
-    db.serialize(() => {
-      db.run('BEGIN')
-      Object.keys(json).forEach(key => writeData(key, json[key]))
-      db.run('COMMIT', [], (err) => {
-        if (err) {
-          reject(err)
-        } else {
-          resolve()
-        }
-      })
-    })
-  })
-}
-
 export function readData (key: string): Promise<Buffer | string | void> {
   return new Promise((resolve, reject) => {
-    checkKey(key)
     readStatement.get([key], (err, row) => {
       if (err) {
         reject(err)
@@ -96,7 +65,6 @@ export function readData (key: string): Promise<Buffer | string | void> {
 
 export function writeData (key: string, value: Buffer | string): Promise<void> {
   return new Promise((resolve, reject) => {
-    checkKey(key)
     writeStatement.run([key, value], (err) => {
       if (err) {
         reject(err)

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -176,8 +176,8 @@ route.POST('/file', {
       console.error(`hash(${hash}) != ourHash(${ourHash})`)
       return Boom.badRequest('bad hash!')
     }
-    await sbp('chelonia/db/set', `blob=${hash}`, data)
-    return '/file/blob=' + hash
+    await sbp('chelonia/db/set', hash, data)
+    return '/file/' + hash
   } catch (err) {
     return logger(err)
   }
@@ -185,18 +185,17 @@ route.POST('/file', {
 
 // Serve data from Chelonia DB.
 // Note that a `Last-Modified` header isn't included in the response.
-route.GET('/file/{key}', {
+route.GET('/file/{hash}', {
   cache: {
     // Do not set other cache options here, to make sure the 'otherwise' option
     // will be used so that the 'immutable' directive gets included.
     otherwise: 'public,max-age=31536000,immutable'
   }
 }, async function (request, h) {
-  const { key } = request.params
-  console.debug(`GET /file/${key}`)
-  // TODO: Simplify this when `¢hel deploy` no longer generates unprefixed keys.
-  const hash = key.includes('=') ? key.slice(key.indexOf('=') + 1) : key
-  const blobOrString = await sbp('chelonia/db/get', key)
+  const { hash } = request.params
+  console.debug(`GET /file/${hash}`)
+
+  const blobOrString = await sbp('chelonia/db/get', `any:${hash}`)
   if (!blobOrString) {
     return Boom.notFound()
   }

--- a/test/backend.test.js
+++ b/test/backend.test.js
@@ -331,7 +331,7 @@ describe('Full walkthrough', function () {
       form.append('data', new Blob([buffer]), path.basename(filepath))
       await fetch(`${process.env.API_URL}/file`, { method: 'POST', body: form })
         .then(handleFetchResult('text'))
-        .then(r => should(r).equal(`/file/blob=${hash}`))
+        .then(r => should(r).equal(`/file/${hash}`))
     })
   })
 


### PR DESCRIPTION
Closes #1548

#### Changes in `'chelonia/db/get'`:
-    If no prefix is given, only blobs are decoded to strings before returning. All other values are returned as-is, whether they are strings or not.
-    If `blob:` is passed in but the DB backend returns a string, an error is thrown. The alternative would be to encode the string to a buffer.
-    The `any:` prefix is used in `GET file/` to pass data from the DB backend to `h.response()` without transforming the data ourselves. I didn't want to decode buffers here since Hapi or the OS would likely encode them back anyway when sending, and `blob:` would throw with strings.

#### Other changes:
- The internal `readData() `and `writeData() `don't take any encoding or key prefix in their arguments. They're just the lowest-level DB access layer we have, and may behave differently for different backends (unlike the 'chelonia/db/' functions, which _must_ be consistent). An alternative would be to allow an `encoding` parameter which would be used when the raw data is a buffer, but ignored otherwise.
- Key validation with `checkKey()` has been moved from the internal backend functions into `'chelonia/db/set'`, to make sure the same constraints are applied whatever the DB backend.
 Note that `'chelonia/db/get'` and `'-delete'` don't use prefixable keys, so they don't need this check. Although in the `fs` backend an additonnal check is done in `readData()` against path traversal attacks. Other backends do not need it. 