### PR TITLE
#2019 - Share app logs instead of downloading on mobile

### DIFF
--- a/frontend/model/captureLogs.js
+++ b/frontend/model/captureLogs.js
@@ -123,7 +123,7 @@ function clearLogs () {
 }
 
 // Util to download all stored logs so far.
-function downloadLogs (elLink: Object): void {
+function downloadOrShareLogs (elLink: Object): void {
   const filename = 'gi_logs.json'
 
   const file = new Blob([JSON.stringify({
@@ -174,7 +174,7 @@ function setAppLogsFilter (filter: Array<string>) {
 window.addEventListener('beforeunload', event => sbp('appLogs/save'))
 
 sbp('sbp/selectors/register', {
-  'appLogs/download' (elLink) { downloadLogs(elLink) },
+  'appLogs/downloadOrShare' (...args) { downloadOrShareLogs(...args) },
   'appLogs/get' () { return getLogger()?.entries?.toArray() ?? [] },
   'appLogs/save' () { getLogger()?.save() },
   'appLogs/pauseCapture' ({ wipeOut }) { captureLogsPause({ wipeOut }) },

--- a/frontend/model/captureLogs.js
+++ b/frontend/model/captureLogs.js
@@ -125,9 +125,8 @@ function clearLogs () {
 
 // Util to download all stored logs so far.
 function downloadOrShareLogs (actionType: 'share' | 'download', elLink?: HTMLAnchorElement): any {
-  const isDownload = actionType === 'download'
-  const filename = isDownload ? 'gi_logs.json' : 'gi_logs.txt'
-  const mimeType = isDownload ? 'application/json' : 'text/plain'
+  const filename = 'gi_logs.json.txt'
+  const mimeType = 'text/plain'
 
   const blob = new Blob([JSON.stringify({
     // Add instructions in case the user opens the file.
@@ -136,7 +135,7 @@ function downloadOrShareLogs (actionType: 'share' | 'download', elLink?: HTMLAnc
     logs: getLogger().entries.toArray()
   }, undefined, 2)], { type: mimeType })
 
-  if (isDownload) {
+  if (actionType === 'download') {
     if (!elLink) { return }
 
     const url = URL.createObjectURL(blob)
@@ -186,9 +185,9 @@ function setAppLogsFilter (filter: Array<string>) {
 window.addEventListener('beforeunload', event => sbp('appLogs/save'))
 
 sbp('sbp/selectors/register', {
-  'appLogs/downloadOrShare' (...args) { downloadOrShareLogs(...args) },
+  'appLogs/downloadOrShare': downloadOrShareLogs,
   'appLogs/get' () { return getLogger()?.entries?.toArray() ?? [] },
   'appLogs/save' () { getLogger()?.save() },
-  'appLogs/pauseCapture' ({ wipeOut }) { captureLogsPause({ wipeOut }) },
-  'appLogs/startCapture' (identityContractID) { captureLogsStart(identityContractID) }
+  'appLogs/pauseCapture': captureLogsPause,
+  'appLogs/startCapture': captureLogsStart
 })


### PR DESCRIPTION
closes #2019 

Below are the screenshots of the button working (tested via `grunt dev --tunnel`)


#### [1] The button says 'Share' instead and clicking on it displays the native 'share' interface dialog (Chrome Android).

<img src='https://github.com/okTurtles/group-income/assets/17641213/901bbda5-d6a0-43e6-af1d-e08634aa5c71' width='360'>

#### [2] I can share the `.txt` file to Slack mobile via the native interface launched in [1] above.

<img src='https://github.com/okTurtles/group-income/assets/17641213/e7bbea0c-807f-462a-9b3d-c85e0b1aef38' width='360'>

---

**NOTE:** The reason why the log file is converted to `.txt` instead of `.json` is according to **[this MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share#shareable_file_types)** listing the shareable file types via Web Share API.

Thanks,
