### PR TITLE
bump ci actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
       with:
         node-version: 18
         cache: 'npm'


### PR DESCRIPTION
Work on #2284 based on [this suggestion](https://github.com/cypress-io/github-action/issues/1232#issuecomment-2269697077)

EDIT: ~~this PR [did not](https://github.com/okTurtles/group-income/actions/runs/10258780893/job/28382156089?pr=2285)~~ fix #2284, so likely #2284 will require an upgrade of Cypress.

EDIT2: All of a sudden, on the [second run](https://github.com/okTurtles/group-income/actions/runs/10258780893/job/28382399206?pr=2285) of the tests — [it did upload the video](https://cloud.cypress.io/projects/q6whky/runs/2890/test-results/8af7d000-7dd9-413c-a9e6-b959450e9498/video?actions=%5B%5D&browsers=%5B%5D&groups=%5B%5D&isFlaky=%5B%5D&modificationDateRange=%7B%22startDate%22%3A%221970-01-01%22%2C%22endDate%22%3A%222038-01-19%22%7D&orderBy=EXECUTION_ORDER&oses=%5B%5D&specs=%5B%5D&statuses=%5B%7B%22value%22%3A%22FAILED%22%2C%22label%22%3A%22FAILED%22%7D%5D&testingTypesEnum=%5B%5D&utm_source=github) on failure! 😲