### PR TITLE
#2345 - Broken username in the in-app notification after the user has been kicked out

### DIFF
--- a/frontend/model/contracts/shared/functions.js
+++ b/frontend/model/contracts/shared/functions.js
@@ -225,13 +225,13 @@ export function swapMentionIDForDisplayname (
   }
 ): string {
   const {
-    ourContactProfilesById,
     getChatroomNameById,
     usernameFromID,
     userDisplayNameFromID
   } = sbp('state/vuex/getters')
+  const { reverseNamespaceLookups } = sbp('state/vuex/state')
   const possibleMentions = [
-    ...Object.keys(ourContactProfilesById).map(u => makeMentionFromUserID(u).me).filter(v => !!v),
+    ...Object.keys(reverseNamespaceLookups).map(u => makeMentionFromUserID(u).me).filter(v => !!v),
     makeChannelMention('[^\\s]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
   ]
 


### PR DESCRIPTION
closes #2345 

<img src='https://github.com/user-attachments/assets/bd9731f1-d7ee-473b-8eb9-00c123891361' width='460'>