### PR TITLE
#2179 - bugfix for identityContract syncing failure not being notified

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -48,7 +48,7 @@ import './utils/touchInteractions.js'
 import { showNavMixin } from './views/utils/misc.js'
 import './views/utils/vStyle.js'
 
-const { Vue, L, LTags, LError } = Common
+const { Vue, L, LError } = Common
 
 console.info('GI_VERSION:', process.env.GI_VERSION)
 console.info('CONTRACTS_VERSION:', process.env.CONTRACTS_VERSION)
@@ -540,9 +540,7 @@ async function startApp () {
 
         sbp('gi.ui/prompt', {
           heading: L('Failed to login'),
-          question: e.message
-            ? L('Error details:{br_}{err}', { err: e.message, ...LTags() })
-            : L('Error details: {reportError}', ...LError(e)),
+          question: L('Error details: {reportError}', LError(e)),
           primaryButton: L('Close')
         })
       }).finally(() => {

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -48,7 +48,7 @@ import './utils/touchInteractions.js'
 import { showNavMixin } from './views/utils/misc.js'
 import './views/utils/vStyle.js'
 
-const { Vue, L } = Common
+const { Vue, L, LTags, LError } = Common
 
 console.info('GI_VERSION:', process.env.GI_VERSION)
 console.info('CONTRACTS_VERSION:', process.env.CONTRACTS_VERSION)
@@ -534,12 +534,17 @@ async function startApp () {
         await syncContractsInOrder(identityContractID, contractIDs)
 
         if (this.ephemeral.finishedLogin === 'yes') return
-        return sbp('gi.app/identity/login', { identityContractID }).catch((e) => {
-          console.error(`[main] caught ${e?.name} while logging in: ${e?.message || e}`, e)
-          console.warn(`It looks like the local user '${identityContractID}' does not exist anymore on the server 😱 If this is unexpected, contact us at https://gitter.im/okTurtles/group-income`)
-        })
+        return sbp('gi.app/identity/login', { identityContractID })
       }).catch(e => {
         console.error(`[main] caught ${e?.name} while fetching settings or handling a login error: ${e?.message || e}`, e)
+
+        sbp('gi.ui/prompt', {
+          heading: L('Failed to login'),
+          question: e.message
+            ? L('Error details:{br_}{err}', { err: e.message, ...LTags() })
+            : L('Error details: {reportError}', ...LError(e)),
+          primaryButton: L('Close')
+        })
       }).finally(() => {
         this.ephemeral.ready = true
         this.removeLoadingAnimation()

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -10,7 +10,7 @@ import type { GIKey, GIOpActionUnencrypted, GIOpContract, GIOpKeyAdd, GIOpKeyDel
 import type { Key } from './crypto.js'
 import { EDWARDS25519SHA512BATCH, deserializeKey, keyId, keygen, serializeKey } from './crypto.js'
 import { ChelErrorUnexpected, ChelErrorUnrecoverable } from './errors.js'
-import { CONTRACTS_MODIFIED, CONTRACT_REGISTERED, CONTRACT_IS_SYNCING } from './events.js'
+import { CONTRACTS_MODIFIED, CONTRACT_REGISTERED } from './events.js'
 // TODO: rename this to ChelMessage
 import { GIMessage } from './GIMessage.js'
 import type { Secret } from './Secret.js'
@@ -812,7 +812,6 @@ export default (sbp('sbp/selectors/register', {
         'chelonia/private/in/syncContract', contractID, params
       ]).catch((err) => {
         console.error(`[chelonia] failed to sync ${contractID}:`, err)
-        sbp('okTurtles.events/emit', CONTRACT_IS_SYNCING, contractID, false)
         throw err // re-throw the error
       })
     }))

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -10,7 +10,7 @@ import type { GIKey, GIOpActionUnencrypted, GIOpContract, GIOpKeyAdd, GIOpKeyDel
 import type { Key } from './crypto.js'
 import { EDWARDS25519SHA512BATCH, deserializeKey, keyId, keygen, serializeKey } from './crypto.js'
 import { ChelErrorUnexpected, ChelErrorUnrecoverable } from './errors.js'
-import { CONTRACTS_MODIFIED, CONTRACT_REGISTERED } from './events.js'
+import { CONTRACTS_MODIFIED, CONTRACT_REGISTERED, CONTRACT_IS_SYNCING } from './events.js'
 // TODO: rename this to ChelMessage
 import { GIMessage } from './GIMessage.js'
 import type { Secret } from './Secret.js'
@@ -812,6 +812,7 @@ export default (sbp('sbp/selectors/register', {
         'chelonia/private/in/syncContract', contractID, params
       ]).catch((err) => {
         console.error(`[chelonia] failed to sync ${contractID}:`, err)
+        sbp('okTurtles.events/emit', CONTRACT_IS_SYNCING, contractID, false)
         throw err // re-throw the error
       })
     }))

--- a/shared/domains/chelonia/internals.js
+++ b/shared/domains/chelonia/internals.js
@@ -1129,22 +1129,23 @@ export default (sbp('sbp/selectors/register', {
   },
   'chelonia/private/in/syncContract': async function (contractID: string, params?: { force?: boolean, resync?: boolean }) {
     const state = sbp(this.config.stateSelector)
-    this.currentSyncs[contractID] = { firstSync: !state.contracts[contractID]?.type }
-    sbp('okTurtles.events/emit', CONTRACT_IS_SYNCING, contractID, true)
-    const currentVolatileState = state[contractID]?._volatile || Object.create(null)
-    // If the dirty flag is set (indicating that new encryption keys were received),
-    // we remove the current state before syncing (this has the effect of syncing
-    // from the beginning, recreating the entire state). When this is the case,
-    // the _volatile state is preserved
-    if (currentVolatileState?.dirty || params?.resync) {
-      delete currentVolatileState.dirty
-      currentVolatileState.resyncing = true
-      sbp('chelonia/private/removeImmediately', contractID, { resync: true })
-      this.config.reactiveSet(state, contractID, Object.create(null))
-      this.config.reactiveSet(state[contractID], '_volatile', currentVolatileState)
-    }
 
     try {
+      this.currentSyncs[contractID] = { firstSync: !state.contracts[contractID]?.type }
+      sbp('okTurtles.events/emit', CONTRACT_IS_SYNCING, contractID, true)
+      const currentVolatileState = state[contractID]?._volatile || Object.create(null)
+      // If the dirty flag is set (indicating that new encryption keys were received),
+      // we remove the current state before syncing (this has the effect of syncing
+      // from the beginning, recreating the entire state). When this is the case,
+      // the _volatile state is preserved
+      if (currentVolatileState?.dirty || params?.resync) {
+        delete currentVolatileState.dirty
+        currentVolatileState.resyncing = true
+        sbp('chelonia/private/removeImmediately', contractID, { resync: true })
+        this.config.reactiveSet(state, contractID, Object.create(null))
+        this.config.reactiveSet(state[contractID], '_volatile', currentVolatileState)
+      }
+
       const { HEAD: latestHEAD } = await sbp('chelonia/out/latestHEADInfo', contractID)
       console.debug(`[chelonia] syncContract: ${contractID} latestHash is: ${latestHEAD}`)
       // there is a chance two users are logged in to the same machine and must check their contracts before syncing


### PR DESCRIPTION
closes #2179 

<img src='https://github.com/okTurtles/group-income/assets/17641213/4e178668-7084-4b81-8745-00be06dd632d' width='430'>

When this issue happens in `main.js` as a result of below async operation,
https://github.com/okTurtles/group-income/blob/1e959f059e07ca1d2278eb76fc176e6a71bebb1d/frontend/main.js#L532

It (the root component) needs to be notified of it so it can filters out that failed `identityContractID` from the `this.ephemeral.syncs` array.
