### PR TITLE
#2143 remove channel deletion message / Fix the bug re mentioning a deleted channel

### DIFF
--- a/frontend/assets/style/_icons.scss
+++ b/frontend/assets/style/_icons.scss
@@ -5,6 +5,7 @@ $icons: (
   angle-left: "\f104",
   angle-down: "\f107",
   arrow-right: "\f061",
+  ban: "\f05e",
   bars: "\f0c9",
   bell: "\f0f3",
   bold: "\f032",

--- a/frontend/model/contracts/shared/constants.js
+++ b/frontend/model/contracts/shared/constants.js
@@ -89,7 +89,6 @@ export const MESSAGE_NOTIFICATIONS = {
   KICK_MEMBER: 'kick-member',
   UPDATE_DESCRIPTION: 'update-description',
   UPDATE_NAME: 'update-name',
-  DELETE_CHANNEL: 'delete-channel',
   VOTE_ON_POLL: 'vote-on-poll',
   CHANGE_VOTE_ON_POLL: 'change-vote-on-poll'
 }

--- a/frontend/views/containers/chatroom/DeleteChannelModal.vue
+++ b/frontend/views/containers/chatroom/DeleteChannelModal.vue
@@ -44,7 +44,6 @@ import BannerSimple from '@components/banners/BannerSimple.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
-import { MESSAGE_TYPES, MESSAGE_NOTIFICATIONS } from '@model/contracts/shared/constants.js'
 
 export default ({
   name: 'DeleteChannelModal',
@@ -80,21 +79,7 @@ export default ({
           data: { chatRoomID },
           hooks: {
             postpublish: (message) => {
-              const contractID = this.groupGeneralChatRoomId
               // TODO: This should be moved to a side-effect
-              sbp('gi.actions/chatroom/addMessage', {
-                contractID,
-                data: {
-                  type: MESSAGE_TYPES.NOTIFICATION,
-                  notification: {
-                    type: MESSAGE_NOTIFICATIONS.DELETE_CHANNEL,
-                    channelName: this.chatRoomAttributes.name,
-                    channelDescription: this.chatRoomAttributes.description
-                  }
-                }
-              }).catch(e => {
-                console.log(`Error sending chatroom removal notification to ${contractID} for ${chatRoomID}`, e)
-              })
               sbp('gi.actions/chatroom/delete', { contractID: chatRoomID, data: {} }).catch(e => {
                 console.log(`Error sending chatroom removal action for ${chatRoomID}`, e)
               })

--- a/frontend/views/containers/chatroom/MessageNotification.vue
+++ b/frontend/views/containers/chatroom/MessageNotification.vue
@@ -77,8 +77,7 @@ export default ({
           [MESSAGE_NOTIFICATIONS.KICK_MEMBER]: L('Kicked a member from {title}: {displayName}', { displayName, title: channelName }),
           [MESSAGE_NOTIFICATIONS.UPDATE_NAME]: L('Updated the channel name to: {title}', { title: channelName }),
           [MESSAGE_NOTIFICATIONS.UPDATE_DESCRIPTION]:
-            L('Updated the channel description to: {description}', { description: channelDescription }),
-          [MESSAGE_NOTIFICATIONS.DELETE_CHANNEL]: L('Deleted the channel: {title}', { title: channelName })
+            L('Updated the channel description to: {description}', { description: channelDescription })
         }
       }
       const pollNotificationTemplates = {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -643,7 +643,7 @@ export default ({
       }
       const convertChannelMentionToId = name => {
         const found = this.mentionableChatroomsInDetails.find(entry => entry.name === name)
-        return found ? makeChannelMention(found.id) : ''
+        return found ? makeChannelMention(found.id, true) : ''
       }
       const convertAllMentions = str => {
         return str.replace(

--- a/frontend/views/pages/DesignSystem.vue
+++ b/frontend/views/pages/DesignSystem.vue
@@ -169,6 +169,7 @@ page(
               i.icon-angle-left icon-angle-left
               i.icon-angle-down icon-angle-down
               i.icon-arrow-right icon-arrow-right
+              i.icon-ban icon-ban
               i.icon-bars icon-bars
               i.icon-bell icon-bell
               i.icon-bold icon-bold

--- a/test/cypress/integration/group-chat.spec.js
+++ b/test/cypress/integration/group-chat.spec.js
@@ -136,10 +136,6 @@ describe('Group Chat Basic Features (Create & Join & Leave & Close)', () => {
     cy.getByDT('deleteChannelSubmit').click()
     cy.getByDT('closeModal').should('not.exist')
     cy.getByDT('channelName').should('contain', CHATROOM_GENERAL_NAME)
-    cy.getByDT('conversationWrapper').within(() => {
-      cy.get('div.c-message:last-child .c-who > span:first-child').should('contain', me)
-      cy.get('div.c-message:last-child .c-notification').should('contain', `Deleted the channel: ${channelName}`)
-    })
   }
 
   function updateName (name) {


### PR DESCRIPTION
closes #2143 

@taoeffect 
As I mentioned in the issue too, made a bug-fix for mentioning a deleted channel too, like below.

<img src='https://github.com/okTurtles/group-income/assets/17641213/85fb3360-b8ca-4d48-9cd5-4d02d6109907' width='430'>

It will say, 'Unknown chatroom' instead as in the screenshot. But please let me know if you want to present it otherwise.

---
As part of the bug-fix I had to modify how the app convert/interpret the channel mention.
It currently `#chatroom-1` -> `#chatroomId` before storing the message text in the contract. 
But later if it wants to convert it back to `#chatroom-1` but then chatroom has been deleted, The app can't find the chatroom data with that ID and interprets this `#chatroomId` as **a plain text** instead as a result.

To fix this, I updated it to do `#chatroom-1` -> **`#:chatID:chatroomId`** instead.
This way, if the app can't find the data with the `chatroomId` it still knows this text was a channel mention and present it as an unknown chatroom.

Hope it sounds good.