### PR TITLE
#2145 - Prevent creation of multiple duplicate groups

### DIFF
--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -119,9 +119,14 @@ export default ({
             distributionDate: this.form.distributionDate
           }
         })
+
         this.$router.push({
           path: '/pending-approval',
-          query: this.$route.query
+          // NOTE: during a series of consecutive async steps of group-creation, error can occur that leads to displaying 'Prompt.vue' pop-up.
+          //       in that case, leave that pop-up open. (reference: https://github.com/okTurtles/group-income/pull/2091) 
+          query: this.$route.query?.modal === 'Prompt'
+            ? this.$route.query
+            : undefined
         })
       } catch (e) {
         console.error('CreateGroup.vue submit() error:', e)

--- a/frontend/views/containers/group-settings/GroupCreationModal.vue
+++ b/frontend/views/containers/group-settings/GroupCreationModal.vue
@@ -123,7 +123,7 @@ export default ({
         this.$router.push({
           path: '/pending-approval',
           // NOTE: during a series of consecutive async steps of group-creation, error can occur that leads to displaying 'Prompt.vue' pop-up.
-          //       in that case, leave that pop-up open. (reference: https://github.com/okTurtles/group-income/pull/2091) 
+          //       in that case, leave that pop-up open. (reference: https://github.com/okTurtles/group-income/pull/2091)
           query: this.$route.query?.modal === 'Prompt'
             ? this.$route.query
             : undefined


### PR DESCRIPTION
closes #2145 

Firstly, this issue was brought in from my previous PR [here](https://github.com/okTurtles/group-income/pull/2091/files#diff-b6d1ebb068be3ba75078591e07897965f90da5d4e7da3252ec728448a9993ce7).

The reason why I added that change back then was to fix below
**A.** An error is thrown during the chain of 'group-creation' related async operations.
**B.** it leads to `Prompt.vue` pop-up showing that error detail to the user.
**C.** But then that router-navigation to `/pending-approval` gets executed which abruptly closing the prompt.
**D.** Due to the error occurred in **A.** above, the user gets permanently stuck in the `/pending-approval` page, without knowing what's happened.

So I updated the relevant part again with some comment.

