### PR TITLE
#1560 'CLOSE_EMOTICON' event is emitted on screen resize even when the emoticon pop-up is not active

### DIFF
--- a/frontend/views/containers/chatroom/Emoticons.vue
+++ b/frontend/views/containers/chatroom/Emoticons.vue
@@ -89,8 +89,15 @@ export default ({
       }
     },
     closeEmoticonDlg () {
+      if (!this.isActive) { return }
+
       this.isActive = false
       sbp('okTurtles.events/emit', CLOSE_EMOTICON)
+
+      if (this.lastFocus) {
+        this.lastFocus.focus()
+        this.lastFocus = null
+      }
     }
   }
 }: Object)


### PR DESCRIPTION
closes #1560 

fixes below issue in the Chat page.

https://user-images.githubusercontent.com/17641213/235024921-61c1f81f-081d-4fd8-b1e9-9e44e7927391.mp4

