### PR TITLE
#1985 - Wrong position of the mention pop-up menu 

### DIFF
--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -1085,10 +1085,11 @@ export default ({
   position: absolute;
   left: 0;
   right: 0;
-  bottom: 5rem;
+  top: 0;
+  transform: translateY(-100%);
   overflow-y: auto;
   overflow-x: hidden;
-  max-height: 12rem;
+  max-height: 12.25rem;
 
   .c-mention-user,
   .c-mention-channel {


### PR DESCRIPTION
closes #1985 

**[Member mentions]**

<img src='https://github.com/okTurtles/group-income/assets/17641213/447a0567-43a7-414e-8df8-e50aa6a5cc92' width='420'>

**[Channel mentions]**

<img src='https://github.com/okTurtles/group-income/assets/17641213/8db27aae-c704-4a8c-89ef-79ae8050b9fb' width='420'>