### PR TITLE
#2245 - Make non-monetary contribution mandatory in IncomeDetails.vue for non-pledgers

### DIFF
--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1061,6 +1061,7 @@ sbp('chelonia/defineContract', {
           with: stringMax(GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR, 'with')
         }),
         nonMonetaryRemove: stringMax(GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR, 'nonMonetaryRemove'),
+        nonMonetaryReplace: arrayOf(stringMax(GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR)),
         paymentMethods: arrayOf(
           objectOf({
             name: stringMax(GROUP_NAME_MAX_CHAR),
@@ -1082,6 +1083,9 @@ sbp('chelonia/defineContract', {
               break
             case 'nonMonetaryEdit':
               nonMonetary.splice(nonMonetary.indexOf(value.replace), 1, value.with)
+              break
+            case 'nonMonetaryReplace':
+              groupProfile.nonMonetaryContributions = cloneDeep(value)
               break
             default:
               groupProfile[key] = value

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -54,7 +54,7 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
 
           payment-methods.c-methods(v-if='needsIncome' ref='paymentMethods')
 
-          non-monetary-pledges.c-non-monetary-pledges(:optional='isPledging')
+          non-monetary-pledges.c-non-monetary-pledges( ref='nonMonetaryPledges' :optional='isPledging')
 
       banner-scoped(ref='formMsg' :allowA='true')
 
@@ -180,8 +180,10 @@ export default ({
       }
 
       let paymentMethodsUpdates = null
+      let nonMonetaryPledgeUpdates = null
 
       if (this.needsIncome) {
+        // - validations in the children components : 1. PaymentMethods.vue
         this.$refs.paymentMethods.$v.form.$touch()
 
         // Find the methods that have some info filled...
@@ -215,6 +217,13 @@ export default ({
         }
       }
 
+      // - validations in the children components : 2. nonMonetaryPledges.vue
+      if(!this.$refs.nonMonetaryPledges.validate()) return
+
+      if (this.$refs.nonMonetaryPledges.checkHasUpdates()) {
+        nonMonetaryPledgeUpdates = this.$refs.nonMonetaryPledges.getValues()
+      }
+
       try {
         const incomeDetailsType = this.form.incomeDetailsType
         await sbp('gi.actions/group/groupProfileUpdate', {
@@ -222,10 +231,10 @@ export default ({
           data: {
             incomeDetailsType,
             [incomeDetailsType]: normalizeCurrency(this.form.amount),
-            ...(
-              paymentMethodsUpdates?.length
-                ? { paymentMethods: paymentMethodsUpdates }
-                : {}
+            ...Object.assign(
+              {},
+              Boolean(paymentMethodsUpdates?.length) && { paymentMethods: paymentMethodsUpdates },
+              Boolean(nonMonetaryPledgeUpdates) && { nonMonetaryReplace: nonMonetaryPledgeUpdates }
             )
           }
         })

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -53,6 +53,8 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
             i18n.helper(v-else-if='!needsIncome') Define up to how much you pledge to contribute to the group every 30 days. Only the minimum amount needed will be distributed.
           payment-methods.c-methods(v-if='needsIncome' ref='paymentMethods')
 
+      non-monetary-pledges.c-non-monetary-pledges
+
       banner-scoped(ref='formMsg' :allowA='true')
 
       .buttons
@@ -77,6 +79,7 @@ import { validationMixin } from 'vuelidate'
 import { required } from 'vuelidate/lib/validators'
 import currencies, { normalizeCurrency } from '@model/contracts/shared/currencies.js'
 import PaymentMethods from './PaymentMethods.vue'
+import NonMonetaryPledges from './NonMonetaryPledges.vue'
 import GroupPledgesGraph from './GroupPledgesGraph.vue'
 import Tooltip from '@components/Tooltip.vue'
 import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
@@ -97,6 +100,7 @@ export default ({
     ButtonSubmit,
     Tooltip,
     PaymentMethods,
+    NonMonetaryPledges,
     GroupPledgesGraph
   },
   data () {
@@ -305,7 +309,8 @@ export default ({
   }
 }
 
-.c-methods {
+.c-methods,
+.c-non-monetary-pledges {
   margin-top: 1.5rem;
 }
 

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -218,7 +218,7 @@ export default ({
       }
 
       // - validations in the children components : 2. nonMonetaryPledges.vue
-      if(!this.$refs.nonMonetaryPledges.validate()) return
+      if (!this.$refs.nonMonetaryPledges.validate()) return
 
       if (this.$refs.nonMonetaryPledges.checkHasUpdates()) {
         nonMonetaryPledgeUpdates = this.$refs.nonMonetaryPledges.getValues()

--- a/frontend/views/containers/contributions/IncomeDetails.vue
+++ b/frontend/views/containers/contributions/IncomeDetails.vue
@@ -51,9 +51,10 @@ modal-base-template(ref='modal' :fullscreen='true' :a11yTitle='L("Income Details
             .helper(v-if='needsIncome && whoIsPledging.length')
               p {{ contributionMemberText }}
             i18n.helper(v-else-if='!needsIncome') Define up to how much you pledge to contribute to the group every 30 days. Only the minimum amount needed will be distributed.
+
           payment-methods.c-methods(v-if='needsIncome' ref='paymentMethods')
 
-      non-monetary-pledges.c-non-monetary-pledges
+          non-monetary-pledges.c-non-monetary-pledges(:optional='isPledging')
 
       banner-scoped(ref='formMsg' :allowA='true')
 

--- a/frontend/views/containers/contributions/NonMonetaryPledges.vue
+++ b/frontend/views/containers/contributions/NonMonetaryPledges.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 fieldset(
   data-test='nonMonetaryPledges'
-  v-error:pledges=''
+  v-error:pledges='{ attrs: { "data-test": "badPledges" } }'
 )
   legend.has-text-bold.c-legend
     i18n.is-title-4 Non-monetary pledge
@@ -20,6 +20,7 @@ fieldset(
           input.input(
             type='text'
             v-model='pledge.value'
+            data-test='inputNonMonetaryPledge'
             :aria-label='L("Pledge value")'
             :class='{ error: $v.form.pledges.$each[index].value.$error }'
           )
@@ -125,13 +126,13 @@ export default {
     return {
       form: {
         pledges: {
-          [L('At least one non-monetary pledge is required.')]: (value) => {
+          [L('At least one non-monetary pledge is required')]: (value) => {
             return this.optional ||
               (value?.length && value.some(entry => entry.value))
           },
           $each: {
             value: {
-              [L('Non-monetary pledge cannot exceed {maxChars} characters.', {
+              [L('Non-monetary pledge cannot exceed {maxChars} characters', {
                 maxChars: GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR
               })]: maxLength(GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR)
             }

--- a/frontend/views/containers/contributions/NonMonetaryPledges.vue
+++ b/frontend/views/containers/contributions/NonMonetaryPledges.vue
@@ -1,0 +1,104 @@
+<template lang='pug'>
+fieldset(data-test='nonMonetaryPledges')
+  legend.has-text-bold.c-legend
+    i18n.is-title-4 Non-monetary pledge
+
+  i18n.has-text-1 All members can support each other with non-monetary contributions. There's value in time, skills, and willingness to help the group.
+
+  ul.c-fields(ref='fields' data-test='nonMonetaryFields')
+    li.c-fields-item(
+      v-for='(pledge, index) in form.pledges'
+      :key='`pledge-${pledge.id}`'
+      data-test='pledgeEntry'
+    )
+      fieldset.inputgroup
+        input.input(
+          type='text'
+          v-model='pledge.value'
+          :aria-label='L("Pledge value")'
+          :class='{ error: $v.form.pledges.$each[index].value.$error }'
+        )
+        button.is-icon-small.is-btn-shifted(
+          type='button'
+          :aria-label='L("Remove pledge entry")'
+          @click='removeEntry(index)'
+          data-test='removePledgeEntry'
+        )
+          i.icon-times
+
+  button.link.has-icon(
+    type='button'
+    @click='addPledgeEntry'
+    data-test='addPledgeEntry'
+  )
+    i.icon-plus
+    i18n Add more
+</template>
+
+<script>
+import { L } from '@common/common.js'
+import { validationMixin } from 'vuelidate'
+import { maxLength, required } from 'vuelidate/lib/validators'
+import { GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR } from '@model/contracts/shared/constants.js'
+import { randomHexString } from '@model/contracts/shared/giLodash.js'
+
+export default {
+  name: 'NonMonetaryPledges',
+  mixins: [validationMixin],
+  data () {
+    return {
+      form: {
+        pledges: [
+          { id: randomHexString(10), value: '' }
+        ]
+      }
+    }
+  },
+  methods: {
+    removeEntry (index) {
+      if (this.form.pledges.length > 1) {
+        // Remove the method from the list
+        this.form.pledges.splice(index, 1)
+      } else {
+        this.form.pledges = [{ id: randomHexString(10), value: '' }]
+      }
+    },
+    addPledgeEntry () {
+      this.form.pledges.push({ id: randomHexString(10), value: '' })
+    }
+  },
+  validations () {
+    return {
+      form: {
+        pledges: {
+          $each: {
+            value: {
+              [L('Non-monetary pledge is required.')]: required,
+              [L('Non-monetary pledge cannot exceed {maxChars} characters.', {
+                maxChars: GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR
+              })]: maxLength(GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR)
+            }
+          }
+        }
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@assets/style/_variables.scss";
+
+.c-legend {
+  margin-bottom: 0.25rem;
+}
+
+.c-fields {
+  margin-top: 1rem;
+
+  &-item {
+    display: block;
+    margin-bottom: 1rem;
+  }
+}
+</style>

--- a/frontend/views/containers/contributions/NonMonetaryPledges.vue
+++ b/frontend/views/containers/contributions/NonMonetaryPledges.vue
@@ -98,7 +98,7 @@ export default {
 
       if (currValidation.$error) {
         for (const key in currValidation.$params) {
-          if (!cur[key]) {
+          if (!currValidation[key]) {
             return key
           }
         }

--- a/frontend/views/containers/contributions/NonMonetaryPledges.vue
+++ b/frontend/views/containers/contributions/NonMonetaryPledges.vue
@@ -21,6 +21,7 @@ fieldset(
             type='text'
             v-model='pledge.value'
             data-test='inputNonMonetaryPledge'
+            :maxlength='config.maxChar'
             :aria-label='L("Pledge value")'
             :class='{ error: $v.form.pledges.$each[index].value.$error }'
           )
@@ -66,6 +67,9 @@ export default {
         pledges: [
           { id: randomHexString(10), value: '' }
         ]
+      },
+      config: {
+        maxChar: GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR
       }
     }
   },

--- a/frontend/views/containers/contributions/NonMonetaryPledges.vue
+++ b/frontend/views/containers/contributions/NonMonetaryPledges.vue
@@ -2,6 +2,7 @@
 fieldset(data-test='nonMonetaryPledges')
   legend.has-text-bold.c-legend
     i18n.is-title-4 Non-monetary pledge
+    i18n.c-optional(v-if='optional') (optional)
 
   i18n.has-text-1 All members can support each other with non-monetary contributions. There's value in time, skills, and willingness to help the group.
 
@@ -45,6 +46,12 @@ import { randomHexString } from '@model/contracts/shared/giLodash.js'
 export default {
   name: 'NonMonetaryPledges',
   mixins: [validationMixin],
+  props: {
+    optional: {
+      type: Boolean,
+      default: false
+    }
+  },
   data () {
     return {
       form: {
@@ -88,6 +95,14 @@ export default {
 
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";
+
+.c-optional {
+  display: inline-block;
+  color: $text_1;
+  user-select: none;
+  font-size: $size_5;
+  margin-left: 0.5rem;
+}
 
 .c-legend {
   margin-bottom: 0.25rem;

--- a/frontend/views/containers/contributions/NonMonetaryPledges.vue
+++ b/frontend/views/containers/contributions/NonMonetaryPledges.vue
@@ -78,13 +78,9 @@ export default {
     return {
       form: {
         pledges: {
-          $each: {
-            value: {
-              [L('Non-monetary pledge is required.')]: required,
-              [L('Non-monetary pledge cannot exceed {maxChars} characters.', {
-                maxChars: GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR
-              })]: maxLength(GROUP_NON_MONETARY_CONTRIBUTION_MAX_CHAR)
-            }
+          [L('At least one non-monetary pledge is required.')]: (value) => {
+            return this.optional ||
+              (value?.length && value.some(entry => entry.value))
           }
         }
       }

--- a/frontend/views/containers/contributions/NonMonetaryPledges.vue
+++ b/frontend/views/containers/contributions/NonMonetaryPledges.vue
@@ -131,7 +131,7 @@ export default {
       form: {
         pledges: {
           [L('At least one non-monetary pledge is required')]: (value) => {
-            return this.optional ||
+            return this.optional || // Don't need to validate when 'optional'
               (value?.length && value.some(entry => entry.value))
           },
           $each: {

--- a/test/cypress/integration/group-contributions.spec.js
+++ b/test/cypress/integration/group-contributions.spec.js
@@ -193,19 +193,28 @@ describe('Contributions', () => {
     })
 
     cy.getByDT('submitIncome').click()
+
+    // When 'need income' is selected, at least 1 non-monetary contribution is mandatory
+    cy.getByDT('badPledges').should('contain', 'At least one non-monetary pledge is required')
+    cy.getByDT('inputNonMonetaryPledge').type('Cooking')
+    // Adding a non-monetary pledge will clear the error message
+    cy.getByDT('badPledges').should('not.be.visible')
+
+    cy.getByDT('submitIncome').click()
     cy.getByDT('closeModal').should('not.exist')
 
     // After closing the modal it should dislay how much user need
     cy.getByDT('headerNeed').should('contain', 'You need $100')
+
     // The user should be inform that even if he can't pledge he can still contribute
-    cy.getByDT('givingParagraph').should('contain', 'You can contribute to your group with money or other valuables like teaching skills, sharing your time to help someone. The sky is the limit!')
+    cy.getByDT('givingParagraph').should('contain', 'No one needs monetary contributions at the moment. You can still add non-monetary contributions if you would like.')
 
     assertContributionsWidget({
       paymentsTitle: 'Payments received',
       paymentsStatus: 'No members in the group are pledging yet! 😔',
       monetaryTitle: 'You need $100',
       monetaryStatus: 'You will receive $0.',
-      nonMonetaryStatus: 'There are no non-monetary contributions.'
+      nonMonetaryStatus: 'You are contributing.'
     })
   })
 
@@ -335,33 +344,26 @@ describe('Contributions', () => {
     cy.getByDT('closeProfileCard').click()
   })
 
-  const firstContribution = 'Portuguese classes'
+  const anotherContribution = 'Portuguese classes'
 
-  it('user1 adds non monetary contribution', () => {
-    addNonMonetaryContribution(firstContribution)
+  it('user1 adds another non-monetary contribution', () => {
+    addNonMonetaryContribution(anotherContribution)
 
     cy.getByDT('givingList', 'ul')
       .get('li.is-editable')
-      .should('have.length', 1)
-      .should('contain', firstContribution)
+      .should('have.length', 2)
+      .should('contain', anotherContribution)
   })
 
-  it('user1 removes non monetary contribution', () => {
-    cy.getByDT('buttonEditNonMonetaryContribution')
+  it('user1 removes a non-monetary contribution', () => {
+    cy.getByDT('givingList').find('li').should('have.length', 3) // contributions + cta to add
+      .eq(1).within(() => {
+        cy.getByDT('buttonEditNonMonetaryContribution').click()
+      })
 
-    cy.getByDT('givingList').find('li').should('have.length', 2) // contribution + cta to add
-    cy.getByDT('buttonEditNonMonetaryContribution').click()
     cy.getByDT('buttonRemoveNonMonetaryContribution').click()
-    cy.getByDT('givingList').find('li').should('have.length', 1) // cta to add
+    cy.getByDT('givingList').find('li').should('have.length', 2) // 1 contributon + cta to add
     cy.getByDT('givingParagraph').should('exist')
-  })
-
-  it('user1 re-adds the same non monetary contribution', () => {
-    addNonMonetaryContribution(firstContribution)
-    cy.getByDT('givingList', 'ul')
-      .get('li.is-editable')
-      .should('have.length', 1)
-      .should('contain', firstContribution)
   })
 
   it('user1 edits the non monetary contribution', () => {

--- a/test/cypress/integration/group-contributions.spec.js
+++ b/test/cypress/integration/group-contributions.spec.js
@@ -196,7 +196,7 @@ describe('Contributions', () => {
 
     // When 'need income' is selected, at least 1 non-monetary contribution is mandatory
     cy.getByDT('badPledges').should('contain', 'At least one non-monetary pledge is required')
-    cy.getByDT('inputNonMonetaryPledge').type('Cooking')
+    cy.randomNonMonetaryInIncomeDetails()
     // Adding a non-monetary pledge will clear the error message
     cy.getByDT('badPledges').should('not.be.visible')
 

--- a/test/cypress/integration/group-paying.spec.js
+++ b/test/cypress/integration/group-paying.spec.js
@@ -25,6 +25,7 @@ function setIncomeDetails (doesPledge, incomeAmount) {
 
   if (!doesPledge) {
     cy.randomPaymentMethodInIncomeDetails()
+    cy.randomNonMonetaryInIncomeDetails()
   }
 
   cy.getByDT('submitIncome').click()

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -598,6 +598,7 @@ Cypress.Commands.add('giAddRandomIncome', () => {
   if (action === 'needsIncomeRadio') {
     // it's mandatory to fill out the payment details when 'needsIncome' is selected.
     cy.randomPaymentMethodInIncomeDetails()
+    cy.randomNonMonetaryInIncomeDetails()
   }
 
   cy.getByDT('submitIncome').click()
@@ -619,6 +620,17 @@ Cypress.Commands.add('randomPaymentMethodInIncomeDetails', () => {
       cy.get('input').type(detailMap[paymentMethod])
     })
   })
+})
+
+Cypress.Commands.add('randomNonMonetaryInIncomeDetails', () => {
+  const randomClass = () => {
+    const langs = ['English', 'Korean', 'German', 'French', 'Japanese', 'Chinese', 'Javascript', 'Typescript', 'Python']
+    const randomIndex = Math.floor(Math.random() * langs.length)
+
+    return `${langs[randomIndex]} class`
+  }
+
+  cy.getByDT('inputNonMonetaryPledge').type(randomClass())
 })
 
 Cypress.Commands.add('giAddNewChatroom', ({

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -624,10 +624,13 @@ Cypress.Commands.add('randomPaymentMethodInIncomeDetails', () => {
 
 Cypress.Commands.add('randomNonMonetaryInIncomeDetails', () => {
   const randomClass = () => {
-    const langs = ['English', 'Korean', 'German', 'French', 'Japanese', 'Chinese', 'Javascript', 'Typescript', 'Python']
-    const randomIndex = Math.floor(Math.random() * langs.length)
+    const classes = [
+      'English', 'Korean', 'German', 'French', 'Japanese', 'Mandarin', 'Cantonese', 'Portuguese', 'Spanish',
+      'Javascript', 'Typescript', 'Python', 'React', 'Vue', 'Angular', 'Node.js', 'Express', 'PHP'
+    ]
+    const randomIndex = Math.floor(Math.random() * classes.length)
 
-    return `${langs[randomIndex]} class`
+    return `${classes[randomIndex]} class`
   }
 
   cy.getByDT('inputNonMonetaryPledge').type(randomClass())


### PR DESCRIPTION
closes #2245 

Adding below block to `IncomeDetails.vue`

<img src='https://github.com/user-attachments/assets/8e35f96e-fbf0-49ad-86e5-744dab49ebea' width='80%'>

@taoeffect 
Please let me know if you would like to change the validation copy.