### PR TITLE
Fix browser notifications not showing up on Android

### DIFF
--- a/frontend/controller/serviceworkers/sw-primary.js
+++ b/frontend/controller/serviceworkers/sw-primary.js
@@ -66,6 +66,11 @@ self.addEventListener('message', function (event) {
   }
 })
 
+// Handle clicks on notifications issued via registration.showNotification().
+self.addEventListener('notificationclick', event => {
+  console.debug('[sw] Notification clicked:', event.notification)
+})
+
 self.addEventListener('push', function (event) {
   // PushEvent reference: https://developer.mozilla.org/en-US/docs/Web/API/PushEvent
 

--- a/frontend/model/contracts/shared/nativeNotification.js
+++ b/frontend/model/contracts/shared/nativeNotification.js
@@ -31,10 +31,22 @@ export function makeNotification ({ title, body, icon, path }: {
   title: string, body: string, icon?: string, path?: string
 }): void {
   if (Notification?.permission === 'granted' && sbp('state/vuex/settings').notificationEnabled) {
-    const notification = new Notification(title, { body, icon })
-    if (path) {
-      notification.onclick = function (event) {
-        sbp('controller/router').push({ path }).catch(console.warn)
+    try {
+      const notification = new Notification(title, { body, icon })
+      if (path) {
+        notification.onclick = (event) => {
+          sbp('controller/router').push({ path }).catch(console.warn)
+        }
+      }
+    } catch {
+      try {
+        // FIXME: find a cross-browser way to pass the 'path' parameter when the notification is clicked.
+        navigator.serviceWorker?.ready.then(registration => {
+          // $FlowFixMe
+          registration.showNotification(title, { body, icon })
+        }).catch(console.warn)
+      } catch (error) {
+        console.debug('makeNotification: ', error.message)
       }
     }
   }

--- a/frontend/model/contracts/shared/nativeNotification.js
+++ b/frontend/model/contracts/shared/nativeNotification.js
@@ -46,7 +46,7 @@ export function makeNotification ({ title, body, icon, path }: {
           registration.showNotification(title, { body, icon })
         }).catch(console.warn)
       } catch (error) {
-        console.debug('makeNotification: ', error.message)
+        console.error('makeNotification: ', error.message)
       }
     }
   }


### PR DESCRIPTION
Closes #1944

### Summary of changes
- Change `makeNotification()` to use `ServiceWorkerRegistration.showNotification()` to display browser notifications where `new Notification()` isn't supported, e.g. in Android.

#### Additional information
- Notifications displayed using the above mentioned way do not take the `path` parameter into account, in other words the user isn't redirected to the appropriate page when the notification is clicked.