### PR TITLE
#1793 Dark theme status bar color in the PWA 

### DIFF
--- a/frontend/assets/pwa-manifest.webmanifest
+++ b/frontend/assets/pwa-manifest.webmanifest
@@ -23,6 +23,5 @@
       "type": "image/svg+xml"
     }
   ],
-  "background_color": "#EDEDED",
-  "theme_color": "#EDEDED"
+  "background_color": "#EDEDED"
 }

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,6 +5,7 @@
     <title>Group Income</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
+    <meta id="theme-color" name="theme-color" content="#EDEDED">
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="manifest" href="/assets/pwa-manifest.webmanifest" />
     <link rel="icon" href="/assets/images/group-income-icon-transparent.png" sizes="32x32">

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,7 +5,7 @@
     <title>Group Income</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0">
-    <meta id="theme-color" name="theme-color" content="#EDEDED">
+    <meta name="theme-color" content="#F5F5F5">
     <link rel="stylesheet" href="/assets/css/main.css">
     <link rel="manifest" href="/assets/pwa-manifest.webmanifest" />
     <link rel="icon" href="/assets/images/group-income-icon-transparent.png" sizes="32x32">

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -13,7 +13,7 @@ import type { GIMessage } from '~/shared/domains/chelonia/chelonia.js'
 import '~/shared/domains/chelonia/chelonia.js'
 import { CONTRACT_IS_SYNCING } from '~/shared/domains/chelonia/events.js'
 import * as Common from '@common/common.js'
-import { LOGIN, LOGOUT, SWITCH_GROUP } from './utils/events.js'
+import { LOGIN, LOGOUT, SWITCH_GROUP, THEME_CHANGE } from './utils/events.js'
 import './controller/namespace.js'
 import './controller/actions/index.js'
 import './controller/backend.js'
@@ -331,6 +331,7 @@ async function startApp () {
         )
       }
 
+      sbp('okTurtles.events/emit', THEME_CHANGE, this.$store.state.settings.themeColor)
       this.setBadgeOnTab()
     },
     computed: {

--- a/frontend/utils/events.js
+++ b/frontend/utils/events.js
@@ -32,3 +32,5 @@ export const INCOME_DETAILS_UPDATE = 'income-details-update'
 export const PAYMENTS_RECORDED = 'payments-recorded'
 
 export const AVATAR_EDITED = 'avatar-edited'
+
+export const THEME_CHANGE = 'theme-change'


### PR DESCRIPTION
closes #1793 

<img src='https://github.com/okTurtles/group-income/assets/17641213/6b55ad7c-d2fd-4836-98f1-3b578bb8dd74' width='380'>

The `theme_color` field in the `manifest.json` file is responsible for colouring the status bar but the thing is, the value needs to be updated dynamically either according to the browser's system preference or the user's selection in the app.

So I chose to use `<meta name='theme-color' >` instead, so that we can dynamically update the value from inside the app.

(Mainly referenced [this article](https://css-tricks.com/meta-theme-color-and-trickery/) for the task.)