### PR TITLE
#2051 - Enhance the logic handling 'Already-joined group' error

### DIFF
--- a/frontend/views/pages/Join.vue
+++ b/frontend/views/pages/Join.vue
@@ -218,6 +218,7 @@ export default ({
         const alreadyJoinedErr = this.checkAlreadyJoinedGroup(groupId)
         this.pageStatus = alreadyJoinedErr ? 'JOINED' : 'INVALID'
         if (alreadyJoinedErr) {
+          // if errored by attempting to join an already-joined group, show a different UI informing it.
           const targetGroupState = this.$store.state[groupId] || {}
 
           this.ephemeral.groupInfo = {


### PR DESCRIPTION
work on #2051 

I was able to reproduce the target error via the steps I described in [this comment](https://github.com/okTurtles/group-income/issues/2051#issuecomment-2257516385). This PR is to present below screen when that error is encountered. (In the screenshot, the console error saying 'Cannot join already joined group' is correctly mapped to this screen.)

![image](https://github.com/user-attachments/assets/9138b5ad-17df-4fe0-af15-fd1b92f58516)
