### PR TITLE
#2012 - Add "Copy message text" menu to the chat message toast pop-up

### DIFF
--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -83,11 +83,19 @@ menu-parent(ref='menu')
         i18n Add emoticons
 
       menu-item.is-icon-small(
+        v-if='isText'
+        tag='button'
+        @click='action("copyMessageText")'
+      )
+        i.icon-copy
+        i18n Copy message text
+
+      menu-item.is-icon-small(
         tag='button'
         @click='action("copyMessageLink")'
       )
         i.icon-link
-        i18n Copy message Link
+        i18n Copy message link
 
       menu-item.is-icon-small.is-danger(
         tag='button'
@@ -120,6 +128,8 @@ export default ({
         return Object.values(MESSAGE_VARIANTS).indexOf(value) !== -1
       }
     },
+    messageHash: String,
+    text: String,
     type: String,
     isMsgSender: Boolean,
     isGroupCreator: Boolean
@@ -140,8 +150,30 @@ export default ({
   },
   methods: {
     action (type, e) {
-      // Change to sbp action
-      this.$emit(type, e)
+      const copyString = str => {
+        navigator?.clipboard.writeText(str)
+      }
+      switch (type) {
+        case 'copyMessageLink': {
+          if (!this.messageHash) { return }
+
+          const url = new URL(location.href)
+          url.search = `mhash=${this.messageHash}`
+
+          copyString(url.href)
+          break
+        }
+        case 'copyMessageText': {
+          if (!this.text) { return }
+
+          copyString(this.text)
+          break
+        }
+        default: {
+          // Change to sbp action
+          this.$emit(type, e)
+        }
+      }
     }
   }
 }: Object)

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -100,6 +100,8 @@
     v-if='!isEditing'
     :variant='variant'
     :type='type'
+    :text='text'
+    :messageHash='messageHash'
     :isMsgSender='isMsgSender'
     :isGroupCreator='isGroupCreator'
     ref='messageAction'
@@ -108,7 +110,6 @@
     @deleteMessage='$emit("delete-message")'
     @reply='reply'
     @retry='$emit("retry")'
-    @copyMessageLink='copyMessageLink'
   )
 </template>
 
@@ -235,14 +236,6 @@ export default ({
     },
     reply () {
       this.$emit('reply')
-    },
-    copyMessageLink () {
-      if (!this.messageHash) { return }
-
-      const url = new URL(location.href)
-      url.search = `mhash=${this.messageHash}`
-
-      navigator.clipboard.writeText(url.href)
     },
     selectEmoticon (emoticon) {
       this.$emit('add-emoticon', emoticon.native || emoticon)


### PR DESCRIPTION
closes #2012 

Adding 'Copy message text' menu to the chat message's toast menu.

<img src='https://github.com/okTurtles/group-income/assets/17641213/297ef402-9c69-4be4-9a36-134c1e25dbc4' width='420'>
