### PR TITLE
#1830 Fix the incorrect route redirection bug

### DIFF
--- a/frontend/views/pages/Home.vue
+++ b/frontend/views/pages/Home.vue
@@ -96,7 +96,20 @@ export default ({
       sbp('okTurtles.events/emit', OPEN_MODAL, mode)
     },
     navigateToGroupPage () {
-      this.$router.push({ path: this.ourGroupProfile ? '/dashboard' : '/pending-approval' }).catch(console.warn)
+      this.$router.push({
+        // NOTE:
+        // When browser refresh is triggered, there is an issue that Vue router prematurely decides ('loginGuard' there) that
+        // the user is not signed in when in actual reality user-login is still being processed and then
+        // takes user to 'Home.vue' with the '$route.query.next' being set to the initial url.
+        // In this particular condition, the app needs to immediately redirect user to '$route.query.next'
+        // so that the user stays in the same page after the browser refresh.
+        // (Related GH issue: https://github.com/okTurtles/group-income/issues/1830)
+        path: this.$route.query.next ?? (
+          this.ourGroupProfile
+            ? '/dashboard'
+            : '/pending-approval'
+        )
+      }).catch(console.warn)
     }
   },
   watch: {


### PR DESCRIPTION
closes #1830 

I have left this as the comment inside the source-code too but,
This bug happens because Vue-router prematurely decides that the user is not logged in and takes the user to `Home.vue` while in reality the logging user in([here](https://github.com/okTurtles/group-income/blob/36b7b598ed0f038c1870813acfd6922070321cf5/frontend/main.js#L375C1-L378C11) in `main.js`) is still in progress.
So as a fix, `navigateToGroupPage` in `Home.vue` needs a small addition there where it checks if that's what happened.

cc. @taoeffect 
