### PR TITLE
Bugfix for the issue #1954

### DIFF
--- a/frontend/views/containers/chatroom/CreatePoll.vue
+++ b/frontend/views/containers/chatroom/CreatePoll.vue
@@ -232,6 +232,14 @@ export default {
         this.$v.form.$reset()
         this.close()
       })
+    },
+    resizeHandler () {
+      if (window.matchMedia('(hover: hover)').matches) {
+        // This is a fix for the issue #1954(https://github.com/okTurtles/group-income/issues/1954)
+        // -> closes the pop-up if the viewport size changes only when it's NOT a touch device.
+        //    e.g) The viewport size changes when the keyboard tab is pulled out on the touch device.
+        this.close()
+      }
     }
   },
   created () {
@@ -241,11 +249,11 @@ export default {
     }
     this.ephemeral.isDesktopScreen = this.matchMediaDesktop.matches
 
-    window.addEventListener('resize', this.close)
+    window.addEventListener('resize', this.resizeHandler)
     document.addEventListener('keydown', this.trapFocus)
   },
   beforeDestroy () {
-    window.removeEventListener('resize', this.close)
+    window.removeEventListener('resize', this.resizeHandler)
     document.removeEventListener('keydown', this.trapFocus)
 
     this.matchMediaDesktop.onchange = null

--- a/frontend/views/containers/chatroom/Emoticons.vue
+++ b/frontend/views/containers/chatroom/Emoticons.vue
@@ -30,12 +30,12 @@ export default ({
     sbp('okTurtles.events/on', OPEN_EMOTICON, this.openEmoticon)
     // When press escape it should close the modal
     window.addEventListener('keyup', this.handleKeyUp)
-    window.addEventListener('resize', this.closeEmoticonDlg)
+    window.addEventListener('resize', this.resizeHandler)
   },
   beforeDestroy () {
     sbp('okTurtles.events/off', OPEN_EMOTICON)
     window.removeEventListener('keyup', this.handleKeyUp)
-    window.removeEventListener('resize', this.closeEmoticonDlg)
+    window.removeEventListener('resize', this.resizeHandler)
   },
   computed: {
     position () {
@@ -97,6 +97,14 @@ export default ({
       if (this.lastFocus) {
         this.lastFocus.focus()
         this.lastFocus = null
+      }
+    },
+    resizeHandler () {
+      if (window.matchMedia('(hover: hover)').matches) {
+        // This is a fix for the issue #1954 (https://github.com/okTurtles/group-income/issues/1954)
+        // -> closes the pop-up if the viewport size changes only when it's NOT a touch device.
+        //    e.g) The viewport size changes when the keyboard tab is pulled out on the touch device.
+        this.closeEmoticonDlg()
       }
     }
   }


### PR DESCRIPTION
closes #1954 

The cause of the issue in both `CreatePoll.vue` and `Emoticons.vue` components was that there is resize handler that closes the pop-up when it detects viewport changes. But then what happens in touch devices is, when the input field is clicked, the keyboard pad is pulled out which triggers viewport size changes.

The fix I made here is to update the logic to take this into account.