### PR TITLE
Use API_PORT and --port option instead of PORT_SHIFT

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,27 +31,6 @@ const packageJSON = require('./package.json')
 // See https://esbuild.github.io/api/#define
 // =======================
 
-/**
- * Creates a modified copy of the given `process.env` object, according to its `PORT_SHIFT` variable.
- *
- * The `API_PORT` and `API_URL` variables will be updated.
- * TODO: make the protocol (http vs https) variable based on environment var.
- * @param {Object} env
- * @returns {Object}
- */
-const applyPortShift = (env) => {
-  // TODO: implement automatic port selection when `PORT_SHIFT` is 'auto'.
-  const API_PORT = 8000 + Number.parseInt(env.PORT_SHIFT || '0')
-  const API_URL = 'http://127.0.0.1:' + API_PORT
-
-  if (Number.isNaN(API_PORT) || API_PORT < 8000 || API_PORT > 65535) {
-    throw new RangeError(`Invalid API_PORT value: ${API_PORT}.`)
-  }
-  return { ...env, API_PORT, API_URL }
-}
-
-Object.assign(process.env, applyPortShift(process.env))
-
 process.env.GI_VERSION = `${packageJSON.version}@${new Date().toISOString()}`
 
 // Not loading babel-register here since it is quite a heavy import and is not always used.
@@ -65,6 +44,10 @@ const {
   NODE_ENV = 'development',
   EXPOSE_SBP = ''
 } = process.env
+
+if (!['development', 'production'].includes(NODE_ENV)) {
+  throw new TypeError(`Invalid NODE_ENV value: ${NODE_ENV}.`)
+}
 
 const backendIndex = './backend/index.js'
 const distAssets = 'dist/assets'
@@ -83,6 +66,17 @@ const production = !development
 
 module.exports = (grunt) => {
   require('load-grunt-tasks')(grunt)
+
+  // Ensure API_PORT and API_URL envars are defined and available to subprocesses.
+  ;(function defineApiEnvars () {
+    const API_PORT = Number.parseInt(grunt.option('port') ?? process.env.API_PORT ?? '8000', 10)
+
+    if (Number.isNaN(API_PORT) || API_PORT < 8000 || API_PORT > 65535) {
+      throw new RangeError(`Invalid API_PORT value: ${API_PORT}.`)
+    }
+    process.env.API_PORT = String(API_PORT)
+    process.env.API_URL = 'http://127.0.0.1:' + API_PORT
+  })()
 
   // Helper functions
 
@@ -452,7 +446,8 @@ module.exports = (grunt) => {
       }
     }[command]
     grunt.log.writeln(`cypress: running in "${command}" mode...`)
-    cypress[command](options).then(r => done(r.totalFailed === 0)).catch(done)
+    cypress[command]({ config: { baseUrl: process.env.API_URL }, ...options })
+      .then(r => done(r.totalFailed === 0)).catch(done)
   })
 
   grunt.registerTask('_pin', async function (version) {

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "baseUrl": "http://localhost:8000",
   "viewportWidth": 1201,
   "viewportHeight": 900,
   "defaultCommandTimeout": 10000,

--- a/frontend/views/pages/DesignSystem.vue
+++ b/frontend/views/pages/DesignSystem.vue
@@ -1306,7 +1306,7 @@ page(
             pre
               | link-to-copy.c-link(link='string')
           td
-            link-to-copy.c-link(link='http://localhost:3000/app/join?groupId=21XWnNJvq9&secret=3763')
+            link-to-copy.c-link(link='/app/join?groupId=21XWnNJvq9&secret=3763')
 
       br
       h3.is-title-3 Copyable input

--- a/test/cypress/integration/group-paying.spec.js
+++ b/test/cypress/integration/group-paying.spec.js
@@ -5,6 +5,7 @@ export function humanDate (datems, opts = { month: 'short', day: 'numeric' }) {
   return new Date(datems).toLocaleDateString(locale, opts)
 }
 
+const API_URL = Cypress.config('baseUrl')
 const userId = Math.floor(Math.random() * 10000)
 const groupName = 'Dreamers'
 const mincome = 1000
@@ -24,7 +25,7 @@ function setIncomeDetails (doesPledge, incomeAmount) {
 
   cy.getByDT('submitIncome').click()
   cy.getByDT('closeModal').should('not.exist')
-  cy.url().should('eq', 'http://localhost:8000/app/contributions')
+  cy.url().should('eq', `${API_URL}/app/contributions`)
 }
 
 function assertNavTabs (tabs) {

--- a/test/cypress/integration/group-proposals.spec.js
+++ b/test/cypress/integration/group-proposals.spec.js
@@ -1,5 +1,6 @@
 import { INVITE_EXPIRES_IN_DAYS } from '../../../frontend/model/contracts/shared/constants.js'
 
+const API_URL = Cypress.config('baseUrl')
 const userId = Math.floor(Math.random() * 10000)
 const groupName = 'Dreamers'
 const groupMincome = 250
@@ -221,12 +222,12 @@ describe('Proposals - Add members', () => {
         cy.getByDT('title', 'p').should('contain', 'You proposed')
         cy.getByDT('sendLink').should('contain', `Please send the following link to ${username}-${userId} so they can join the group:`)
         cy.getByDT('sendLink').within(() => {
-          cy.getByDT('invitationLink').get('.link').should('contain', 'http://localhost')
+          cy.getByDT('invitationLink').get('.link').should('contain', API_URL)
           cy.getByDT('invitationLink').get('.c-invisible-input')
             .invoke('prop', 'value')
             .then(inviteLink => {
               invitationLinks[username] = inviteLink
-              expect(inviteLink).to.contain('http://localhost')
+              expect(inviteLink).to.contain(API_URL)
             })
         })
       })
@@ -350,18 +351,18 @@ describe('Proposals - Add members', () => {
       .should('contain', 'Oh no! This invite is not valid')
     cy.getByDT('helperText').should('contain', 'You should ask for a new one. Sorry about that!')
     cy.get('button').click()
-    cy.url().should('eq', 'http://localhost:8000/app/')
+    cy.url().should('eq', `${API_URL}/app/`)
     cy.getByDT('welcomeHome').should('contain', 'Welcome to Group Income')
   })
 
   it('an invalid invitation link cannot be used', () => {
-    cy.visit('http://localhost:8000/app/join?groupId=321&secret=123')
+    cy.visit('/app/join?groupId=321&secret=123')
     cy.getByDT('pageTitle')
       .invoke('text')
       .should('contain', 'Oh no! This invite is not valid')
     cy.getByDT('helperText').should('contain', 'Something went wrong. Please, try again. 404: Not Found')
     cy.get('button').click()
-    cy.url().should('eq', 'http://localhost:8000/app/')
+    cy.url().should('eq', `${API_URL}/app/`)
     cy.getByDT('welcomeHome').should('contain', 'Welcome to Group Income')
   })
 

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -9,6 +9,8 @@ import 'cypress-file-upload'
 import { CHATROOM_GENERAL_NAME } from '../../../frontend/model/contracts/shared/constants.js'
 import { EVENT_HANDLED } from '../../../shared/domains/chelonia/events.js'
 
+const API_URL = Cypress.config('baseUrl')
+
 // util funcs
 const randomFromArray = arr => arr[Math.floor(Math.random() * arr.length)] // importing giLodash.js fails for some reason.
 
@@ -99,7 +101,7 @@ Cypress.Commands.add('giLogout', ({ hasNoGroup = false } = {}) => {
     cy.getByDT('link-logout').click()
     cy.getByDT('closeModal').should('not.exist')
   }
-  cy.url().should('eq', 'http://localhost:8000/app/')
+  cy.url().should('eq', `${API_URL}/app/`)
   cy.getByDT('welcomeHome').should('contain', 'Welcome to Group Income')
 })
 
@@ -143,7 +145,7 @@ Cypress.Commands.add('giCreateGroup', (name, {
       })
       await sbp('controller/router').push({ path: '/dashboard' }).catch(e => {})
     })
-    cy.url().should('eq', 'http://localhost:8000/app/dashboard')
+    cy.url().should('eq', `${API_URL}/app/dashboard`)
     cy.getByDT('groupName').should('contain', name)
     cy.getByDT('app').then(([el]) => {
       cy.get(el).should('have.attr', 'data-sync', '')
@@ -203,7 +205,7 @@ Cypress.Commands.add('giCreateGroup', (name, {
     cy.getByDT('welcomeGroup').should('contain', `Welcome to ${name}!`)
     cy.getByDT('toDashboardBtn').click()
   })
-  cy.url().should('eq', 'http://localhost:8000/app/dashboard')
+  cy.url().should('eq', `${API_URL}/app/dashboard`)
   cy.getByDT('app').then(([el]) => {
     cy.get(el).should('have.attr', 'data-sync', '')
   })
@@ -220,9 +222,9 @@ function inviteUser (invitee, index) {
 Cypress.Commands.add('giGetInvitationAnyone', () => {
   cy.getByDT('inviteButton').click()
   cy.getByDT('invitationLink').invoke('text').then(text => {
-    const urlAt = text.indexOf('http://')
-    const url = text.substr(urlAt)
-    assert.isOk(url, 'invitation link is found')
+    const urlIndex = text.includes('https://') ? text.indexOf('https://') : text.indexOf('http://')
+    assert.isOk(urlIndex >= 0, 'invitation link is found')
+    const url = text.slice(urlIndex)
     cy.closeModal()
     return cy.wrap(url)
   })
@@ -287,7 +289,7 @@ Cypress.Commands.add('giAcceptGroupInvite', (invitationLink, {
     }
 
     cy.getByDT('toDashboardBtn').click()
-    cy.url().should('eq', 'http://localhost:8000/app/dashboard')
+    cy.url().should('eq', `${API_URL}/app/dashboard`)
     cy.getByDT('app').then(([el]) => {
       if (!isLoggedIn) {
         cy.get(el).should('have.attr', 'data-logged-in', 'yes')


### PR DESCRIPTION
Closes #1642

### Summary of changes:
- New `API_PORT` envar, allowing to specify the default backend port. If not defined, then port 8000 will be the default.
- New `--port` Grunt option, to be used in Grunt commands. Useful e.g. when running two or more server instances.
 Example: `grunt --port=8004` will try to launch a dev instance on port 8004, whereas the usual `grunt` command will rely on the `API_PORT` envar, or 8000 if not defined.
- Cypress tests have been updated to no longer refer to a hard-coded `http://localhost:8000 URL`.
  This allows to run them against a backend running on another port.
