### PR TITLE
#2192 Remove email from signup

### DIFF
--- a/frontend/model/contracts/identity.js
+++ b/frontend/model/contracts/identity.js
@@ -25,7 +25,7 @@ import {
 
 const attributesType = objectMaybeOf({
   username: stringMax(IDENTITY_USERNAME_MAX_CHARS, 'username'),
-  email: stringMax(IDENTITY_EMAIL_MAX_CHARS, 'email'),
+  email: optional(stringMax(IDENTITY_EMAIL_MAX_CHARS, 'email')),
   bio: optional(stringMax(IDENTITY_BIO_MAX_CHARS, 'bio')),
   picture: unionOf(stringMax(MAX_URL_LEN), objectOf({
     manifestCid: stringMax(MAX_HASH_LEN, 'manifestCid'),

--- a/frontend/model/contracts/identity.js
+++ b/frontend/model/contracts/identity.js
@@ -25,7 +25,7 @@ import {
 
 const attributesType = objectMaybeOf({
   username: stringMax(IDENTITY_USERNAME_MAX_CHARS, 'username'),
-  email: optional(stringMax(IDENTITY_EMAIL_MAX_CHARS, 'email')),
+  email: optional(stringMax(IDENTITY_EMAIL_MAX_CHARS, 'email')), // https://github.com/okTurtles/group-income/issues/2192
   bio: optional(stringMax(IDENTITY_BIO_MAX_CHARS, 'bio')),
   picture: unionOf(stringMax(MAX_URL_LEN), objectOf({
     manifestCid: stringMax(MAX_HASH_LEN, 'manifestCid'),

--- a/frontend/views/containers/access/SignupForm.vue
+++ b/frontend/views/containers/access/SignupForm.vue
@@ -13,19 +13,6 @@ form(data-test='signup' @submit.prevent='')
       v-error:username='{ attrs: { "data-test": "badUsername" } }'
     )
 
-  label.field
-    i18n.label Email
-    input.input(
-      :class='{error: $v.form.email.$error}'
-      name='email'
-      type='email'
-      v-model.trim='form.email'
-      @input='debounceField("email")'
-      @blur='updateField("email")'
-      data-test='signEmail'
-      v-error:email='{ attrs: { "data-test": "badEmail" } }'
-    )
-
   .c-password-fields-container
     password-form(:label='L("Password")' name='password' :$v='$v')
 
@@ -56,7 +43,7 @@ form(data-test='signup' @submit.prevent='')
 <script>
 import sbp from '@sbp/sbp'
 import { L } from '@common/common.js'
-import { email, maxLength, minLength, required, sameAs } from 'vuelidate/lib/validators'
+import { maxLength, minLength, required, sameAs } from 'vuelidate/lib/validators'
 import { validationMixin } from 'vuelidate'
 import PasswordForm from '@containers/access/PasswordForm.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
@@ -118,7 +105,6 @@ export default ({
     return {
       form: {
         username: '',
-        email: '',
         password: '',
         passwordConfirm: '',
         terms: false,
@@ -140,7 +126,6 @@ export default ({
       try {
         await sbp('gi.app/identity/signupAndLogin', {
           username: this.form.username,
-          email: this.form.email,
           password: new Secret(this.form.password)
         })
         await this.postSubmit()
@@ -195,10 +180,6 @@ export default ({
         },
         passwordConfirm: {
           [L('Passwords do not match.')]: sameAs('password')
-        },
-        email: {
-          [L('An email is required.')]: required,
-          [L('Please enter a valid email.')]: email
         },
         terms: {
           [L('You need to agree to the terms and conditions.')]: (value) => {

--- a/frontend/views/containers/user-settings/NotificationSettings.vue
+++ b/frontend/views/containers/user-settings/NotificationSettings.vue
@@ -14,18 +14,6 @@
             :checked='pushNotificationGranted'
             @change='handleNotificationSettings'
           )
-      i18n.is-title-3.c-title(tag='h2') Email notifications
-      .c-divider
-      .c-subcontent
-        .c-text-content
-          i18n.c-smaller-title(tag='h3') Allow email notifications
-          i18n.c-description(tag='p') Know when new proposals are created, their income and get a reminder to vote if they are about to expire.
-        .switch-wrapper
-          input.switch(
-            type='checkbox'
-            name='switch'
-            :checked='emailNotificationGranted'
-          )
 </template>
 
 <script>
@@ -40,8 +28,7 @@ export default ({
   name: 'NotificationSettings',
   data () {
     return {
-      pushNotificationGranted: false,
-      emailNotificationGranted: true
+      pushNotificationGranted: false
     }
   },
   mounted () {

--- a/frontend/views/containers/user-settings/UserProfile.vue
+++ b/frontend/views/containers/user-settings/UserProfile.vue
@@ -40,19 +40,6 @@
           )
 
         label.field
-          i18n.label Email
-          input.input(
-            :class='{error: $v.form.email.$error}'
-            name='email'
-            type='email'
-            v-model='form.email'
-            @input='debounceField("email")'
-            @blur='updateField("email")'
-            data-test='profileEmail'
-            v-error:email='{ attrs: { "data-test": "badEmail" } }'
-          )
-
-        label.field
           i18n.label Password
           .fake-password(aria-hidden='true') **********
 
@@ -91,7 +78,6 @@
 import sbp from '@sbp/sbp'
 import { validationMixin } from 'vuelidate'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
-import { required, email } from 'vuelidate/lib/validators'
 import { OPEN_MODAL } from '@utils/events.js'
 import { cloneDeep } from '@model/contracts/shared/giLodash.js'
 import { mapGetters, mapState } from 'vuex'
@@ -117,8 +103,7 @@ export default ({
     return {
       form: {
         displayName: attrsCopy.displayName,
-        bio: attrsCopy.bio,
-        email: attrsCopy.email
+        bio: attrsCopy.bio
       },
       config: {
         bioMaxChar: IDENTITY_BIO_MAX_CHARS
@@ -127,10 +112,6 @@ export default ({
   },
   validations: {
     form: {
-      email: {
-        [L('An email is required.')]: required,
-        [L('Please enter a valid email.')]: email
-      },
       bio: {
         [L('Reached character limit.')]: (value) => {
           return !value || Number(value.length) <= IDENTITY_BIO_MAX_CHARS

--- a/test/cypress/integration/signup-and-login.spec.js
+++ b/test/cypress/integration/signup-and-login.spec.js
@@ -42,9 +42,6 @@ describe('Signup, Profile and Login', () => {
     cy.getByDT('displayName').clear().type('John Bot')
     cy.getByDT('bio').clear().type('Born in a test case')
 
-    cy.getByDT('profileEmail').should('have.value', `${username}@email.com`)
-    cy.getByDT('profileEmail').clear().type(`${username}@new-email.com`)
-
     cy.getByDT('saveAccount').click()
     cy.getByDT('profileMsg').should('contain', 'Your changes were saved!')
 
@@ -64,7 +61,6 @@ describe('Signup, Profile and Login', () => {
     cy.getByDT('signupBtn').click()
 
     cy.getByDT('signName').type(user2)
-    cy.getByDT('signEmail').type(`${user2}@email.com`)
     cy.getByDT('password').type(password)
     cy.getByDT('passwordConfirm').type(wrongPassword)
     cy.getByDT('signTerms').check({ force: true }).should('be.checked')

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -160,14 +160,12 @@ Cypress.Commands.add('giSignup', (username, {
   groupName,
   bypassUI = false
 } = {}) => {
-  const email = `${username}@email.com`
-
   if (bypassUI) {
     // Wait for the app to be ready
     cy.getByDT('app').should('have.attr', 'data-ready', 'true')
 
     cy.window().its('sbp').then(async sbp => {
-      await sbp('gi.app/identity/signupAndLogin', { username, email, password })
+      await sbp('gi.app/identity/signupAndLogin', { username, password })
       await sbp('controller/router').push({ path: '/' }).catch(e => {})
     })
   } else {
@@ -175,7 +173,6 @@ Cypress.Commands.add('giSignup', (username, {
       cy.getByDT('signupBtn').click()
     }
     cy.getByDT('signName').clear().type(username)
-    cy.getByDT('signEmail').clear().type(email)
     cy.getByDT('password').type(password)
     cy.getByDT('passwordConfirm').type(password)
     cy.getByDT('signTerms').check({ force: true }).should('be.checked')


### PR DESCRIPTION
closes #2192 

As the safest and fastest way, and in case it becomes required in the future again. I didn't remove the email implementation from the `identity.js` contract but rather just made it optional. But let me know if they are removed too.