### PR TITLE
#2244 - Drag and Drop file upload doesn't work in Safari

### DIFF
--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -2,7 +2,6 @@
 .c-chat-main(
   v-if='summary.chatRoomID'
   :class='{ "is-dnd-active": dndState && dndState.isActive }'
-  @dragstart='dragStartHandler'
   @dragover='dragStartHandler'
 )
   drag-active-overlay(
@@ -1087,17 +1086,15 @@ export default ({
     }, 250),
     // Handlers for file-upload via drag & drop action
     dragStartHandler (e) {
+      e.preventDefault()
       // handler function for 'dragstart', 'dragover' events
-      const items = Array.from(e?.dataTransfer?.items) || []
 
-      if (items.some(entry => entry.kind === 'file')) { // check if the detected content is something attachable to the chat.
-        if (!this.dndState.isActive) {
-          this.dndState.isActive = true
-        }
-
-        // give user a correct feedback about what happens upon 'drop' action. (https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
-        e.dataTransfer.dropEffect = 'copy'
+      if (!this.dndState.isActive) {
+        this.dndState.isActive = true
       }
+
+      // give user a correct feedback about what happens upon 'drop' action. (https://developer.mozilla.org/en-US/docs/Web/API/HTML_Drag_and_Drop_API)
+      e.dataTransfer.dropEffect = 'copy'
     },
     dragEndHandler (e) {
       // handler function for 'dragleave', 'dragend', 'drop' events

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -1087,7 +1087,7 @@ export default ({
     // Handlers for file-upload via drag & drop action
     dragStartHandler (e) {
       e.preventDefault()
-      // handler function for 'dragstart', 'dragover' events
+      // handler function for 'dragstart', 'dragover' events.
 
       if (!this.dndState.isActive) {
         this.dndState.isActive = true


### PR DESCRIPTION
closes #2244 

[ video - images are uploaded correctly via drag&drop now in Safari. Also, silently discarding a folder works properly too in there]
https://github.com/user-attachments/assets/b5038233-9968-4367-bd5f-e34beed9f821

