### PR TITLE
Fix error to pin message in the older version of contracts

### DIFF
--- a/frontend/model/contracts/chatroom.js
+++ b/frontend/model/contracts/chatroom.js
@@ -730,6 +730,13 @@ sbp('chelonia/defineContract', {
         message: object
       })),
       process ({ data, innerSigningContractID }, { state }) {
+        // TODO: remove the below 'if' statement when no older version of contracts are being used
+        if (!state.pinnedMessages) {
+          // NOTE: this is temporary solution for the older version of contracts
+          //       that doesn't have 'pinnedMessages' field which is created in its constructor
+          state.pinnedMessages = []
+        }
+
         const { message } = data
         state.pinnedMessages.unshift(message)
 

--- a/frontend/model/contracts/shared/functions.js
+++ b/frontend/model/contracts/shared/functions.js
@@ -175,7 +175,7 @@ export function leaveChatRoom (contractID: string) {
   // contract (for DMs).
 }
 
-export function findMessageIdx (hash: string, messages: Array<Object>): number {
+export function findMessageIdx (hash: string, messages: Array<Object> = []): number {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].hash === hash) {
       return i


### PR DESCRIPTION
### Summary of Changes

- Fix error to pin messages in the older version of chatroom contracts which doesn't have `pinnedMessages` field in it's state