### PR TITLE
Fixes #2311.

### DIFF
--- a/frontend/model/notifications/storageConstants.js
+++ b/frontend/model/notifications/storageConstants.js
@@ -2,8 +2,10 @@ import { DAYS_MILLIS } from '~/frontend/model/contracts/shared/time.js'
 
 // The maximum allowed age of read (resp. unread) stored notifications.
 // Not to be confused with maximum storage duration.
-export const MAX_AGE_READ = 30 * DAYS_MILLIS
-export const MAX_AGE_UNREAD = Infinity
+// Notifications older than `MAX_AGE_READ` are automatically marked as read
+export const MAX_AGE_READ = 60 * DAYS_MILLIS
+// Notifications older than `MAX_AGE_UNREAD` are automatically discarded.
+export const MAX_AGE_UNREAD = 180 * DAYS_MILLIS
 // The maximum allowed number of stored notifications.
 export const MAX_COUNT = 30
 // The maximum allowed number of read (resp. unread) stored notifications.

--- a/frontend/model/notifications/utils.js
+++ b/frontend/model/notifications/utils.js
@@ -20,6 +20,9 @@ export function age (notification: Notification): number {
 /*
  * Creates a copy of the given notification list, possibly sorted and/or truncated to
  * make it suitable for offline storage.
+ * The second argument, `status` contains separarately-stored parameters for that
+ * notification hash to reflect how notifications are used in the app
+ * (specifically, the `read` parameter is stored there).
  *
  * Algorithm steps taken on the copy:
  *
@@ -40,9 +43,9 @@ export function age (notification: Notification): number {
  *   5f. discard unread notifications, older ones first.
  * 6. Return the remaining notifications.
  */
-export function applyStorageRules (notifications: Notification[]): Notification[] {
+export function applyStorageRules (notifications: Notification[], status: { [string]: Notification } = {}): Notification[] {
   // Apply the MAX_AGE constraint by selecting items that have not yet expired.
-  let items = notifications.filter(item => !isExpired(item))
+  let items = notifications.filter(item => !isExpired({ ...item, ...status[item.hash] }))
 
   if (items.length > MAX_COUNT) {
     // Sort the list by descending priority order.

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -123,7 +123,7 @@ sbp('sbp/selectors/register', {
       }
 
       const { identityContractID, encryptionParams } = state.loggedIn
-      state.notifications.items = applyStorageRules(state.notifications.items || [])
+      state.notifications.items = applyStorageRules(state.notifications.items || [], state.notifications.status || {})
       if (encrypted) {
         await sbp('gi.db/settings/saveEncrypted', identityContractID, state, encryptionParams)
       } else {


### PR DESCRIPTION
This implements the following changes:

  * Increase KV notification status memory to 2 months
  * Set Vuex notification memory to 6 months
  * Automatically mark notifications as read after the notification status memory window (e.g. after 2 months)
  * Purge notifications from Vuex store that are older than 6 months