### PR TITLE
#2313 Make sure at least 1 non-monetary is required in Contributions page

### DIFF
--- a/frontend/views/containers/contributions/Contribution.vue
+++ b/frontend/views/containers/contributions/Contribution.vue
@@ -24,7 +24,7 @@ transition(name='replace-list')
       .c-helper(v-if='receiverHasOnlyOneItem')
         i.icon-info-circle
         i18n At least one non-monetary contribution is required.
-      
+
       .buttons
         button-submit.is-small.is-danger.is-outlined(
           v-if='showRemoveBtn'

--- a/frontend/views/containers/contributions/Contribution.vue
+++ b/frontend/views/containers/contributions/Contribution.vue
@@ -20,9 +20,14 @@ transition(name='replace-list')
         @keydown.esc='cancel'
         @keydown.enter.prevent='handleEnter'
       )
+
+      .c-helper(v-if='receiverHasOnlyOneItem')
+        i.icon-info-circle
+        i18n At least one non-monetary contribution is required.
+      
       .buttons
         button-submit.is-small.is-danger.is-outlined(
-          v-if='isEditing && !isAdding'
+          v-if='showRemoveBtn'
           @click='handleDelete'
           data-test='buttonRemoveNonMonetaryContribution'
         ) {{ L('Remove') }}
@@ -94,6 +99,7 @@ export default ({
     initialValue: {
       type: String
     },
+    needsIncome: Boolean,
     contributionsList: Array
   },
   data () {
@@ -120,6 +126,12 @@ export default ({
     },
     isUnfilled () {
       return this.variant === 'unfilled'
+    },
+    receiverHasOnlyOneItem () {
+      return this.needsIncome && this.contributionsList?.length === 1
+    },
+    showRemoveBtn () {
+      return this.isEditing && !this.isAdding && !this.receiverHasOnlyOneItem
     },
     editAriaLabel () {
       return L('Edit contribution settings')
@@ -235,6 +247,15 @@ export default ({
     font-size: $size_5;
     color: $text_1;
   }
+}
+
+.c-helper {
+  display: flex;
+  align-items: flex-start;
+  column-gap: 0.25rem;
+  color: $text_1;
+  margin-top: 0.5rem;
+  font-size: $size_4;
 }
 
 .buttons {

--- a/frontend/views/pages/Contributions.vue
+++ b/frontend/views/pages/Contributions.vue
@@ -111,6 +111,7 @@ page(pageTestName='contributionsPage' pageTestHeaderName='contributionsTitle')
           contribution.has-text-weight-bold(
             v-for='(contribution, index) in ourGroupProfile.nonMonetaryContributions'
             :key='`contribution-${index}`'
+            :needs-income='needsIncome'
             variant='editable'
             :contributions-list='ourGroupProfile.nonMonetaryContributions'
             :initial-value='contribution'


### PR DESCRIPTION
closes #2313 

When the user is non-pledger and there is **only one** non-monetary contribution,

1) Do not reveal the 'Remove' button
2) Display a information text saying at least 1 item is required.

<img width="406" alt="receiver-one-item-required" src="https://github.com/user-attachments/assets/d72de9d8-cf37-436b-a496-061fbf25917b">
