### PR TITLE
#2041 - Fix the In-app link panel not working

### DIFF
--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -202,10 +202,12 @@ export default ({
       this.$refs.messageAction.$refs.menu.handleTrigger()
     },
     longPressHandler (e) {
-      const targetEl = e.target
-      if (targetEl.matches('a.link[href]')) {
-        const url = targetEl.getAttribute('href')
+      const wrappingLinkTag = e.target.closest('a.link[href]')
+
+      if (wrappingLinkTag) {
+        const url = wrappingLinkTag.getAttribute('href')
         sbp('okTurtles.events/emit', OPEN_TOUCH_LINK_HELPER, url)
+        e?.preventDefault()
       } else {
         this.openMenu()
       }


### PR DESCRIPTION
closes #2041 

Due to the recent update on how the markdown texts are rendered in [this PR](https://github.com/okTurtles/group-income/pull/2016), the logic governing this needed to be updated accordingly too.

Proof of the fix:

<img src='https://github.com/okTurtles/group-income/assets/17641213/a02d50ce-0c45-4003-a43d-4cdebd1c10ff' width='320'>