### PR TITLE
Fix for a cypress failure related to push-subscription in Electron

### DIFF
--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -65,11 +65,11 @@ sbp('sbp/selectors/register', {
       ))
     } else {
       return new Promise((resolve) => {
-        try {
-          // Generate a new push subscription
-          sbp('okTurtles.events/once', REQUEST_TYPE.PUSH_ACTION, async ({ data }) => {
-            const PUBLIC_VAPID_KEY = data
+        // Generate a new push subscription
+        sbp('okTurtles.events/once', REQUEST_TYPE.PUSH_ACTION, async ({ data }) => {
+          const PUBLIC_VAPID_KEY = data
 
+          try {
             // 1. Add a new subscription to pushManager using it.
             const subscription = await registration.pushManager.subscribe({
               userVisibleOnly: true,
@@ -86,16 +86,16 @@ sbp('sbp/selectors/register', {
             ))
 
             resolve()
-          })
+          } catch (err) {
+            console.error('[sw] service-worker/setup-push-subscription failed with the following error: ', err)
+            resolve()
+          }
+        })
 
-          pubsub.socket.send(createMessage(
-            REQUEST_TYPE.PUSH_ACTION,
-            { action: PUSH_SERVER_ACTION_TYPE.SEND_PUBLIC_KEY }
-          ))
-        } catch (err) {
-          console.error('[sw] service-worker/setup-push-subscription failed with the following error: ', err)
-          resolve()
-        }
+        pubsub.socket.send(createMessage(
+          REQUEST_TYPE.PUSH_ACTION,
+          { action: PUSH_SERVER_ACTION_TYPE.SEND_PUBLIC_KEY }
+        ))
       })
     }
   },


### PR DESCRIPTION
Fix for below issue in Cypress when it's run with Electron89.

<img src='https://github.com/okTurtles/group-income/assets/17641213/c609e6b7-5aa3-42cf-86a3-f1e67b586089' width='380'>

Apparently the root cause is that below method is not supported in Electron (refer to [this article](https://medium.com/@MatthieuLemoine/my-journey-to-bring-web-push-support-to-node-and-electron-ce70eea1c0b0))
`pushManager.subscribe()`

I made a fix where the error is caught and silently logged out to the console instead of it becoming an uncaught Promise error.