### PR TITLE
fix help and feedback page link

### DIFF
--- a/frontend/views/utils/allowedUrls.js
+++ b/frontend/views/utils/allowedUrls.js
@@ -13,7 +13,7 @@ const ALLOWED_URLS: Object = Object.freeze(Object.fromEntries([
   ['BLOG_PAGE', 'https://groupincome.org/blog'],
   ['DONATE_PAGE', 'https://groupincome.org/donate'],
   ['FAQ_PAGE', 'https://groupincome.org/faq'],
-  ['COMMUNITY_PAGE', 'https://groupincome.org/community'],
+  ['COMMUNITY_PAGE', 'https://github.com/okTurtles/group-income/discussions'],
   ['TERMS_PAGE', 'https://groupincome.org/terms-and-conditions'],
   ['WIKIPEDIA_DUNBARS_NUMBER', "https://en.wikipedia.org/wiki/Dunbar's_number"]
 ]))


### PR DESCRIPTION
The new site doesn't have a `/community` page link (should probably add one, but later)