### PR TITLE
Set us up with Github CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: NodeJS with Grunt
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 18
+        cache: 'npm'
+    - run: npm ci
+    - run: npm test


### PR DESCRIPTION
Closes #974

### Summary of changes:
- New `ci.yml` file in the `.gitbub/workflows/` directory.

### Additional information:
- Tested on my fork:

![image](https://github.com/okTurtles/group-income/assets/64228468/c0bd3900-037f-471c-a95e-7557a222e92c)

- Details:

![image](https://github.com/okTurtles/group-income/assets/64228468/f334920e-1473-4ec4-97e3-3b792cd29c98)

- Build logs:
[logs_46.zip](https://github.com/okTurtles/group-income/files/12656984/logs_46.zip)

- Not sure whether caching actually works and doesn't prevent things to work e.g. when doing a Cypress version upgrade