### PR TITLE
[e2e-protocol] Fix the welcome screen bug in /pending-approval page

### DIFF
--- a/frontend/views/pages/PendingApproval.vue
+++ b/frontend/views/pages/PendingApproval.vue
@@ -94,7 +94,7 @@ export default ({
   font-size: $size_4;
 }
 
-::v-deep .c-welcome {
+::v-deep .c-welcome.wrapper {
   position: fixed;
   top: 0;
   left: 0;

--- a/frontend/views/pages/PendingApproval.vue
+++ b/frontend/views/pages/PendingApproval.vue
@@ -93,4 +93,15 @@ export default ({
 .c-text {
   font-size: $size_4;
 }
+
+::v-deep .c-welcome {
+  position: fixed;
+  top: 0;
+  left: 0;
+  min-width: 100vw;
+  width: 100vw;
+  height: 100%;
+  background-color: $background_0;
+  z-index: $zindex-sidebar + 1;
+}
 </style>


### PR DESCRIPTION
closes #1738 

@taoeffect 
I just figured out the issue only happens when the welcome screen(`GroupWelcome.vue`) is shown as part of `/pending-approval` page which is where the navigation menu still needs to be displayed if joinning the group is in pending-state for the reasons you listed in [this comment](https://github.com/okTurtles/group-income/issues/1738#issuecomment-1732381382).

So I made a fix where `GroupWelcome.vue` simply covers the whole page when rendered in `/pending-approval` page. This way, if there was a problem and user's joining a group didn't succeed, the user can access the menu for the actions you listed in the issue.