### PR TITLE
#2144 - Updating user avatar while group settings is open updates both avatars

### DIFF
--- a/frontend/views/components/AvatarUpload.vue
+++ b/frontend/views/components/AvatarUpload.vue
@@ -34,6 +34,10 @@ export default ({
     sbpParams: {
       type: Object,
       required: true
+    },
+    avatarType: {
+      type: String,
+      validator: v => ['user', 'group'].includes(v) // feel free to extend this list.
     }
   },
   components: {
@@ -45,9 +49,10 @@ export default ({
       if (!fileList.length) return
       const imageUrl = URL.createObjectURL(fileList[0])
 
-      sbp('okTurtles.events/emit', OPEN_MODAL, 'AvatarEditorModal', { imageUrl })
+      sbp('okTurtles.events/emit', OPEN_MODAL, 'AvatarEditorModal', { imageUrl, avatarType: this.avatarType })
     },
-    async uploadEditedImage ({ blob }) {
+    async uploadEditedImage ({ blob, avatarType }) {
+      if (avatarType !== this.avatarType) { return }
       let picture
 
       try {

--- a/frontend/views/components/avatar-editor/AvatarEditorModal.vue
+++ b/frontend/views/components/avatar-editor/AvatarEditorModal.vue
@@ -122,7 +122,7 @@ export default ({
     },
     submit () {
       const blob = this.$refs.editorCanvas.extractEditedImage()
-      sbp('okTurtles.events/emit', AVATAR_EDITED, { blob })
+      sbp('okTurtles.events/emit', AVATAR_EDITED, { blob, avatarType: this.$route.query.avatarType || '' })
 
       this.close()
     },

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -5,6 +5,7 @@
     avatar-upload(
       :avatar='attributes.picture'
       :sbpParams='sbpParams'
+      avatar-type='user'
     )
 
     section.card

--- a/frontend/views/pages/GroupSettings.vue
+++ b/frontend/views/pages/GroupSettings.vue
@@ -7,6 +7,7 @@ page.c-page
   avatar-upload(
     :avatar='$store.getters.groupSettings.groupPicture'
     :sbpParams='sbpParams'
+    avatar-type='group'
   )
 
   page-section


### PR DESCRIPTION
closes #2144 (great catch @dotmacro, btw. This is something I implemented a while ago.)

`AvatarUpload.vue` subscribes to `AVATAR_EDITED` for when the user is done with editing the image. But then, when two components that have `AvatarUpload.vue` are both in the screen, they all end up listening to this event and updating the avatar at the same time.
As a fix, I've placed `avatarType` prop in the event payload as an identifier, so that the component knows whether the event is meant for it or not.