### PR TITLE
Enable source maps in production

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -239,7 +239,7 @@ module.exports = (grunt) => {
       minifySyntax: production,
       minifyWhitespace: production,
       outdir: distJS,
-      sourcemap: development,
+      sourcemap: true,
       // Warning: split mode has still a few issues. See https://github.com/okTurtles/group-income/pull/1196
       splitting: !grunt.option('no-chunks'),
       watch: false // Not using esbuild's own watch mode since it involves polling.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "group-income",
-  "version": "0.5.1",
+  "version": "0.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "group-income",
-      "version": "0.5.1",
+      "version": "0.5.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@babel/core": "7.23.7",


### PR DESCRIPTION
Closes #2045

### Summary of changes
- Enable source maps in default esbuild options when `NODE_ENV=production`.
- Bump `package-lock.json` version field to match `package.json`'s one (i.e. v.0.5.4).