### PR TITLE
#2130 - Chat rendering issue re handling '<' and '>' character

### DIFF
--- a/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
+++ b/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
@@ -11,8 +11,13 @@ export function htmlStringToDomObjectTree (htmlString: any): Array<DomObject> {
   // Refernce 2. (Converting html to virtual DOM): https://medium.com/@fulit103/converting-html-to-a-virtual-dom-in-javascript-3a6db0f563b1)
 
   const parser = new DOMParser()
+
+  // Below is a bug-fix for the issue #2130 (https://github.com/okTurtles/group-income/issues/2130)
+  // DOMParser.parseFromString() has some caveats re how it interprets &lt; and &gt;
+  // so manually wrap them with <span> tags
   htmlString = htmlString.replaceAll('&lt;', '<span>&lt;</span>')
     .replaceAll('&gt;', '<span>&gt;</span>')
+
   const doc = parser.parseFromString(htmlString, 'text/html')
   const rootNode = doc.body
 

--- a/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
+++ b/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
@@ -5,7 +5,7 @@ export type DomObject = {
   children?: Array<DomObject>
 }
 
-export function htmlStringToDomObjectTree (htmlString: any): Array<DomObject> {
+export function htmlStringToDomObjectTree (htmlString: string): Array<DomObject> {
   // Use DOMParser to parse the HTML string into a DOM tree.
   // Reference 1. (DOMParser API): https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
   // Refernce 2. (Converting html to virtual DOM): https://medium.com/@fulit103/converting-html-to-a-virtual-dom-in-javascript-3a6db0f563b1)
@@ -15,6 +15,7 @@ export function htmlStringToDomObjectTree (htmlString: any): Array<DomObject> {
   // Below is a bug-fix for the issue #2130 (https://github.com/okTurtles/group-income/issues/2130)
   // DOMParser.parseFromString() has some caveats re how it interprets &lt; and &gt;
   // so manually wrap them with <span> tags
+  // $FlowFixMe[prop-missing]
   htmlString = htmlString.replaceAll('&lt;', '<span>&lt;</span>')
     .replaceAll('&gt;', '<span>&gt;</span>')
 

--- a/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
+++ b/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
@@ -5,12 +5,14 @@ export type DomObject = {
   children?: Array<DomObject>
 }
 
-export function htmlStringToDomObjectTree (htmlString: string): Array<DomObject> {
+export function htmlStringToDomObjectTree (htmlString: any): Array<DomObject> {
   // Use DOMParser to parse the HTML string into a DOM tree.
   // Reference 1. (DOMParser API): https://developer.mozilla.org/en-US/docs/Web/API/DOMParser
   // Refernce 2. (Converting html to virtual DOM): https://medium.com/@fulit103/converting-html-to-a-virtual-dom-in-javascript-3a6db0f563b1)
 
   const parser = new DOMParser()
+  htmlString = htmlString.replaceAll('&lt;', '<span>&lt;</span>')
+    .replaceAll('&gt;', '<span>&gt;</span>')
   const doc = parser.parseFromString(htmlString, 'text/html')
   const rootNode = doc.body
 

--- a/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
+++ b/frontend/views/containers/chatroom/chat-mentions/chat-mentions-utils.js
@@ -14,7 +14,7 @@ export function htmlStringToDomObjectTree (htmlString: string): Array<DomObject>
 
   // Below is a bug-fix for the issue #2130 (https://github.com/okTurtles/group-income/issues/2130)
   // DOMParser.parseFromString() has some caveats re how it interprets &lt; and &gt;
-  // so manually wrap them with <span> tags
+  // so manually wrap them with <span> tags.
   // $FlowFixMe[prop-missing]
   htmlString = htmlString.replaceAll('&lt;', '<span>&lt;</span>')
     .replaceAll('&gt;', '<span>&gt;</span>')

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -29,6 +29,7 @@ export function renderMarkdown (str: string): any {
   // markedjs with the gfm(Github Flavored Markdown) style always collapses multiple line-breaks into one
   // so we need some custom logic to handle it manually.
   // (Reference issue here: https://github.com/markedjs/marked/issues/190)
+  str = str.replace(/</g, '&lt;').replace(/>/g, '&gt;')
   str = str.replace(/\n(?=\n)/g, '\n<br>')
     .replace(/<br>\n(\s*)(\d+\.|-|```)/g, '\n\n$1$2') // custom-handling the case where <br> is directly followed by the start of block-code (```)
     .replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // this is a custom-logic added so that the end of ordered/un-ordered lists are correctly detected by markedjs.

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -29,7 +29,12 @@ export function renderMarkdown (str: string): any {
   // markedjs with the gfm(Github Flavored Markdown) style always collapses multiple line-breaks into one
   // so we need some custom logic to handle it manually.
   // (Reference issue here: https://github.com/markedjs/marked/issues/190)
+
+  // There is some caveats discovered with 'dompurify' and DOMParser() API regarding how they interpret '<' and '>' characters.
+  // So manually converting them to '&lt;' and '&gt;' here first.
+  // (context: https://github.com/okTurtles/group-income/issues/2130)
   str = str.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+
   str = str.replace(/\n(?=\n)/g, '\n<br>')
     .replace(/<br>\n(\s*)(\d+\.|-|```)/g, '\n\n$1$2') // custom-handling the case where <br> is directly followed by the start of block-code (```)
     .replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // this is a custom-logic added so that the end of ordered/un-ordered lists are correctly detected by markedjs.

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -32,7 +32,7 @@ export function renderMarkdown (str: string): any {
 
   // There is some caveats discovered with 'dompurify' and DOMParser() API regarding how they interpret '<' and '>' characters.
   // So manually converting them to '&lt;' and '&gt;' here first.
-  // (context: https://github.com/okTurtles/group-income/issues/2130)
+  // ( context: https://github.com/okTurtles/group-income/issues/2130 )
   str = str.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
   str = str.replace(/\n(?=\n)/g, '\n<br>')


### PR DESCRIPTION
closes #2130 

[ proof of fix ]

<img src='https://github.com/okTurtles/group-income/assets/17641213/e3fabc1c-194c-4722-a191-de460769ea89' width='420'>

@taoeffect (cc. @corrideat )
That was a bug caused by caveats in how `dompurify` and `parseFromString` method of the DOMParser API ([reference](https://developer.mozilla.org/en-US/docs/Web/API/DOMParser/parseFromString)) interpret `<'`,`>` and also `&lt;` and `&gt;` characters. So had to make updates to two places to take them into account. 