### PR TITLE
#1756 User marked as 'needing' even if their income is above the group's mincome

### DIFF
--- a/frontend/views/containers/proposals/ProposalTemplate.vue
+++ b/frontend/views/containers/proposals/ProposalTemplate.vue
@@ -199,7 +199,7 @@ export default ({
   },
   methods: {
     close () {
-      this.$refs.modal.close()
+      this.$refs.modal.unload()
     },
     next () {
       // TODO/BUG - we must clear formMsg (if visible) when changing steps.


### PR DESCRIPTION
closes #1756 

This is a fix for [this symptom](https://github.com/okTurtles/group-income/issues/1756#issuecomment-1752270090) in  `master` branch.