### PR TITLE
#2020 - UI bug related to auto-scroll on 'Focus' in mobile browsers.

### DIFF
--- a/frontend/views/components/group-creation-steps/GroupName.vue
+++ b/frontend/views/components/group-creation-steps/GroupName.vue
@@ -62,6 +62,8 @@ export default ({
   },
   mounted () {
     window.setTimeout(() => {
+      // An arbitrary delay here is to fix the issue #2020.
+      // See the PR description here for the details: https://github.com/okTurtles/group-income/pull/2036#issue-2332505747
       this.$refs.name.focus()
     }, 300)
 

--- a/frontend/views/components/group-creation-steps/GroupName.vue
+++ b/frontend/views/components/group-creation-steps/GroupName.vue
@@ -61,7 +61,10 @@ export default ({
     sbp('okTurtles.events/on', AVATAR_EDITED, this.updateGroupPictureByEditor)
   },
   mounted () {
-    this.$refs.name.focus()
+    window.setTimeout(() => {
+      this.$refs.name.focus()
+    }, 300)
+
     const c = this.$refs.pictureCanvas
     c.width = 256
     c.height = 256


### PR DESCRIPTION
closes #2020 

---

@taoeffect 

This issue actually happens in all mobile browsers, which is where the native keyboard panel is pulled out when an input field focuses.

What I noticed is that the same doesn't happen in the following group creation steps despite them all calling `inputEl.focus()` in their `mounted()` hook too. 
The difference in the first step is, The native keyboard is pulled out [1] almost at the same time as when the Modal pops out [2] and this requires browser to handle the layout change (by [2]) while the viewport size is decreasing (by [1]) and it somehow leads to this overzealous behaviour.

The best solution I could come up with was to giving a bit of delay to calling `focus()` on the input element, so that browser can fully render modal first and then deals with the viewport change caused by the focus. Below is the improvement I see.

**[Before fix]**
<img src='https://github.com/okTurtles/group-income/assets/17641213/76851a93-30be-4ad9-979c-0b7e36db2b77' width='320'>

**[After fix]**
<img src='https://github.com/okTurtles/group-income/assets/17641213/6aa1bae4-5fb8-4dcb-a271-fc30eecb6669' width='320'>