### PR TITLE
#1833 - Fix the double dialog box issue on chat file-attachment

### DIFF
--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -587,6 +587,8 @@ export default ({
       })
     },
     openFileAttach (e) {
+      if (e.target.matches('input')) { return }
+
       e.target.blur()
       this.$refs.fileAttachmentInputEl.click()
     },


### PR DESCRIPTION
closes #1833 

@Silver-IT 
I noticed that the `openFileAttach` method, which is triggered by `fileAttachmentInputEl` actually somehow programatically clicks itself within the method and that leads to browser unnecessarily showing the file upload dialog twice.

I didn't encounter the bug related to drag&drop action you mentioned in the issue though. If you attach some demo of how to exactly reproduce it, will make a fix for that too.

cc. @taoeffect 