### PR TITLE
#2392 - No need to send a notification when the chatroom is open

### DIFF
--- a/frontend/controller/actions/chatroom.js
+++ b/frontend/controller/actions/chatroom.js
@@ -24,6 +24,9 @@ sbp('okTurtles.events/on', MESSAGE_RECEIVE_RAW, ({
   const getters = sbp('state/vuex/getters')
   const rootState = sbp('state/vuex/state')
   const targetChatroomState = rootState[contractID]
+  const currentRoute = sbp('controller/router').history.current || ''
+  const isTargetChatroomCurrentlyActive = currentRoute.path.includes('/group-chat') &&
+    getters.currentChatRoomId === contractID
   const mentions = makeMentionFromUserID(getters.ourIdentityContractId)
   const msgData = newMessage || data
   const isMentionedMe = (!!newMessage || data.type === MESSAGE_TYPES.TEXT) && msgData.text &&
@@ -39,7 +42,7 @@ sbp('okTurtles.events/on', MESSAGE_RECEIVE_RAW, ({
     if (isAlreadyAdded) return
   }
 
-  messageReceivePostEffect({
+  !isTargetChatroomCurrentlyActive && messageReceivePostEffect({
     contractID,
     messageHash: msgData.hash,
     height: msgData.height,

--- a/frontend/controller/actions/chatroom.js
+++ b/frontend/controller/actions/chatroom.js
@@ -26,7 +26,7 @@ sbp('okTurtles.events/on', MESSAGE_RECEIVE_RAW, ({
   const targetChatroomState = rootState[contractID]
   const currentRoute = sbp('controller/router').history.current || ''
   const isTargetChatroomCurrentlyActive = currentRoute.path.includes('/group-chat') &&
-    getters.currentChatRoomId === contractID
+    getters.currentChatRoomId === contractID // when the target chatroom is currently open/active on the browser, No need to send a notification.
   const mentions = makeMentionFromUserID(getters.ourIdentityContractId)
   const msgData = newMessage || data
   const isMentionedMe = (!!newMessage || data.type === MESSAGE_TYPES.TEXT) && msgData.text &&


### PR DESCRIPTION
closes #2392 

It appears the fix works well when tested with multiple containers of Firefox Dev Edition.