### PR TITLE
Fix issue 1629

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,8 +52,6 @@ const applyPortShift = (env) => {
 
 Object.assign(process.env, applyPortShift(process.env))
 
-process.env.GI_VERSION = `${packageJSON.version}@${new Date().toISOString()}`
-
 // Not loading babel-register here since it is quite a heavy import and is not always used.
 // We will rather load it later, and only if necessary.
 // require('@babel/register')
@@ -61,10 +59,18 @@ process.env.GI_VERSION = `${packageJSON.version}@${new Date().toISOString()}`
 const {
   CI = '',
   LIGHTWEIGHT_CLIENT = 'true',
-  GI_VERSION,
   NODE_ENV = 'development',
   EXPOSE_SBP = ''
 } = process.env
+
+const CONTRACTS_VERSION = packageJSON.contractsVersion
+// In production, append a timestamp so that browsers will detect a new version
+// and reload whenever the live server is restarted.
+// TODO: get rid of this timestamp and just bump the package version when necessary.
+const GI_VERSION = packageJSON.version + (NODE_ENV === 'production' ? `@${new Date().toISOString()}` : '')
+
+// Make version info available to subprocesses.
+Object.assign(process.env, { CONTRACTS_VERSION, GI_VERSION })
 
 const backendIndex = './backend/index.js'
 const distAssets = 'dist/assets'
@@ -193,6 +199,7 @@ module.exports = (grunt) => {
       define: {
         'process.env.BUILD': "'web'", // Required by Vuelidate.
         'process.env.CI': `'${CI}'`,
+        'process.env.CONTRACTS_VERSION': `'${CONTRACTS_VERSION}'`,
         'process.env.GI_VERSION': `'${GI_VERSION}'`,
         'process.env.LIGHTWEIGHT_CLIENT': `'${LIGHTWEIGHT_CLIENT}'`,
         'process.env.NODE_ENV': `'${NODE_ENV}'`,

--- a/backend/pubsub.js
+++ b/backend/pubsub.js
@@ -107,7 +107,7 @@ export function createServer (httpServer: Object, options?: Object = {}): Object
   // Setup a ping interval if required.
   if (server.options.pingInterval > 0) {
     server.pingIntervalID = setInterval(() => {
-      if (server.clients.length && server.options.logPingRounds) {
+      if (server.clients.size && server.options.logPingRounds) {
         log.debug('Pinging clients')
       }
       server.clients.forEach((client) => {
@@ -128,7 +128,7 @@ export function createServer (httpServer: Object, options?: Object = {}): Object
 }
 
 const defaultOptions = {
-  logPingRounds: process.env.NODE_ENV === 'development' && !process.env.CI,
+  logPingRounds: process.env.NODE_ENV !== 'production' && !process.env.CI,
   logPongMessages: false,
   maxPayload: 6 * 1024 * 1024,
   pingInterval: 30000

--- a/backend/server.js
+++ b/backend/server.js
@@ -12,6 +12,8 @@ import chalk from 'chalk'
 
 const Inert = require('@hapi/inert')
 
+const { CONTRACTS_VERSION, GI_VERSION } = process.env
+
 // NOTE: migration guides for Hapi v16 -> v17:
 //       https://github.com/hapijs/hapi/issues/3658
 //       https://medium.com/yld-engineering-blog/so-youre-thinking-about-updating-your-hapi-js-server-to-v17-b5732ab5bdb8
@@ -86,9 +88,8 @@ if (process.env.NODE_ENV === 'development' && !process.env.CI) {
 sbp('okTurtles.data/set', PUBSUB_INSTANCE, createServer(hapi.listener, {
   serverHandlers: {
     connection (socket: Object, request: Object) {
-      if (process.env.NODE_ENV === 'production') {
-        socket.send(createNotification(NOTIFICATION_TYPE.APP_VERSION, process.env.GI_VERSION))
-      }
+      const versioInfo = { GI_VERSION, CONTRACTS_VERSION }
+      socket.send(createNotification(NOTIFICATION_TYPE.VERSION_INFO, versioInfo))
     }
   }
 }))

--- a/backend/server.js
+++ b/backend/server.js
@@ -88,8 +88,8 @@ if (process.env.NODE_ENV === 'development' && !process.env.CI) {
 sbp('okTurtles.data/set', PUBSUB_INSTANCE, createServer(hapi.listener, {
   serverHandlers: {
     connection (socket: Object, request: Object) {
-      const versioInfo = { GI_VERSION, CONTRACTS_VERSION }
-      socket.send(createNotification(NOTIFICATION_TYPE.VERSION_INFO, versioInfo))
+      const versionInfo = { GI_VERSION, CONTRACTS_VERSION }
+      socket.send(createNotification(NOTIFICATION_TYPE.VERSION_INFO, versionInfo))
     }
   }
 }))

--- a/frontend/controller/backend.js
+++ b/frontend/controller/backend.js
@@ -13,7 +13,7 @@ const languageFileMap = new Map([
   ['fr', 'french.json']
 ])
 
-sbp('okTurtles.events/on', NOTIFICATION_TYPE.UPDATE_AVAILABLE, (versionInfo) => {
+sbp('okTurtles.events/on', NOTIFICATION_TYPE.VERSION_INFO, (versionInfo) => {
   console.info('New Group Income version available:', versionInfo)
   // Prevent the client from trying to reconnect when the page starts unloading.
   sbp('okTurtles.data/get', PUBSUB_INSTANCE).destroy()

--- a/frontend/controller/backend.js
+++ b/frontend/controller/backend.js
@@ -13,8 +13,8 @@ const languageFileMap = new Map([
   ['fr', 'french.json']
 ])
 
-sbp('okTurtles.events/on', NOTIFICATION_TYPE.APP_VERSION, (version) => {
-  console.info('New Group Income version available:', version)
+sbp('okTurtles.events/on', NOTIFICATION_TYPE.UPDATE_AVAILABLE, (versionInfo) => {
+  console.info('New Group Income version available:', versionInfo)
   // Prevent the client from trying to reconnect when the page starts unloading.
   sbp('okTurtles.data/get', PUBSUB_INSTANCE).destroy()
   // TODO: allow the user to manually reload the page later.
@@ -25,8 +25,7 @@ sbp('sbp/selectors/register', {
   /**
    * Fetches a JSON object containing translation strings for a given language.
    *
-   * @param language - A BPC-47 language tag like the value
-   * of `navigator.language`.
+   * @param language - A BPC-47 language tag like the value of `navigator.language`.
    *
    * @see The 'translations/init' SBP selector in `~view-utils/translations.js`.
    */

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -42,6 +42,7 @@ import notificationsMixin from './model/notifications/mainNotificationsMixin.js'
 const { Vue, L } = Common
 
 console.info('GI_VERSION:', process.env.GI_VERSION)
+console.info('CONTRACTS_VERSION:', process.env.CONTRACTS_VERSION)
 console.info('NODE_ENV:', process.env.NODE_ENV)
 
 Vue.config.errorHandler = function (err, vm, info) {

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -148,12 +148,14 @@ export default (sbp('sbp/selectors/register', {
           // Calling via SBP also makes it simple to implement 'test/backend.js'
           sbp('chelonia/private/in/enqueueHandleEvent', GIMessage.deserialize(msg.data))
         },
-        [NOTIFICATION_TYPE.APP_VERSION] (msg) {
+        [NOTIFICATION_TYPE.VERSION_INFO] (msg) {
           const ourVersion = process.env.GI_VERSION
-          const theirVersion = msg.data
+          const theirVersion = msg.data.GI_VERSION
 
-          if (ourVersion !== theirVersion) {
-            sbp('okTurtles.events/emit', NOTIFICATION_TYPE.APP_VERSION, theirVersion)
+          const ourContractsVersion = process.env.CONTRACTS_VERSION
+          const theirContractsVersion = msg.data.CONTRACTS_VERSION
+          if (ourVersion !== theirVersion || ourContractsVersion !== theirContractsVersion) {
+            sbp('okTurtles.events/emit', NOTIFICATION_TYPE.UPDATE_AVAILABLE, { ...msg.data })
           }
         }
       }

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -155,7 +155,7 @@ export default (sbp('sbp/selectors/register', {
           const ourContractsVersion = process.env.CONTRACTS_VERSION
           const theirContractsVersion = msg.data.CONTRACTS_VERSION
           if (ourVersion !== theirVersion || ourContractsVersion !== theirContractsVersion) {
-            sbp('okTurtles.events/emit', NOTIFICATION_TYPE.UPDATE_AVAILABLE, { ...msg.data })
+            sbp('okTurtles.events/emit', NOTIFICATION_TYPE.VERSION_INFO, { ...msg.data })
           }
         }
       }

--- a/shared/pubsub.js
+++ b/shared/pubsub.js
@@ -75,12 +75,12 @@ export type UnsubMessage = {
 
 export const NOTIFICATION_TYPE = Object.freeze({
   ENTRY: 'entry',
-  APP_VERSION: 'app_version',
   PING: 'ping',
   PONG: 'pong',
   PUB: 'pub',
   SUB: 'sub',
-  UNSUB: 'unsub'
+  UNSUB: 'unsub',
+  VERSION_INFO: 'version_info'
 })
 
 export const REQUEST_TYPE = Object.freeze({


### PR DESCRIPTION
Closes #1629

### Summary of changes:
- New `process.env.CONTRACTS_VERSION`  field available, taken from `package.json`'s `contractsVersion`.
- The server will now send both its current `GI_VERSION` and `CONTRACTS_VERSION` to the client on every (re)connection, including in development mode, allowing it to reload if necessary (fix issue #1629).
- Fixed a bug causing the server to not log ping rounds despite the option being enabled.
- 
