### PR TITLE
fix dbPath

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,7 @@ const development = NODE_ENV === 'development'
 const production = !development
 
 // Make database path available to subprocess
-const dbPath = process.env.DB_PATH || (production ? `./${distDir}/data` : './data')
+const dbPath = process.env.DB_PATH || './data'
 if (!process.env.DB_PATH) {
   Object.assign(process.env, { DB_PATH: dbPath })
 }


### PR DESCRIPTION
Now uses `./data` in both production and development (unless otherwise specified by `process.env.DB_PATH`)