### PR TITLE
Closes #2072 - capture tunnel logs

### DIFF
--- a/backend/routes.js
+++ b/backend/routes.js
@@ -143,6 +143,29 @@ route.GET('/eventsAfter/{contractID}/{since}/{limit?}', {}, async function (requ
   }
 })
 
+if (process.env.NODE_ENV === 'development') {
+  const levelToColor = {
+    error: chalk.bold.red,
+    warn: chalk.yellow,
+    log: chalk.green,
+    info: chalk.green,
+    debug: chalk.blue
+  }
+  route.POST('/log', {
+    validate: {
+      payload: Joi.object({
+        level: Joi.string().required(),
+        value: Joi.string().required()
+      })
+    }
+  }, function (request, h) {
+    const ip = request.info.remoteAddress
+    const log = levelToColor[request.payload.level]
+    console.debug(chalk.bold.yellow(`REMOTE LOG (${ip}): `) + log(`[${request.payload.level}] ${request.payload.value}`))
+    return h.response().code(200)
+  })
+}
+
 /*
 // The following endpoint is disabled because name registrations are handled
 // through the `shelter-namespace-registration` header when registering a

--- a/frontend/model/captureLogs.js
+++ b/frontend/model/captureLogs.js
@@ -191,19 +191,17 @@ sbp('sbp/selectors/register', {
   'appLogs/save' () { getLogger()?.save() },
   'appLogs/pauseCapture': captureLogsPause,
   'appLogs/startCapture': captureLogsStart,
-  'appLogs/logServer': process.env.NODE_ENV !== 'development'
+  'appLogs/logServer': process.env.NODE_ENV !== 'development' || !window.location.href.startsWith('https://gi')
     ? noop
     : function (level, string) {
-      if (window.location.href.startsWith('https://gi')) {
-        fetch(`${sbp('okTurtles.data/get', 'API_URL')}/log`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json'
-          },
-          body: JSON.stringify({ level, value: string })
-        }).catch(e => {
-          originalConsole.error(`[captureLogs] '${e.message}' attempting to log [${level}] to server:`, string)
-        })
-      }
+      fetch(`${sbp('okTurtles.data/get', 'API_URL')}/log`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ level, value: string })
+      }).catch(e => {
+        originalConsole.error(`[captureLogs] '${e.message}' attempting to log [${level}] to server:`, string)
+      })
     }
 })

--- a/frontend/model/captureLogs.js
+++ b/frontend/model/captureLogs.js
@@ -191,19 +191,21 @@ sbp('sbp/selectors/register', {
   'appLogs/save' () { getLogger()?.save() },
   'appLogs/pauseCapture': captureLogsPause,
   'appLogs/startCapture': captureLogsStart,
+  // only log to server if we're in development mode and connected over the tunnel (which creates URLs that
+  // begin with 'https://gi' per Gruntfile.js)
   'appLogs/logServer': process.env.NODE_ENV !== 'development' || !window.location.href.startsWith('https://gi')
     ? noop
     : function (level, stringifyMe) {
       if (level === 'debug') return // comment out to send much more log info
-      const string = JSON.stringify(stringifyMe)
+      const value = JSON.stringify(stringifyMe)
       fetch(`${sbp('okTurtles.data/get', 'API_URL')}/log`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
         },
-        body: JSON.stringify({ level, value: string })
+        body: JSON.stringify({ level, value })
       }).catch(e => {
-        originalConsole.error(`[captureLogs] '${e.message}' attempting to log [${level}] to server:`, string)
+        originalConsole.error(`[captureLogs] '${e.message}' attempting to log [${level}] to server:`, value)
       })
     }
 })

--- a/frontend/model/captureLogs.js
+++ b/frontend/model/captureLogs.js
@@ -84,7 +84,7 @@ function captureLogEntry (type, ...args) {
   // The reason this works is because the entire `sbp` domain is blacklisted
   // from being logged in main.js.
   sbp('sbp/selectors/fn', 'okTurtles.events/emit')(CAPTURED_LOGS, entry)
-  sbp('sbp/selectors/fn', 'appLogs/logServer')(type, JSON.stringify(entry.msg))
+  sbp('sbp/selectors/fn', 'appLogs/logServer')(type, entry.msg)
 }
 
 function captureLogsStart (userLogged: string) {
@@ -193,7 +193,8 @@ sbp('sbp/selectors/register', {
   'appLogs/startCapture': captureLogsStart,
   'appLogs/logServer': process.env.NODE_ENV !== 'development' || !window.location.href.startsWith('https://gi')
     ? noop
-    : function (level, string) {
+    : function (level, stringifyMe) {
+      const string = JSON.stringify(stringifyMe)
       fetch(`${sbp('okTurtles.data/get', 'API_URL')}/log`, {
         method: 'POST',
         headers: {

--- a/frontend/model/captureLogs.js
+++ b/frontend/model/captureLogs.js
@@ -194,6 +194,7 @@ sbp('sbp/selectors/register', {
   'appLogs/logServer': process.env.NODE_ENV !== 'development' || !window.location.href.startsWith('https://gi')
     ? noop
     : function (level, stringifyMe) {
+      if (level === 'debug') return // comment out to send much more log info
       const string = JSON.stringify(stringifyMe)
       fetch(`${sbp('okTurtles.data/get', 'API_URL')}/log`, {
         method: 'POST',


### PR DESCRIPTION
Captures phone logs to server console run accessing via `grunt dev --tunnel`.

Adds new `'appLogs/logServer'` selector that can be called manually if necessary before the log capture begins (when login is called). Generally speaking you won't need to call this manually and the logs will appear automatically on the backend, color coded.