### PR TITLE
#2373 - Bug: Proposal does not expire

### DIFF
--- a/frontend/controller/actions/group.js
+++ b/frontend/controller/actions/group.js
@@ -1106,13 +1106,15 @@ export default (sbp('sbp/selectors/register', {
   ...encryptedAction('gi.actions/group/markProposalsExpired', L('Failed to mark proposals expired.'), async function (sendMessage, params) {
     const { contractID, data } = params
     const state = await sbp('chelonia/contract/state', contractID)
-    const proposal = state.proposals[data.proposalHash]
-    const proposalToSend = extractProposalData(proposal, { proposalId: data.proposalHash, status: STATUS_EXPIRED })
+
+    for (const proposalHash of data.proposalIds) {
+      const proposal = state.proposals[proposalHash]
+      const proposalToSend = extractProposalData(proposal, { proposalId: proposalHash, status: STATUS_EXPIRED })
+
+      await sbp('gi.actions/group/notifyProposalStateInGeneralChatRoom', { groupID: contractID, proposal: proposalToSend })
+    }
 
     const response = await sendMessage(params)
-
-    await sbp('gi.actions/group/notifyProposalStateInGeneralChatRoom', { groupID: contractID, proposal: proposalToSend })
-
     return response
   }),
   ...encryptedAction('gi.actions/group/updateSettings', L('Failed to update group settings.')),


### PR DESCRIPTION
closes #2373 

I can see the app now handles proposal expiration correctly.

<img src='https://github.com/user-attachments/assets/fb551d0d-5f52-45e9-990b-558a240da135' width='80%'>

<br>

---

It appears that `gi.actions/group/markProposalsExpired` used to only take one proposal ID as the param(`data.proposalHash`) and then was changed to take an array of IDs(`data.proposalIds`) later. But the relevant part in `frontend/controller/actions/group.js` file has not been updated to take this into account, which lead to causing below runtime error:

<img src='https://github.com/user-attachments/assets/366736dd-395d-44bb-8ef4-193bea4cf6ef' width='80%'>

<br>

So made a fix accordingly.