### PR TITLE
Resolving two issues in #1934

### DIFF
--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -90,7 +90,7 @@ export default ({
   },
   methods: {
     show () {
-      if (!this.manual) this.isActive = true
+      if (!this.manual && !this.deactivated) this.isActive = true
     },
     hide () {
       if (!this.manual) this.isActive = false

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -85,6 +85,7 @@
             v-if='ephemeral.showButtons'
             direction='top'
             :text='L("Add reaction")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Add reaction")'
@@ -94,6 +95,7 @@
           tooltip(
             direction='top'
             :text='L("Bold")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Bold style text")'
@@ -103,6 +105,7 @@
           tooltip(
             direction='top'
             :text='L("Italic")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Italic style text")'
@@ -112,6 +115,7 @@
           tooltip(
             direction='top'
             :text='L("Code")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Add code")'
@@ -121,6 +125,7 @@
           tooltip(
             direction='top'
             :text='L("Strikethrough")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Add strikethrough")'
@@ -130,6 +135,7 @@
           tooltip(
             direction='top'
             :text='L("Link")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Add link")'
@@ -153,6 +159,7 @@
           tooltip(
             direction='top'
             :text='L("Bold")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Bold style text")'
@@ -162,6 +169,7 @@
           tooltip(
             direction='top'
             :text='L("Italic")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Italic style text")'
@@ -171,6 +179,7 @@
           tooltip(
             direction='top'
             :text='L("Code")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Add code")'
@@ -180,6 +189,7 @@
           tooltip(
             direction='top'
             :text='L("Strikethrough")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Add strikethrough")'
@@ -189,6 +199,7 @@
           tooltip(
             direction='top'
             :text='L("Link")'
+            :deactivated='ephemeral.isPhone'
           )
             button.is-icon(
               :aria-label='L("Add link")'
@@ -806,15 +817,6 @@ export default ({
 
         inputEl.value = result.output
         this.$refs.textarea.setSelectionRange(result.focusIndex.start, result.focusIndex.end)
-
-        this.$nextTick(() => {
-          // make sure the button is blurred after the text-transformation.
-          // (Github reference: https://github.com/okTurtles/group-income/pull/1999#issuecomment-2119466437)
-          const btnEl = e.target.closest('button.is-icon')
-          if (btnEl) {
-            btnEl.blur()
-          }
-        })
       }
     },
     onUserTyping (data) {
@@ -921,7 +923,6 @@ export default ({
     background-color: transparent;
     border: none;
     padding: 0.5rem;
-    padding-bottom: 1.25rem;
 
     &::-webkit-scrollbar {
       display: none;
@@ -1163,5 +1164,20 @@ export default ({
   display: block;
   font-size: 0.675rem;
   padding: 0.25rem 0.25rem;
+}
+
+@media (hover: none) and (pointer: coarse) {
+  // fix for some mobile-specific issue: https://github.com/okTurtles/group-income/issues/1934
+  .c-send-textarea {
+    padding-bottom: 1rem;
+    height: 3.25rem;
+  }
+
+  .c-send-actions {
+    button.is-icon:focus,
+    button.is-icon:hover {
+      color: $general_0 !important;
+    }
+  }
 }
 </style>

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -1155,8 +1155,4 @@ export default ({
   font-size: 0.675rem;
   padding: 0.25rem 0.25rem;
 }
-
-.c-send-textarea {
-
-}
 </style>

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -806,6 +806,15 @@ export default ({
 
         inputEl.value = result.output
         this.$refs.textarea.setSelectionRange(result.focusIndex.start, result.focusIndex.end)
+
+        this.$nextTick(() => {
+          // make sure the button is blurred after the text-transformation.
+          // (Github reference: https://github.com/okTurtles/group-income/pull/1999#issuecomment-2119466437)
+          const btnEl = e.target.closest('button.is-icon')
+          if (btnEl) {
+            btnEl.blur()
+          }
+        })
       }
     },
     onUserTyping (data) {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -797,16 +797,15 @@ export default ({
           case 'code':
           case 'strikethrough': {
             result = injectOrStripSpecialChar(inputValue, type, selStart, selEnd)
-            inputEl.value = result.output
-            this.moveCursorTo(result.focusIndex)
             break
           }
           case 'link': {
             result = injectOrStripLink(inputValue, selStart, selEnd)
-            inputEl.value = result.output
-            this.$refs.textarea.setSelectionRange(result.focusIndex.start, result.focusIndex.end)
           }
         }
+
+        inputEl.value = result.output
+        this.$refs.textarea.setSelectionRange(result.focusIndex.start, result.focusIndex.end)
       }
     },
     onUserTyping (data) {
@@ -913,6 +912,7 @@ export default ({
     background-color: transparent;
     border: none;
     padding: 0.5rem;
+    padding-bottom: 1.25rem;
 
     &::-webkit-scrollbar {
       display: none;
@@ -1154,5 +1154,9 @@ export default ({
   display: block;
   font-size: 0.675rem;
   padding: 0.25rem 0.25rem;
+}
+
+.c-send-textarea {
+
 }
 </style>

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -48,10 +48,14 @@ export function injectOrStripSpecialChar (
   let segment = str.slice(startIndex, endIndex)
   let before = str.slice(0, startIndex)
   let after = str.slice(endIndex)
+  let focusStart = startIndex, focusEnd = endIndex
   const specialChar = charMap[type]
 
   if (!specialChar) {
-    return { output: str, focusIndex: str.length }
+    return {
+      output: str,
+      focusIndex: { start: focusStart, end: focusEnd }
+    }
   }
 
   if (before.endsWith(specialChar) && after.startsWith(specialChar)) {
@@ -59,18 +63,24 @@ export function injectOrStripSpecialChar (
     const len = specialChar.length
     before = before.slice(0, before.length - len)
     after = after.slice(len)
+
+    focusStart -= len
+    focusEnd -= len * 2
   } else if (segment.startsWith(specialChar) && segment.endsWith(specialChar)) {
     // Stripping condition No 2. - when the selected segment itself contains the special character at both start/end of the string.
     const len = specialChar.length
     segment = segment.slice(len, segment.length - len)
+    focusEnd -= len * 2
   } else {
+    const len = specialChar.length
     // Otherwise, let's wrap the selected segment with the speical character.
     segment = `${specialChar}${segment}${specialChar}`
+    focusEnd += len * 2
   }
 
   const output = before + segment + after
   const focusIndex = (before + segment).length
-  return { output, focusIndex }
+  return { output, focusIndex: { start: focusStart, end: focusEnd } }
 }
 
 export function injectOrStripLink (

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -48,7 +48,8 @@ export function injectOrStripSpecialChar (
   let segment = str.slice(startIndex, endIndex)
   let before = str.slice(0, startIndex)
   let after = str.slice(endIndex)
-  let focusStart = startIndex, focusEnd = endIndex
+  let focusStart = startIndex
+  let focusEnd = endIndex
   const specialChar = charMap[type]
 
   if (!specialChar) {
@@ -79,7 +80,6 @@ export function injectOrStripSpecialChar (
   }
 
   const output = before + segment + after
-  const focusIndex = (before + segment).length
   return { output, focusIndex: { start: focusStart, end: focusEnd } }
 }
 


### PR DESCRIPTION
work on **problem 1. & 2.** of the issue #1934 

@taoeffect 
for the **problem 1.** , I actually went a bit ambitious and increased the buttom padding to `1.25rem` but please let me know if you feel it's too much.

<img src='https://github.com/okTurtles/group-income/assets/17641213/4af82efc-a280-44fd-8732-2cba3d40a3d1' width='430'>

And as a fix for the **problem 2.** , the target text segment now remains selected after pressing the format buttons.

---

For **problem 3.** there which is an issue related iOS's built-in call-out menu, there seems to be no CSS rule to control behaviour of it nor disable/enable it. (`-webkit-touch-callout` rule doesn't work for this case)
I will keep researching on this issue with iOS simulator on my Mac and send another PR once I figure out the solution.

Thanks,