### PR TITLE
#2283 - Chat should not replace symbols in <code>

### DIFF
--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -63,7 +63,7 @@
     margin: 0.75rem 0;
   }
 
-  ul li {
+  ul > li {
     position: relative;
     display: block;
     padding: 0 0 0.2rem 1.125rem;
@@ -85,7 +85,7 @@
     }
   }
 
-  ol li {
+  ol > li {
     position: relative;
     padding-bottom: 0.2rem;
     margin-left: 1.125rem;
@@ -102,7 +102,7 @@
       margin-bottom: 0;
     }
 
-    > ul li::before {
+    > ul > li::before {
       background-color: rgba(0, 0, 0, 0);
       border: 1px solid $text_0;
       top: 0.6rem;

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -40,14 +40,13 @@ export function renderMarkdown (str: string): any {
       entryText = entryText.replace(/</g, '&lt;').replace(/>/g, '&gt;')
 
       entryText = entryText.replace(/\n(?=\n)/g, '\n<br>')
-        .replace(/<br>\n(\s*)(\d+\.|-|```)/g, '\n\n$1$2') // custom-handling the case where <br> is directly followed by the start of block-code (```)
+        .replace(/<br>\n(\s*)(\d+\.|-)/g, '\n\n$1$2') // custom-handling the case where <br> is directly followed by the start of ordered/unordered lists
         .replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // this is a custom-logic added so that the end of ordered/un-ordered lists are correctly detected by markedjs.
 
       entry.text = entryText
     }
   })
 
-  console.log('!@# strSplitByCodeMarkdown: ', strSplitByCodeMarkdown)
   str = combineMarkdownSegmentListIntoString(strSplitByCodeMarkdown)
 
   // STEP 2. convert the markdown into html DOM string.


### PR DESCRIPTION
closes #2283 

[Proof of the fix]

<img src='https://github.com/user-attachments/assets/2f36a1c9-d641-4fd2-a4f9-dae551801888' width='80%'>
