### PR TITLE
Various bugfixes, related to #2064 and #2066

### DIFF
--- a/frontend/model/notifications/templates.js
+++ b/frontend/model/notifications/templates.js
@@ -251,12 +251,12 @@ export default ({
   },
   PAYMENT_THANKYOU_SENT (data: { creatorID: string, fromMemberID: string, toMemberID: string }) {
     return {
-      avatarUserID: data.creatorID,
+      avatarUserID: data.fromMemberID,
       body: L('{name} sent you a {strong_}thank you note{_strong} for your contribution.', {
         name: strong(userDisplayNameFromID(data.fromMemberID)),
         ...LTags('strong')
       }),
-      creatorID: data.creatorID,
+      creatorID: data.fromMemberID,
       icon: '',
       level: 'info',
       linkTo: `/payments?modal=ThankYouNoteModal&from=${data.fromMemberID}&to=${data.toMemberID}`,

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -439,7 +439,7 @@ const getters = {
       .filter(memberID => getters.groupProfiles[memberID] ||
          getters.groupMembersPending[memberID].expires >= Date.now())
       .map(memberID => {
-        const { contractID, displayName, username } = getters.globalProfile(memberID) || groupMembersPending[memberID] || {}
+        const { contractID, displayName, username } = getters.globalProfile(memberID) || groupMembersPending[memberID] || (getters.groupProfiles[memberID] ? { contractID: memberID } : {})
         return {
           id: memberID, // common unique ID: it can be either the contract ID or the invite key
           contractID,

--- a/frontend/views/components/AvatarUser.vue
+++ b/frontend/views/components/AvatarUser.vue
@@ -18,7 +18,9 @@ export default ({
     picture: {
       type: [String, Object]
     },
-    contractID: String,
+    contractID: {
+      type: String
+    },
     alt: {
       type: String,
       default: ''

--- a/shared/domains/chelonia/internals.js
+++ b/shared/domains/chelonia/internals.js
@@ -723,9 +723,6 @@ export default (sbp('sbp/selectors/register', {
 
           const cheloniaState = sbp(self.config.stateSelector)
 
-          if (!cheloniaState[v.contractID]) {
-            config.reactiveSet(cheloniaState, v.contractID, Object.create(null))
-          }
           const targetState = cheloniaState[v.contractID]
 
           let newestEncryptionKeyHeight = Number.POSITIVE_INFINITY
@@ -743,7 +740,7 @@ export default (sbp('sbp/selectors/register', {
                     transient
                   }])
                   if (
-                    targetState._vm?.authorizedKeys?.[key.id]?._notBeforeHeight != null &&
+                    targetState?._vm?.authorizedKeys?.[key.id]?._notBeforeHeight != null &&
                       Array.isArray(targetState._vm.authorizedKeys[key.id].purpose) &&
                       targetState._vm.authorizedKeys[key.id].purpose.includes('enc')
                   ) {

--- a/shared/domains/chelonia/utils.js
+++ b/shared/domains/chelonia/utils.js
@@ -551,6 +551,11 @@ export const getContractIDfromKeyId = (contractID: string, signingKeyId: ?string
 }
 
 export function eventsAfter (contractID: string, sinceHeight: number, limit?: number, sinceHash?: string): ReadableStream {
+  if (!contractID) {
+    // Avoid making a network roundtrip to tell us what we already know
+    throw new Error('Missing contract ID')
+  }
+
   const fetchEventsStreamReader = async () => {
     requestLimit = Math.min(limit ?? MAX_EVENTS_AFTER, remainingEvents)
     const eventsResponse = await fetch(`${this.config.connectionURL}/eventsAfter/${contractID}/${sinceHeight}${Number.isInteger(requestLimit) ? `/${requestLimit}` : ''}`, { signal })
@@ -756,7 +761,7 @@ export function verifyShelterAuthorizationHeader (authorization: string, rootSta
   }
   // TODO: Remember nonces and reject already used ones
   const [, data, contractID, timestamp, , signature] = matches
-  if (Math.abs(parseInt(timestamp) - (Date.now() / 1e3 | 0)) > 2) {
+  if (Math.abs(parseInt(timestamp) - (Date.now() / 1e3 | 0)) > 60) {
     throw new Error('Invalid signature time range')
   }
   if (!rootState) rootState = sbp('chelonia/rootState')


### PR DESCRIPTION
* eventsAfter: Reject early if the contractID is not set
* Fix instances causing such unset contractIDs
* Fix group members list to include members with only a contractID
* Don't set an empty contract state when receiving OP_KEY_SHARE
* Files: laxer validation when removing to process individual files separately