### PR TITLE
Resolve two issues in #1988

### DIFF
--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -54,7 +54,7 @@
               v-if='isText(objText)'
               v-safe-html:a='objText.text'
             )
-            template(v-else-if='isMemberMention')
+            template(v-else-if='isMemberMention(objText)')
               span.c-mention-profile-card-wrapper(v-if='objText.userID')
                 profile-card(:contractID='objText.userID' direction='top-left')
                   span.c-member-mention(:class='{"c-mention-to-me": objText.toMe}') {{ objText.text }}

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -275,13 +275,7 @@ export default ({
       const allMention = makeMentionFromUserID('').all
 
       if (this.shouldRenderMarkdown) {
-        console.log('!@# before transform: ', text)
         text = renderMarkdown(text)
-        console.log('!@# after transform: ', text)
-
-        const listRegExp = /(<ul>.+<\/ul>)/
-        const isList = str => listRegExp.test(str)
-        const splitByList = text.split(listRegExp).filter(Boolean)
       }
 
       return text

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -14,14 +14,17 @@ marked.use({
 })
 
 export function renderMarkdown (str: string): any {
+  str = str.replace(/\n/g, '<br>') // firstly, manually replace all new-lines with <br>. ("breaks: true" option below doesn't consistently work.)
+    .replace(/<br>-/g, '\n-')
+
   let converted = marked.parse(str, { gfm: true, breaks: true })
 
   // remove unecessary line-breaks from the converted markdown outcome.
   converted = converted.replace(/^\s+|\s+$/g, '')
 
   // remove the unecessary starting/end line-breaks added to the blockquote.
-  converted = converted.replace(/blockquote>\n/g, 'blockquote>')
-    .replace(/\n<\/blockquote>/g, '</blockquote>')
+  converted = converted.replace(/([a-z]+)>\n/g, '$1>')
+    .replace(/\n<\/([a-z]+)>/g, '</$1>')
 
   // if the original string doesn't have a line-break within it,
   // the converted outcome doesn't need to be wrapped with <p></p>.


### PR DESCRIPTION
There is three issues listed in #1988 and this is a PR resolving the **Problem 1.** and **2.** there.
(See the issue description there for details on what they are)


A message containing multiple mentions with several line breaks now look correct.

<img src='https://github.com/okTurtles/group-income/assets/17641213/f780d05c-ad1a-4c9c-8a53-72e22dd2d99c' width='420'>

---
@taoeffect 
**Problem 3.** there (which is related to the case when a mention is wrapped within a html tag generated as a result of markdown conversion) actually requires somewhat ground breaking change on how the `MessageBase.vue` component currently renders a message. (I detailed them in [this comment](https://github.com/okTurtles/group-income/issues/1988#issuecomment-2113659964))

Am currently working on re-writing this logic using Vue's [render function](https://v2.vuejs.org/v2/guide/render-function#The-Data-Object-In-Depth), and will send a follow-up PR  once this is complete and ready for review (Or will merge it to this PR if you are yet to start reviewing this one by the time I finish it).

Hope it sounds good. cheers.