### PR TITLE
#1790 - Remove the extra space in "Add to channel" button

### DIFF
--- a/frontend/views/containers/chatroom/ChatMembersAllModal.vue
+++ b/frontend/views/containers/chatroom/ChatMembersAllModal.vue
@@ -441,11 +441,13 @@ export default ({
 
 ::v-deep .c-actions {
   span {
-    margin-left: 0.3rem;
-
     @include phone {
       display: none;
     }
+  }
+
+  i + span {
+    margin-left: 0.3rem;
   }
 
   .c-action-undo {

--- a/frontend/views/containers/dashboard/GroupMembersAllModal.vue
+++ b/frontend/views/containers/dashboard/GroupMembersAllModal.vue
@@ -311,11 +311,15 @@ export default ({
   }
 }
 
-::v-deep .c-actions span {
-  margin-left: 0.3rem;
+::v-deep .c-actions {
+  span {
+    @include phone {
+      display: none;
+    }
+  }
 
-  @include phone {
-    display: none;
+  i + span {
+    margin-left: 0.3rem;
   }
 }
 


### PR DESCRIPTION
closes #1790 

<img src='https://github.com/okTurtles/group-income/assets/17641213/4c420fe9-062d-4ba8-afd9-194f41e66899' width='320'>

From my investigation, it seems like the left-margin is only needed when the `span` wrapping a text is placed right next to an icon, such as for the case of `added` above and also for the case of `removed` (although no screenshot's attached for it).
So made a fix accordingly.

