### PR TITLE
#1686 - Fix a few bugs in  payment-detail modal

### DIFF
--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -366,7 +366,7 @@ const getters = {
         for (const toUser in paymentsFrom[ourUsername]) {
           for (const paymentHash of paymentsFrom[ourUsername][toUser]) {
             const { data, meta } = allPayments[paymentHash]
-            payments.push({ hash: paymentHash, data, meta, amount: data.amount })
+            payments.push({ hash: paymentHash, data, meta, amount: data.amount, period })
           }
         }
       }

--- a/frontend/views/containers/payments/PaymentDetail.vue
+++ b/frontend/views/containers/payments/PaymentDetail.vue
@@ -27,14 +27,17 @@ modal-template(ref='modal' v-if='payment' :a11yTitle='L("Payment details")')
       i18n.has-text-1 Notes
       p.has-text-bold {{ payment.data.memo }}
 
-  .buttons.c-buttons-container(v-if='!lightningPayment')
+  .buttons.c-buttons-container(
+    v-if='!lightningPayment'
+    :class='{ "is-centered": isPaidByMyself }'
+  )
     i18n.button.is-outlined(
       tag='button'
       @click='cancelPayment'
     ) Cancel payment
 
     i18n.button(
-      v-if='fromUser !== ourUsername'
+      v-if='!isPaidByMyself'
       tag='button'
       @click='sendThankYou'
     ) Send Thanks!
@@ -84,6 +87,9 @@ export default ({
     },
     fromUser () {
       return this.payment?.meta.username || ''
+    },
+    isPaidByMyself () {
+      return this.fromUser === this.ourUsername
     },
     subtitleCopy () {
       const toUser = this.payment.data.toUser
@@ -180,6 +186,10 @@ export default ({
   max-width: 25rem;
   margin: 1.625rem auto 0;
   width: 100%;
+
+  &.is-centered {
+    justify-content: center;
+  }
 
   .button:not(:last-child) {
     margin-right: 0;

--- a/frontend/views/containers/payments/PaymentDetail.vue
+++ b/frontend/views/containers/payments/PaymentDetail.vue
@@ -34,6 +34,7 @@ modal-template(ref='modal' v-if='payment' :a11yTitle='L("Payment details")')
     ) Cancel payment
 
     i18n.button(
+      v-if='fromUser !== ourUsername'
       tag='button'
       @click='sendThankYou'
     ) Send Thanks!
@@ -81,11 +82,13 @@ export default ({
     withCurrency () {
       return currencies[this.payment.data.currencyFromTo[1]].displayWithCurrency
     },
+    fromUser () {
+      return this.payment?.meta.username || ''
+    },
     subtitleCopy () {
       const toUser = this.payment.data.toUser
-      const fromUser = this.payment.meta.username
       const arg = (username) => ({ name: this.userDisplayName(username) })
-      return toUser === this.ourUsername ? L('Sent by {name}', arg(fromUser)) : L('Sent to {name}', arg(toUser))
+      return toUser === this.ourUsername ? L('Sent by {name}', arg(this.fromUser)) : L('Sent to {name}', arg(toUser))
     }
   },
   methods: {

--- a/frontend/views/containers/payments/PaymentRowSent.vue
+++ b/frontend/views/containers/payments/PaymentRowSent.vue
@@ -34,6 +34,7 @@
           i18n Payment details
 
         menu-item(
+          v-if='!isOldPayment'
           tag='button'
           item-id='message'
           icon='times'
@@ -49,7 +50,7 @@ import AvatarUser from '@components/AvatarUser.vue'
 import { OPEN_MODAL } from '@utils/events.js'
 import { MenuItem } from '@components/menu/index.js'
 import { PAYMENT_CANCELLED, PAYMENT_NOT_RECEIVED } from '@model/contracts/shared/payments/index.js'
-import { humanDate } from '@model/contracts/shared/time.js'
+import { humanDate, comparePeriodStamps } from '@model/contracts/shared/time.js'
 import PaymentRow from './payment-row/PaymentRow.vue'
 import PaymentActionsMenu from './payment-row/PaymentActionsMenu.vue'
 import PaymentNotReceivedTooltip from './payment-row/PaymentNotReceivedTooltip.vue'
@@ -73,10 +74,15 @@ export default ({
     ...mapGetters([
       'ourGroupProfile',
       'withGroupCurrency',
-      'periodStampGivenDate'
+      'periodStampGivenDate',
+      'currentPaymentPeriod'
     ]),
     notReceived () {
       return this.payment.data.status === PAYMENT_NOT_RECEIVED
+    },
+    isOldPayment () {
+      // check if it's a past transaction item.
+      return comparePeriodStamps(this.payment.period, this.currentPaymentPeriod) < 0
     }
   },
   methods: {

--- a/frontend/views/containers/payments/PaymentsMixin.js
+++ b/frontend/views/containers/payments/PaymentsMixin.js
@@ -41,7 +41,7 @@ const PaymentsMixin: Object = {
               for (const hash of paymentsFrom[fromUser][toUser]) {
                 if (hash in payments) {
                   const { data, meta } = payments[hash]
-                  paymentsInTypes[receivedOrSent].push({ hash, data, meta, amount: data.amount, username: toUser })
+                  paymentsInTypes[receivedOrSent].push({ hash, data, meta, amount: data.amount, username: toUser, period })
                 } else {
                   console.error(`getHistoricalPaymentsInTypes: couldn't find payment ${hash} for period ${period}!`)
                 }
@@ -89,6 +89,8 @@ const PaymentsMixin: Object = {
     async getHistoricalPaymentByHashAndPeriod (hash: string, period: string) {
       const paymentsKey = `payments/${this.ourUsername}/${period}/${this.currentGroupId}`
       const payments = await sbp('gi.db/archive/load', paymentsKey) || {}
+
+      console.log(`@@ payments for the period [${period}]: `, payments)
       return payments[hash]
     },
     async getHaveNeedsSnapshotByPeriod (period: string) {

--- a/frontend/views/containers/payments/PaymentsMixin.js
+++ b/frontend/views/containers/payments/PaymentsMixin.js
@@ -90,7 +90,6 @@ const PaymentsMixin: Object = {
       const paymentsKey = `payments/${this.ourUsername}/${period}/${this.currentGroupId}`
       const payments = await sbp('gi.db/archive/load', paymentsKey) || {}
 
-      console.log(`@@ payments for the period [${period}]: `, payments)
       return payments[hash]
     },
     async getHaveNeedsSnapshotByPeriod (period: string) {

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -226,8 +226,15 @@ export default ({
         if (section && this.tabSections.includes(section)) {
           this.ephemeral.activeTab = section
         } else {
+          const fromQuery = from.query || {}
+          const isFromPaymentDetailModal = fromQuery.modal === 'PaymentDetail'
           const defaultTab = this.tabSections[0]
-          if (defaultTab) {
+
+          if (isFromPaymentDetailModal && fromQuery.section) {
+            // When payment detail modal is closed, the payment table has to remain in the previously active tab.
+            // (context: https://github.com/okTurtles/group-income/issues/1686)
+            this.handleTabClick(fromQuery.section)
+          } else if (defaultTab) {
             this.handleTabClick(defaultTab)
           } else if (section) {
             const query = omit(this.$route.query, ['section'])
@@ -290,16 +297,17 @@ export default ({
       return items
     },
     tableTitles () {
-      const firstTab = this.needsIncome ? L('Sent by') : L('Sent to')
-      return this.ephemeral.activeTab === 'PaymentRowTodo'
+      const { activeTab } = this.ephemeral
+
+      return activeTab === 'PaymentRowTodo'
         ? {
-            one: firstTab,
+            one: L('Sent to'),
             two: L('Amount'),
             three: L('Accepted methods'),
             four: L('Due on')
           }
         : {
-            one: firstTab,
+            one: activeTab === 'PaymentRowSent' ? L('Sent to') : L('Sent by'),
             two: L('Amount'),
             three: L('Payment method'),
             four: L('Payment date')

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -226,15 +226,15 @@ export default ({
         if (section && this.tabSections.includes(section)) {
           this.ephemeral.activeTab = section
         } else {
-          const fromQuery = from.query || {}
+          const fromQuery = from?.query || {}
           const isFromPaymentDetailModal = fromQuery.modal === 'PaymentDetail'
-          const defaultTab = this.tabSections[0]
-
-          if (isFromPaymentDetailModal && fromQuery.section) {
+          const defaultTab = isFromPaymentDetailModal
             // When payment detail modal is closed, the payment table has to remain in the previously active tab.
             // (context: https://github.com/okTurtles/group-income/issues/1686)
-            this.handleTabClick(fromQuery.section)
-          } else if (defaultTab) {
+            ? fromQuery.section || this.tabSections[0]
+            : this.tabSections[0]
+
+          if (defaultTab) {
             this.handleTabClick(defaultTab)
           } else if (section) {
             const query = omit(this.$route.query, ['section'])


### PR DESCRIPTION
closes #1686 

This PR contains bug-fixes for below items:

1. The payment table in `Completed` tab displays `Sent by` as a label when it's supposed to say `Sent to`
2. Upon closure of `PaymentDetail.vue` modal, the active tab gets always reset to the first tab, instead of remaining in the previously active tab.
3. In the `PaymentDetail` modal, `Send thank you` button is enabled even when I was the sender of the transaction.
4. In the first payment row, in the three-dots menu, clickling on Payment details doesn't reveal any information.
