### PR TITLE
Move key deletion key to chelonia

### DIFF
--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -994,6 +994,19 @@ export default (sbp('sbp/selectors/register', {
       }
     }
   },
+  'chelonia/contract/state': function (contractID: string, height: ?number) {
+    const state = sbp(this.config.stateSelector)[contractID]
+    const stateCopy = state && cloneDeep(state)
+    if (stateCopy?._vm && height != null) {
+      // Remove keys in the future
+      Object.keys(stateCopy._vm.authorizedKeys).forEach(keyId => {
+        if (stateCopy._vm.authorizedKeys[keyId]._notBeforeHeight > height) {
+          delete stateCopy._vm.authorizedKeys[keyId]
+        }
+      })
+    }
+    return stateCopy
+  },
   // 'chelonia/out' - selectors that send data out to the server
   'chelonia/out/registerContract': async function (params: ChelRegParams) {
     const { contractName, keys, hooks, publishOptions, signingKeyId, actionSigningKeyId, actionEncryptionKeyId } = params


### PR DESCRIPTION
This PR implements a new selector, `chelonia/contract/state` and moves the logic to exclude future keys into this selector, so that `ChatMain.vue` doesn't need to do that.

Note that it was a bit flaky getting this to work and I had to use `this.renderingChatRoomId` instead of the more intuitive `currentChatRoomId` (which seems to be what was currently being used).

Note also that `ChatMain.vue` will need to be refactored to a large degree (not because of this PR, but because of moving Chelonia into a service worker). The main change will be that everything using `chelonia/` will need to be asynchronous (including this new selector).