### PR TITLE
#2369 chat paste bug

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -148,10 +148,10 @@ async function startApp () {
         }, 8e3)
       })]
   ).catch(e => {
-    console.error('[main] Error setting up service worker', e)
-    alert(L('Error while setting up service worker'))
-    window.location.reload() // try again, sometimes it fixes it
-    throw e
+    // console.error('[main] Error setting up service worker', e)
+    // alert(L('Error while setting up service worker'))
+    // window.location.reload() // try again, sometimes it fixes it
+    // throw e
   })
 
   /* eslint-disable no-new */

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -148,10 +148,10 @@ async function startApp () {
         }, 8e3)
       })]
   ).catch(e => {
-    // console.error('[main] Error setting up service worker', e)
-    // alert(L('Error while setting up service worker'))
-    // window.location.reload() // try again, sometimes it fixes it
-    // throw e
+    console.error('[main] Error setting up service worker', e)
+    alert(L('Error while setting up service worker'))
+    window.location.reload() // try again, sometimes it fixes it
+    throw e
   })
 
   /* eslint-disable no-new */

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -555,7 +555,7 @@ export default ({
       }
     },
     handlePaste (e) {
-      // fix for the edge-case related to 'paste' action when nothing has been typed.
+      // fix for the edge-case related to 'paste' action when nothing has been typed
       // (reference: https://github.com/okTurtles/group-income/issues/2369)
       const currVal = this.$refs.textarea.value
 

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -544,7 +544,6 @@ export default ({
       }
     },
     handleKeyup (e) {
-      console.log('!@# handle keyup')
       if (e.keyCode === 13) {
         e.preventDefault()
       } else {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -70,6 +70,7 @@
       @keydown.ctrl='isNextLine'
       @keydown='handleKeydown'
       @keyup='handleKeyup'
+      @paste.prevent.stop='handlePaste'
       v-bind='$attrs'
     )
 
@@ -543,6 +544,7 @@ export default ({
       }
     },
     handleKeyup (e) {
+      console.log('!@# handle keyup')
       if (e.keyCode === 13) {
         e.preventDefault()
       } else {
@@ -552,6 +554,11 @@ export default ({
       if (!caretKeyCodeValues[e.keyCode] && !functionalKeyCodeValues[e.keyCode]) {
         this.updateMentionKeyword()
       }
+    },
+    handlePaste (e) {
+      const pastedText = e.clipboardData.getData('text')
+      this.$refs.textarea.value = pastedText
+      this.updateTextArea()
     },
     addSelectedMention (index) {
       const curValue = this.$refs.textarea.value

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -70,7 +70,7 @@
       @keydown.ctrl='isNextLine'
       @keydown='handleKeydown'
       @keyup='handleKeyup'
-      @paste.prevent.stop='handlePaste'
+      @paste='handlePaste'
       v-bind='$attrs'
     )
 
@@ -555,9 +555,16 @@ export default ({
       }
     },
     handlePaste (e) {
-      const pastedText = e.clipboardData.getData('text')
-      this.$refs.textarea.value = pastedText
-      this.updateTextArea()
+      // fix for the edge-case related to 'paste' action when nothing has been typed.
+      // (reference: https://github.com/okTurtles/group-income/issues/2369)
+      const currVal = this.$refs.textarea.value
+
+      if (!currVal) {
+        e.preventDefault()
+        const pastedText = e.clipboardData.getData('text')
+        this.$refs.textarea.value = pastedText
+        this.updateTextArea()
+      }
     },
     addSelectedMention (index) {
       const curValue = this.$refs.textarea.value


### PR DESCRIPTION
closes #2369 

<img src='https://github.com/user-attachments/assets/e96f9e08-1c75-47a3-bf95-a7298d46838f' width='430'>

The textarea element needed a 'paste' event handler.