### PR TITLE
#2188 - Fix payment table UI bug that happens in certain desktop viewport range

### DIFF
--- a/frontend/views/containers/payments/PaymentsList.vue
+++ b/frontend/views/containers/payments/PaymentsList.vue
@@ -149,6 +149,34 @@ export default ({
     @include phone {
       text-align: right;
     }
+
+    @include desktop {
+      min-width: 4.5rem;
+    }
+  }
+
+  th.c-th-method {
+    @include desktop {
+      min-width: 7.25rem;
+    }
+  }
+
+  th.c-th-date {
+    @include desktop {
+      min-width: 6.25rem;
+    }
+  }
+
+  th.c-th-relative-to {
+    @include desktop {
+      min-width: 5.25rem;
+    }
+  }
+
+  ::v-deep td.c-td-user {
+    @include desktop {
+      padding-right: 0.5rem;
+    }
   }
 
   &.c-is-todo {

--- a/frontend/views/containers/payments/payment-row/PaymentRow.vue
+++ b/frontend/views/containers/payments/payment-row/PaymentRow.vue
@@ -2,7 +2,7 @@
   tr.c-row(data-test='payRow')
     td(v-if='$slots["cellPrefix"]')
       slot(name='cellPrefix')
-    td
+    td.c-td-user
       slot(name='cellUser')
       template(v-if='!$slots["cellUser"]')
         .c-user

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -90,13 +90,15 @@ page(
 
       .tab-section
         .c-container(v-if='paymentsFiltered.length')
-          payments-list(
-            ref='paymentList'
-            :titles='tableTitles'
-            :paymentsList='paginateList(paymentsFiltered)'
-            :paymentsType='ephemeral.activeTab'
-            :selectedTodoItems.sync='ephemeral.selectedTodoItems'
-          )
+          .c-payments-table-container
+            payments-list(
+              ref='paymentList'
+              :titles='tableTitles'
+              :paymentsList='paginateList(paymentsFiltered)'
+              :paymentsType='ephemeral.activeTab'
+              :selectedTodoItems.sync='ephemeral.selectedTodoItems'
+            )
+
           .c-footer
             .c-payment-record(v-if='ephemeral.activeTab === "PaymentRowTodo"')
               .c-payment-info-wrapper
@@ -653,6 +655,16 @@ export default ({
       // if the text input element is empty.
       padding-right: 1.375rem;
     }
+  }
+}
+
+.c-payments-table-container {
+  position: relative;
+
+  @include desktop {
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
   }
 }
 


### PR DESCRIPTION
closes #2188 

Apparently 'Showing ellipsis when the user name is too long' has been resolved since the issue was created, but there is still an outstanding bug where some table header elements (`<th>..</th>`) become double lines with not enough margins in between them. 

Made a fix where it makes sure the headers remain single-line in narrow screen and add horizontal scroll-bar to prevent overflowing elements from happening. Hope it sounds good.

**[Before]**

![payment-table-issue](https://github.com/user-attachments/assets/62148cca-1c9e-452b-9395-2cf659405dc0)

<br>

**[After]**

<img width="1281" alt="payment-table-fix" src="https://github.com/user-attachments/assets/f3fb4dda-7123-4838-850d-ab66c2edea7e">
