### PR TITLE
#1005 DRY GroupPledgesGraph.vue

### DIFF
--- a/frontend/views/containers/contributions/GroupPledgesGraph.vue
+++ b/frontend/views/containers/contributions/GroupPledgesGraph.vue
@@ -85,10 +85,10 @@ export default ({
       const ourIncomeAmount = doWeNeedIncome && this.amount < mincome && this.amount
       const haveNeeds = this.haveNeedsForThisPeriod(this.currentPaymentPeriod)
         .filter(entry => entry.name !== this.ourUsername)
-      let othersIncomeNeeded = haveNeeds.reduce(
+      const othersIncomeNeeded = haveNeeds.reduce(
         (accu, entry) => entry.haveNeed < 0 ? accu + (-1 * entry.haveNeed) : accu, 0
       )
-      let othersPledgesAmount = haveNeeds.reduce(
+      const othersPledgesAmount = haveNeeds.reduce(
         (accu, entry) => entry.haveNeed > 0 ? accu + entry.haveNeed : accu, 0
       )
 


### PR DESCRIPTION
closes #1005 

[ Details ]
- Found out that the group's `haveNeeds` calculation is executed manually there by going through each member's profile, so replaced it with the existing getter `haveNeedsForThisPeriod`
- the `haveNeed` entry for the currently active user must be computed dynamically in that Vue component, so unfortunately the rest of the logic there cannot be replaced. (e.g. using the `groupIncomeDistribution` getter in `state.js`), but did replace the part where it uses `mincomeProportional` function from `mincome-proportional.js` directly with `unadjustedDistribution` wrapper function in case it (`unadjustedDistribution`) will be extended or updated in the future.

Hope it sounds good.
