### PR TITLE
#2077 - Warn user about char limit in group description

### DIFF
--- a/frontend/model/contracts/shared/constants.js
+++ b/frontend/model/contracts/shared/constants.js
@@ -13,6 +13,9 @@ export const PROFILE_STATUS = {
   PENDING: 'pending', // shortly after being approved to join the group
   REMOVED: 'removed'
 }
+export const GROUP_DESCRIPTION_MAX_CHAR = 500
+
+// group-proposal related
 
 export const PROPOSAL_RESULT = 'proposal-result'
 export const PROPOSAL_INVITE_MEMBER = 'invite-member'

--- a/frontend/views/components/group-creation-steps/GroupPurpose.vue
+++ b/frontend/views/components/group-creation-steps/GroupPurpose.vue
@@ -3,18 +3,22 @@
   i18n.is-title-4.steps-title(tag='h4') 2. Group Purpose
 
   .card
-    label.field
-      i18n.label How would you describe your group?
+    label.field.c-label
+      .c-label-container
+        i18n.label How would you describe your group?
+        span.c-char-len(:class='{ "is-error": isFieldError }') {{ charLen }}
 
-      textarea.textarea(
+      textarea.textarea.c-textarea(
         name='sharedValues'
         ref='purpose'
         :placeholder='L("Group Purpose")'
+        :maxlength='config.maxChar'
         :class='{ error: isFieldError }'
         :value='group.sharedValues'
         v-error:sharedValues=''
         @input='update'
       )
+
       i18n.helper(v-if='!isFieldError') This is optional.
 
     slot
@@ -42,6 +46,10 @@ export default ({
   computed: {
     isFieldError () {
       return this.$v.form.sharedValues.$error
+    },
+    charLen () {
+      const len = this.group.sharedValues?.length || 0
+      return `${len}/${GROUP_DESCRIPTION_MAX_CHAR}`
     }
   },
   methods: {
@@ -56,3 +64,31 @@ export default ({
   }
 }: Object)
 </script>
+
+<style lang='scss' scoped>
+@import "@assets/style/_variables.scss";
+
+.c-label-container {
+  position: relative;
+  display: flex;
+  column-gap: 0.5rem;
+  align-items: flex-end;
+
+  .label {
+    flex-grow: 1;
+  }
+
+  .c-char-len {
+    display: inline-block;
+    line-height: $size_4;
+    font-size: $size_5;
+    color: $text_1;
+    flex-shrink: 0;
+    margin-bottom: 0.625rem;
+
+    &.is-error {
+      color: $danger_0;
+    }
+  }
+}
+</style>

--- a/frontend/views/components/group-creation-steps/GroupPurpose.vue
+++ b/frontend/views/components/group-creation-steps/GroupPurpose.vue
@@ -10,17 +10,19 @@
         name='sharedValues'
         ref='purpose'
         :placeholder='L("Group Purpose")'
-        maxlength='500'
-        :class='{ error: $v.form.sharedValues.$error }'
+        :class='{ error: isFieldError }'
         :value='group.sharedValues'
+        v-error:sharedValues=''
         @input='update'
       )
-      i18n.helper This is optional.
+      i18n.helper(v-if='!isFieldError') This is optional.
 
     slot
 </template>
 
 <script>
+import { GROUP_DESCRIPTION_MAX_CHAR } from '@model/contracts/shared/constants.js'
+
 export default ({
   name: 'GroupPurpose',
   props: {
@@ -29,6 +31,18 @@ export default ({
   },
   mounted () {
     this.$refs.purpose.focus()
+  },
+  data () {
+    return {
+      config: {
+        maxChar: GROUP_DESCRIPTION_MAX_CHAR
+      }
+    }
+  },
+  computed: {
+    isFieldError () {
+      return this.$v.form.sharedValues.$error
+    }
   },
   methods: {
     update (e) {

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -166,7 +166,7 @@ export default ({
       groupName: { required },
       groupPicture: { },
       sharedValues: {
-        [L('Group purpose cannot exceed {maxchar} characters', { maxChar: GROUP_DESCRIPTION_MAX_CHAR })]: maxLength(GROUP_DESCRIPTION_MAX_CHAR) 
+        [L('Group purpose cannot exceed {maxchar} characters', { maxChar: GROUP_DESCRIPTION_MAX_CHAR })]: maxLength(GROUP_DESCRIPTION_MAX_CHAR)
       },
       mincomeAmount: {
         [L('This field is required')]: required,

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -166,7 +166,7 @@ export default ({
       groupName: { required },
       groupPicture: { },
       sharedValues: {
-        [L('Group purpose cannot exceed {maxchar} characters', { maxChar: GROUP_DESCRIPTION_MAX_CHAR })]: maxLength(GROUP_DESCRIPTION_MAX_CHAR)
+        [L('Group purpose cannot exceed {maxchar} characters', { maxchar: GROUP_DESCRIPTION_MAX_CHAR })]: maxLength(GROUP_DESCRIPTION_MAX_CHAR)
       },
       mincomeAmount: {
         [L('This field is required')]: required,

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -53,7 +53,7 @@ import { validationMixin } from 'vuelidate'
 import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import { RULE_PERCENTAGE } from '@model/contracts/shared/voting/rules.js'
 import proposals from '@model/contracts/shared/voting/proposals.js'
-import { PROPOSAL_GENERIC } from '@model/contracts/shared/constants.js'
+import { PROPOSAL_GENERIC, GROUP_DESCRIPTION_MAX_CHAR } from '@model/contracts/shared/constants.js'
 import currencies, { mincomePositive, normalizeCurrency } from '@model/contracts/shared/currencies.js'
 import { L } from '@common/common.js'
 import { dateToPeriodStamp, addTimeToDate, DAYS_MILLIS } from '@model/contracts/shared/time.js'
@@ -71,7 +71,7 @@ import {
 // we use require instead of import with this file to make rollup happy
 // or not... using require only makes rollup happy during compilation
 // but then the browser complains about "require is not defined"
-import { required, between } from 'vuelidate/lib/validators'
+import { required, between, maxLength } from 'vuelidate/lib/validators'
 
 export default ({
   name: 'GroupCreationModal',
@@ -165,7 +165,9 @@ export default ({
     form: {
       groupName: { required },
       groupPicture: { },
-      sharedValues: { },
+      sharedValues: {
+        [L('Group purpose cannot exceed {maxchar} characters', { maxChar: GROUP_DESCRIPTION_MAX_CHAR })]: maxLength(GROUP_DESCRIPTION_MAX_CHAR) 
+      },
       mincomeAmount: {
         [L('This field is required')]: required,
         [L('The amount must be a number. (E.g. 100.75)')]: function (value) {

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -15,7 +15,7 @@ page.c-page
         i18n.label Group name
         input.input(
           type='text'
-          :class='{error: $v.form.groupName.$error}'
+          :class='{ error: $v.form.groupName.$error }'
           v-model='form.groupName'
           @input='debounceField("groupName")'
           @blur='updateField("groupName")'
@@ -24,10 +24,17 @@ page.c-page
         )
 
       label.field
-        i18n.label About the group
+        .c-desc-label-container
+          i18n.label About the group
+          span.c-char-len(:class='{ "is-error": $v.form.sharedValues.$error }') {{ descCharLen }}
+
         textarea.textarea(
-          maxlength='500'
+          :class='{ error: $v.form.sharedValues.$error }'
+          :maxlength='config.descMaxChar'
           v-model='form.sharedValues'
+          v-error:sharedValues = ''
+          @input='debounceField("sharedValues")'
+          @blur='updateField("sharedValues")'
           data-test='sharedValues'
         )
 
@@ -113,7 +120,7 @@ import { validationMixin } from 'vuelidate'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
 import { mapState, mapGetters } from 'vuex'
 import { OPEN_MODAL } from '@utils/events.js'
-import { required } from 'vuelidate/lib/validators'
+import { required, maxLength } from 'vuelidate/lib/validators'
 import currencies from '@model/contracts/shared/currencies.js'
 import Page from '@components/Page.vue'
 import PageSection from '@components/PageSection.vue'
@@ -122,6 +129,7 @@ import InvitationsTable from '@containers/group-settings/InvitationsTable.vue'
 import GroupRulesSettings from '@containers/group-settings/GroupRulesSettings.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
+import { GROUP_DESCRIPTION_MAX_CHAR } from '@model/contracts/shared/constants.js'
 import { L } from '@common/common.js'
 
 export default ({
@@ -143,6 +151,9 @@ export default ({
         groupName,
         sharedValues,
         mincomeCurrency
+      },
+      config: {
+        descMaxChar: GROUP_DESCRIPTION_MAX_CHAR
       },
       allowPublicChannels: false
     }
@@ -167,6 +178,10 @@ export default ({
     configurePublicChannel () {
       // TODO: check if Chelonia server admin allows to create public channels
       return this.isGroupAdmin && false
+    },
+    descCharLen () {
+      const len = this.form.sharedValues?.length || 0
+      return `${len}/${GROUP_DESCRIPTION_MAX_CHAR}`
     }
   },
   mounted () {
@@ -231,6 +246,9 @@ export default ({
     form: {
       groupName: {
         [L('This field is required')]: required
+      },
+      sharedValues: {
+        [L('Group description cannot exceed {maxchar} characters', { maxchar: GROUP_DESCRIPTION_MAX_CHAR })]: maxLength(GROUP_DESCRIPTION_MAX_CHAR)
       }
     }
   },
@@ -248,6 +266,30 @@ export default ({
 
 .c-page ::v-deep .p-main {
   max-width: 37rem;
+}
+
+.c-desc-label-container {
+  position: relative;
+  display: flex;
+  column-gap: 0.5rem;
+  align-items: flex-end;
+
+  .label {
+    flex-grow: 1;
+  }
+
+  .c-char-len {
+    display: inline-block;
+    line-height: $size_4;
+    font-size: $size_5;
+    color: $text_1;
+    flex-shrink: 0;
+    margin-bottom: 0.625rem;
+
+    &.is-error {
+      color: $danger_0;
+    }
+  }
 }
 
 .c-currency {


### PR DESCRIPTION
closes #2077 

Add below character length indication UI to both group-creation Modal and also to `/group-settings` page.

**-> Group-Creation step**

<img src='https://github.com/okTurtles/group-income/assets/17641213/35a09d38-cd97-4aeb-8fb1-e1fc8d52bf77' width='420'>

**-> `GroupSettings.vue`**

<img src='https://github.com/okTurtles/group-income/assets/17641213/08cdcda4-9148-483c-ae75-64e79b7e6e01' width='420'>

---
@taoeffect @dotmacro 

Normally, specifying maxlength HTML attribute to the `textarea` element will prevent user from entering more characters, just like **[this](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/maxlength#constraint_validation)** MDN doc says and how FireFox Dev edition behaves regarding it. But in case there is any browser out there where this is not how `maxlength` attribute behaves, I've added the in-app validation logic to both form so they show this error message when the description becomes longer than 500 characters.

<img src='https://github.com/okTurtles/group-income/assets/17641213/d3ecf4d1-ddbb-4731-8ed9-6cfcf860652b' width='420'>

Thanks,