### PR TITLE
#1761 - [Bug] Dismissing a payment and resending it doesn't clear it as being sent

### DIFF
--- a/frontend/views/containers/payments/RecordPayment.vue
+++ b/frontend/views/containers/payments/RecordPayment.vue
@@ -136,11 +136,11 @@ export default ({
               hash: item.hash,
               data: item.data,
               meta: item.meta,
-              username: item.toUser,
-              displayName: this.userDisplayName(item.toUser),
+              username: item.data.toUser,
+              displayName: this.userDisplayName(item.data.toUser),
               date: item.meta.createdDate,
-              monthstamp: dateToMonthstamp(item.createdDate),
-              amount: item.amount
+              monthstamp: dateToMonthstamp(item.meta.createdDate),
+              amount: item.data.amount
             }
           : item
       })
@@ -172,6 +172,7 @@ export default ({
 
       for (const pRecord of paymentsToRecord) {
         const payment = this.paymentsList[pRecord.index]
+        const isStatusNotReceived = payment.data && payment.data.status === PAYMENT_NOT_RECEIVED
 
         if (pRecord.amount > payment.amount) {
           // TODO/REVIEW - Should we show a warning?
@@ -199,20 +200,36 @@ export default ({
             paymentType: PAYMENT_TYPE_MANUAL,
             ...(memo ? { memo } : {}) // TODO/BUG with flowTyper validation. Empty string '' fails.
           }
-          const msg = await sbp('gi.actions/group/payment', {
-            contractID: this.currentGroupId, data: paymentInfo
-          })
-          // TODO: hack until /payment supports sending completed payment
-          //       (and "uncompleting" a payment)
-          await sbp('gi.actions/group/paymentUpdate', {
-            contractID: this.currentGroupId,
-            data: {
-              paymentHash: msg.hash(),
-              updatedProperties: {
-                status: PAYMENT_COMPLETED
+
+          if (isStatusNotReceived) {
+            // If it's re-sending the payment that has been marked as 'not-recieved' by the receiver,
+            // only update the details of the existing payment item so that it doesn't lead to duplication bug in the payment UI.
+            await sbp('gi.actions/group/paymentUpdate', {
+              contractID: this.currentGroupId,
+              data: {
+                paymentHash: payment.hash,
+                updatedProperties: {
+                  ...paymentInfo,
+                  status: PAYMENT_COMPLETED
+                }
               }
-            }
-          })
+            })
+          } else {
+            const msg = await sbp('gi.actions/group/payment', {
+              contractID: this.currentGroupId, data: paymentInfo
+            })
+            // TODO: hack until /payment supports sending completed payment
+            //       (and "uncompleting" a payment)
+            await sbp('gi.actions/group/paymentUpdate', {
+              contractID: this.currentGroupId,
+              data: {
+                paymentHash: msg.hash(),
+                updatedProperties: {
+                  status: PAYMENT_COMPLETED
+                }
+              }
+            })
+          }
         } catch (e) {
           hasError = true
           console.error('RecordPayment submit() error:', e)

--- a/frontend/views/containers/payments/RecordPayment.vue
+++ b/frontend/views/containers/payments/RecordPayment.vue
@@ -131,7 +131,7 @@ export default ({
     ]),
     paymentsList () {
       return this.todoItems.map(item => {
-        return item.status === PAYMENT_NOT_RECEIVED // if not received item, re-format the obj
+        return item.data && item.data.status === PAYMENT_NOT_RECEIVED // if not received item, re-format the obj
           ? {
               hash: item.hash,
               data: item.data,


### PR DESCRIPTION
closes #1761 

Currently `RecordPayment.vue` always creates new payment item regardless of whether it's an existing payment item with the status as `PAYMENT_NOT_RECEIVED` or a todo payment that hasn't been payed yet. Apparently this leads to duplicated payment items here and there in the UI. So I made a fix where the component checks if the payment item is `PAYMENT_NOT_RECEIVED` or not and then prevents it from creating a new payment item in group state if it is.
Hope it sounds good.