### PR TITLE
#2337 - Fix the overly tall chatroom height when a message is in edit mode

### DIFF
--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -37,7 +37,7 @@
             @click='$emit("reply-message-clicked")'
           )
 
-        send-area(
+        send-area.c-edit-send-area(
           v-if='isEditing'
           :defaultText='swapMentionIDForDisplayname(text)'
           :isEditing='true'
@@ -378,5 +378,9 @@ export default ({
 
 .c-disappeared {
   animation: disappeared 0.5s linear;
+}
+
+.c-edit-send-area {
+  padding: 0 0 1rem;
 }
 </style>

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -973,6 +973,11 @@ export default ({
     height: auto;
     white-space: pre-line;
     min-height: 0;
+    max-height: 9rem;
+
+    @include tablet {
+      max-height: 12.25rem;
+    }
   }
 
   &-btn {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -938,11 +938,7 @@ export default ({
     width: 100%;
     font-size: 1rem;
     word-wrap: break-word;
-    max-height: 9rem;
-
-    @include tablet {
-      max-height: 12.25rem;
-    }
+    max-height: 12.75rem;
   }
 
   &-textarea {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -938,6 +938,11 @@ export default ({
     width: 100%;
     font-size: 1rem;
     word-wrap: break-word;
+    max-height: 9rem;
+
+    @include tablet {
+      max-height: 12.25rem;
+    }
   }
 
   &-textarea {
@@ -948,12 +953,7 @@ export default ({
     background-color: transparent;
     border: none;
     padding: 0.5rem;
-    max-height: 9rem;
     overflow-y: auto;
-
-    @include tablet {
-      max-height: 12.25rem;
-    }
 
     &::-webkit-scrollbar {
       display: none;
@@ -973,11 +973,6 @@ export default ({
     height: auto;
     white-space: pre-line;
     min-height: 0;
-    max-height: 9rem;
-
-    @include tablet {
-      max-height: 12.25rem;
-    }
   }
 
   &-btn {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -992,7 +992,6 @@ export default ({
   &.is-editing {
     margin: 0;
     padding: 0;
-    overflow: hidden;
 
     .c-send-actions {
       position: relative;

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -991,6 +991,7 @@ export default ({
   &.is-editing {
     margin: 0;
     padding: 0;
+    overflow: hidden;
 
     .c-send-actions {
       position: relative;

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -938,6 +938,11 @@ export default ({
     width: 100%;
     font-size: 1rem;
     word-wrap: break-word;
+    max-height: 9rem;
+
+    @include tablet {
+      max-height: 12.25rem;
+    }
   }
 
   &-textarea {
@@ -948,12 +953,7 @@ export default ({
     background-color: transparent;
     border: none;
     padding: 0.5rem;
-    max-height: 9rem;
     overflow-y: auto;
-
-    @include tablet {
-      max-height: 12.25rem;
-    }
 
     &::-webkit-scrollbar {
       display: none;
@@ -973,6 +973,7 @@ export default ({
     height: auto;
     white-space: pre-line;
     min-height: 0;
+    overflow-y: hidden;
   }
 
   &-btn {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -938,11 +938,6 @@ export default ({
     width: 100%;
     font-size: 1rem;
     word-wrap: break-word;
-    max-height: 9rem;
-
-    @include tablet {
-      max-height: 12.25rem;
-    }
   }
 
   &-textarea {
@@ -953,7 +948,12 @@ export default ({
     background-color: transparent;
     border: none;
     padding: 0.5rem;
+    max-height: 9rem;
     overflow-y: auto;
+
+    @include tablet {
+      max-height: 12.25rem;
+    }
 
     &::-webkit-scrollbar {
       display: none;


### PR DESCRIPTION
closes #2337 

![edit-scroll-issue](https://github.com/user-attachments/assets/9c427898-4457-4c39-acd0-8e75e6498d0a)

From my investigation there is an invisible element `.c-send-mask` that is used to adjust/calculate the height of `<textarea />` element (that has `.c-send-textarea` css class) while the message is in edit mode. The cause of the issue was that this invisible `.c-send-mask` becomes way too tall if the message content is large.

So, made a fix for this.

<img src='https://github.com/user-attachments/assets/1b3638a2-d39b-46c1-b6cf-c1baf1e03e15' width='420'>