### PR TITLE
Remove pushClientErrorHandler from pubsub.js

### DIFF
--- a/shared/pubsub.js
+++ b/shared/pubsub.js
@@ -453,14 +453,7 @@ const defaultMessageHandlers = {
       }
       case REQUEST_TYPE.PUSH_ACTION: {
         const { actionType, message } = data
-        const errorHandler = actionType ? pushClientErrorHandler[actionType] : null
-
         console.warn(`[pubsub] Received ERROR for PUSH_ACTION request with the action type '${actionType}' and the following message: ${message}`)
-        if (errorHandler) {
-          errorHandler()
-        } else {
-          pushClientErrorHandler.default(actionType)
-        }
         break
       }
       default: {
@@ -677,15 +670,6 @@ const publicMethods = {
         socket.send(createRequest(REQUEST_TYPE.UNSUB, { channelID }))
       }
     }
-  }
-}
-
-const pushClientErrorHandler = {
-  [PUSH_SERVER_ACTION_TYPE.SEND_PUSH_NOTIFICATION] () {
-    // TODO: Add a logic here that unregisters from the old subscription and then re-generates it.
-  },
-  default (actionType) {
-    console.error(`[push-error] Invalid request for the action type '${actionType}'`)
   }
 }
 


### PR DESCRIPTION
This is a small PR for removing `pushClientErrorHandler` block written for a pubsub error with `REQUEST_TYPE.PUSH_ACTION` message type.

Currently this block does nothing but generating a console error message, which is what `console.warn()` in L456 already does. 
For the context, the thinking behind creating the `pushClientErrorHandler` logic  was **in case** a certain error might need some kind of post action in response to it. For now, every  push-related error will just be silently ignored so that it doesn't affect users using the app.
