### PR TITLE
#2233 - Custom PWA installation in Home.vue

### DIFF
--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -18,6 +18,7 @@ const pwa = {
 window.addEventListener('beforeinstallprompt', e => {
   // e.preventDefault() - uncomment this if we want to prevent the browser from displaying its own install UI.
 
+  console.log('!@# beforeinstallprompt triggered!!! ', e)
   pwa.deferredInstallPrompt = e
   sbp('okTurtles.events/emit', PWA_INSTALLABLE)
 })

--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -15,6 +15,7 @@ const pwa = {
 // https://web.dev/articles/customize-install
 
 // PWA related event handlers
+// NOTE: Apparently, 'beforeinstallprompt' is not fired either when a PWA from the browser is already installed.
 window.addEventListener('beforeinstallprompt', e => {
   // e.preventDefault() - uncomment this if we want to prevent the browser from displaying its own install UI.
 

--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -18,7 +18,6 @@ const pwa = {
 window.addEventListener('beforeinstallprompt', e => {
   // e.preventDefault() - uncomment this if we want to prevent the browser from displaying its own install UI.
 
-  console.log('!@# beforeinstallprompt triggered!!! ', e)
   pwa.deferredInstallPrompt = e
   sbp('okTurtles.events/emit', PWA_INSTALLABLE)
 })

--- a/frontend/utils/events.js
+++ b/frontend/utils/events.js
@@ -51,3 +51,5 @@ export const CHATROOM_USER_STOP_TYPING = 'chatroom-user-stop-typing'
 export const NAMESPACE_REGISTRATION = 'namespace-registration'
 
 export const KV_QUEUE = 'kv-queue'
+
+export const PWA_INSTALLABLE = 'pwa-installable'

--- a/frontend/views/components/banners/BannerSimple.vue
+++ b/frontend/views/components/banners/BannerSimple.vue
@@ -19,7 +19,7 @@ export default ({
       default: 'info',
       validator: function (value) {
         // The value must match one of these strings
-        return ['success', 'info', 'warning', 'danger'].indexOf(value) !== -1
+        return ['success', 'info', 'warning', 'danger', 'general'].indexOf(value) !== -1
       }
     }
   },
@@ -29,7 +29,8 @@ export default ({
         warning: 'icon-exclamation-triangle c-icon',
         danger: 'icon-times-circle c-icon',
         info: 'icon-info-circle c-icon',
-        success: 'icon-check-circle c-icon'
+        success: 'icon-check-circle c-icon',
+        general: 'icon-info-circle c-icon'
       }[this.severity]
     }
   }
@@ -58,6 +59,15 @@ export default ({
     &:focus {
       color: $text_0;
       border-bottom-color: $text_0;
+    }
+  }
+
+  &.is-general {
+    background-color: $general_1;
+    color: $text_1;
+
+    .c-icon {
+      color: $text_1;
     }
   }
 

--- a/frontend/views/pages/DesignSystem.vue
+++ b/frontend/views/pages/DesignSystem.vue
@@ -580,6 +580,16 @@ page(
               |  with a&nbsp;
               a.link(href='/') link.
 
+        tr
+          td
+            pre banner-simple(severity='general')
+          td
+            banner-simple(severity='general')
+              | This is a&nbsp;
+              strong short message
+              |  with a&nbsp;
+              a.link(href='/') link.
+
       h4.is-title-4 With title
       table
         thead

--- a/frontend/views/pages/Home.vue
+++ b/frontend/views/pages/Home.vue
@@ -51,15 +51,17 @@ main.c-splash(data-test='homeLogo' v-if='!currentGroupId')
         data-test='joinGroup'
       ) Join a Group
 
-  footer.c-footer(v-if='!isLoggedIn && ephemeral.showPwaPromo')
-    banner-simple.c-pwa-promo(severity='info')
-      template(#header='')
-        i18n Install this web app on your device for better usability.
+  banner-simple.hide-hoverable-device.hide-tablet.c-pwa-promo(
+    v-if='!isLoggedIn && ephemeral.showPwaPromo'
+    severity='general'
+  )
+    template(#header='')
+      i18n Install this web app on your device for better usability.
 
-      button-submit.is-success.is-small.c-install-btn(
-        type='button'
-        @click='onInstallClick'
-      ) {{ L('Install') }}
+    button-submit.is-success.is-small.c-install-btn(
+      type='button'
+      @click='onInstallClick'
+    ) {{ L('Install') }}
 
   //- TODO: conditionally show this depending on environment variable
   //- footer.c-footer(v-if='!isLoggedIn')
@@ -268,13 +270,21 @@ export default ({
 }
 
 .c-pwa-promo {
+  position: fixed;
+  bottom: 1.875rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10; // should be less than modal, tooltip, prompt etc.
   text-align: left;
+  width: calc(100vw - 3rem);
+  max-width: 31.25rem;
 
   ::v-deep .c-body {
     margin-top: 1rem;
     text-align: right;
   }
 }
+
 
 .c-install-btn {
   padding-left: 1.75rem;

--- a/frontend/views/pages/Home.vue
+++ b/frontend/views/pages/Home.vue
@@ -285,7 +285,6 @@ export default ({
   }
 }
 
-
 .c-install-btn {
   padding-left: 1.75rem;
   padding-right: 1.75rem;

--- a/frontend/views/pages/Home.vue
+++ b/frontend/views/pages/Home.vue
@@ -50,6 +50,14 @@ main.c-splash(data-test='homeLogo' v-if='!currentGroupId')
         @click='openModal("GroupJoinModal")'
         data-test='joinGroup'
       ) Join a Group
+
+  footer.c-footer(v-if='!isLoggedIn')
+    banner-simple.hide-hoverable-device.hide-tablet.c-pwa-promo(severity='info')
+      template(#header='')
+        i18n Install this web app on your device for better usability.
+
+      i18n.is-success.is-small.c-install-btn(tag='button' type='button' @click='onInstallClick') Install
+
   //- TODO: conditionally show this depending on environment variable
   //- footer.c-footer(v-if='!isLoggedIn')
   //-   banner-simple.c-demo-warning(severity='warning')
@@ -125,6 +133,9 @@ export default ({
       // (Related GH issue: https://github.com/okTurtles/group-income/issues/1830)
       const path = this.$route.query.next ?? (this.ephemeral.ourProfileActive ? '/dashboard' : '/pending-approval')
       this.$router.push({ path }).catch(e => ignoreWhenNavigationCancelled(e, path))
+    },
+    onInstallClick () {
+      console.log('TODO - pop out pwa install prompt!')
     }
   },
   watch: {
@@ -241,5 +252,19 @@ export default ({
 
 .c-demo-warning {
   text-align: left;
+}
+
+.c-pwa-promo {
+  text-align: left;
+
+  ::v-deep .c-body {
+    margin-top: 1rem;
+    text-align: right;
+  }
+}
+
+.c-install-btn {
+  padding-left: 1.75rem;
+  padding-right: 1.75rem;
 }
 </style>


### PR DESCRIPTION
closes #2233 

@taoeffect 
First of all, this implementation is based on [this MDC article](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/How_to/Trigger_install_prompt), which states below warning:

> Warning: The technique described here depends on the [beforeinstallprompt](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event) event, which is non-standard and currently only implemented in Chromium-based browsers.

Both Safari desktop/iOS don't support([reference](https://caniuse.com/?search=beforeinstallprompt)) / fire **'beforeinstallprompt'** event, so the logic won't apply to them. (Meaning the promo banner will be hidden on those browsers)
 
Below are some proof screenshots that it worked on my Android chrome when tried with `grunt dev --tunnel`

 [ Chrome Android ]
 
![KakaoTalk_Photo_2024-07-20-17-59-24 002](https://github.com/user-attachments/assets/5f6ad3c9-5407-4696-9971-a88021168bca)

![KakaoTalk_Photo_2024-07-20-17-59-23 001](https://github.com/user-attachments/assets/933b70f4-b40b-4d03-a7d4-e0039c4a3bc4)

 [ Chrome desktop ]
 
 
![image](https://github.com/user-attachments/assets/4efa3a35-0db1-4594-b1a1-d57ae7e77b5f)
