### PR TITLE
#2158 - Fix the broken 'Reduced-motion' mode

### DIFF
--- a/frontend/assets/style/_transitions.scss
+++ b/frontend/assets/style/_transitions.scss
@@ -1,5 +1,14 @@
 @import "_variables";
 
+@mixin reduce-motion {
+  *:not(.force-motion),
+  *:not(.force-motion)::after,
+  *:not(.force-motion)::before {
+    transition: none !important;
+    animation: none !important;
+  }
+}
+
 .fade-enter-active,
 .fade-leave-active {
   transition: opacity 0.5s cubic-bezier(0.165, 0.84, 0.44, 1);
@@ -161,21 +170,11 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  *,
-  *::after,
-  *::before {
-    transition: none !important;
-    animation: none !important;
-  }
+  @include reduce-motion;
 }
 
 .js-reducedMotion {
-  *,
-  *::after,
-  *::before {
-    transition: none !important;
-    animation: none !important;
-  }
+  @include reduce-motion;
 }
 
 @keyframes focused {

--- a/frontend/assets/style/_transitions.scss
+++ b/frontend/assets/style/_transitions.scss
@@ -161,14 +161,18 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  * {
+  *,
+  *::after,
+  *::before {
     transition: none !important;
     animation: none !important;
   }
 }
 
 .js-reducedMotion {
-  * {
+  *,
+  *::after,
+  *::before {
     transition: none !important;
     animation: none !important;
   }

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -576,7 +576,7 @@ async function startApp () {
         return {
           'l-with-navigation': this.showNav,
           'l-no-navigation': !this.showNav,
-          'js-reducedMotion': this.$store.state.reducedMotion,
+          'js-reducedMotion': this.$store.state.settings.reducedMotion,
           'is-dark-theme': this.$store.getters.isDarkTheme
         }
       },

--- a/frontend/model/settings/vuexModule.js
+++ b/frontend/model/settings/vuexModule.js
@@ -47,6 +47,9 @@ const getters = {
   isDarkTheme (state) {
     return state.themeColor === THEME_DARK
   },
+  isReducedMotionMode (state) {
+    return state.reducedMotion === true
+  },
   theme (state) {
     return state.theme
   }

--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -15,7 +15,7 @@ span.c-twrapper(
 
   .c-tooltip(
     :style='styles'
-    :class='{"has-text-center": isTextCenter, "is-active": isActive, manual, "is-dark-theme": $store.getters.isDarkTheme}'
+    :class='{"has-text-center": isTextCenter, "is-active": isActive, manual, "is-dark-theme": $store.getters.isDarkTheme,  "in-reduced-motion": isReducedMotionMode }'
     v-if='isActive || isVisible'
     v-append-to-body='{ manual }'
   )
@@ -26,6 +26,7 @@ span.c-twrapper(
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import { TABLET } from '@view-utils/breakpoints.js'
 import trapFocus from '@utils/trapFocus.js'
 
@@ -79,6 +80,9 @@ export default ({
     lastFocus: null
   }),
   computed: {
+    ...mapGetters([
+      'isReducedMotionMode'
+    ]),
     rootElAttrs () {
       return {
         'tabindex': !this.triggerElementSelector
@@ -275,6 +279,13 @@ export default ({
 
     .card {
       background-color: $general_1;
+    }
+  }
+
+  &.in-reduced-motion {
+    * {
+      animation-duration: 0ms !important;
+      transition: none !important;
     }
   }
 

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -310,7 +310,8 @@ export default ({
       'isJoinedChatRoom',
       'isGroupDirectMessage',
       'currentChatRoomScrollPosition',
-      'currentChatRoomReadUntil'
+      'currentChatRoomReadUntil',
+      'isReducedMotionMode'
     ]),
     currentUserAttr () {
       return {
@@ -533,7 +534,7 @@ export default ({
         if (!eleTarget) { return }
 
         if (effect) {
-          eleTarget.scrollIntoView({ behavior: 'smooth' })
+          eleTarget.scrollIntoView({ behavior: this.isReducedMotionMode ? 'instant' : 'smooth' })
           eleMessage.classList.add('c-focused')
           setTimeout(() => {
             eleMessage.classList.remove('c-focused')
@@ -594,7 +595,9 @@ export default ({
         this.$refs.conversation.scroll({
           left: 0,
           top: this.$refs.conversation.scrollHeight,
-          behavior
+          behavior: this.isReducedMotionMode
+            ? 'instant' // force 'instant' behaviour in reduced-motion mode regardless of the passed param.
+            : behavior
         })
       }
     },

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-.c-message(
+.c-message.force-motion(
   :class='[variant, isSameSender && "same-sender", "is-type-" + type, isAlreadyPinned && "pinned"]'
   @click='$emit("wrapperAction")'
   v-touch:touchhold='longPressHandler'


### PR DESCRIPTION
closes #2158 

it appears that this feature was broken when the vuex-state for app-settings was moved to a separate module. So fixed it.

While at it, created a `.force-motion` css class for any part of the app where the animation still needs to happen regardless of the reduced-motion setting.
(eg. this highlight animation for `move-to-specific-message` feature in the chat-room.)

<img src='https://github.com/user-attachments/assets/538e9f94-8a39-4fa4-addd-a409cf38ac48' width='480'>


Cheers,