### PR TITLE
Revert `cy.giLogout({ bypassUI: true })` in `group-chat-message.spec.js`

### DIFF
--- a/test/cypress/integration/group-chat-message.spec.js
+++ b/test/cypress/integration/group-chat-message.spec.js
@@ -203,7 +203,7 @@ describe('Send/edit/remove/reply/pin/unpin messages & add/remove reactions insid
       invitationLinkAnyone = url
     })
 
-    cy.giLogout({ bypassUI: true })
+    cy.giLogout()
   })
 
   it(`user2 joins ${groupName} group and sends/deletes/edits messages in "${CHATROOM_GENERAL_NAME}"`, () => {
@@ -471,6 +471,6 @@ describe('Send/edit/remove/reply/pin/unpin messages & add/remove reactions insid
       cy.get('.c-message:nth-child(2) .c-notification').should('contain', `Joined ${CHATROOM_GENERAL_NAME}`)
     })
 
-    cy.giLogout({ bypassUI: true })
+    cy.giLogout()
   })
 })


### PR DESCRIPTION
Fix for a heisen-bug mentioned in [this comment](https://github.com/okTurtles/group-income/pull/2367#issuecomment-2418298225) and elsewhere via Slack.