### PR TITLE
#2393 - Add `ButtonSubmit.vue` for 'Send message' button

### DIFF
--- a/frontend/views/components/ButtonSubmit.vue
+++ b/frontend/views/components/ButtonSubmit.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
   button.is-loader(
-    type='submit'
+    :type='type'
     ref='btn'
     v-bind='$attrs'
     v-on='bindListeners'
@@ -43,7 +43,11 @@ https://github.com/okTurtles/group-income/pull/854/files#r388638068
 export default ({
   name: 'ButtonSubmit',
   props: {
-    disabled: Boolean
+    disabled: Boolean,
+    type: {
+      type: String,
+      default: 'submit'
+    }
   },
   data: () => ({
     ephemeral: {

--- a/frontend/views/components/ProfileCard.vue
+++ b/frontend/views/components/ProfileCard.vue
@@ -63,11 +63,12 @@ tooltip(
         ) Add payment information
 
       .buttons(v-if='!isSelf')
-        i18n.button.is-outlined.is-small(
-          tag='button'
-          @click='sendMessage'
+        button-submit.is-outlined.is-small(
+          type='button'
           data-test='buttonSendMessage'
-        ) Send message
+          @click='sendMessage'
+        )
+          i18n Send message
 
         i18n.button.is-outlined.is-small(
           v-if='groupShouldPropose || isGroupCreator'
@@ -85,6 +86,7 @@ tooltip(
 <script>
 import sbp from '@sbp/sbp'
 import AvatarUser from '@components/AvatarUser.vue'
+import ButtonSubmit from '@components/ButtonSubmit.vue'
 import UserName from '@components/UserName.vue'
 import Tooltip from '@components/Tooltip.vue'
 import ModalClose from '@components/modal/ModalClose.vue'
@@ -114,7 +116,8 @@ export default ({
     AvatarUser,
     ModalClose,
     UserName,
-    Tooltip
+    Tooltip,
+    ButtonSubmit
   },
   computed: {
     ...mapGetters([
@@ -165,10 +168,10 @@ export default ({
     toggleTooltip () {
       this.$refs.tooltip.toggle()
     },
-    sendMessage () {
+    async sendMessage () {
       const chatRoomID = this.ourGroupDirectMessageFromUserIds(this.contractID)
       if (!chatRoomID) {
-        this.createDirectMessage(this.contractID)
+        await this.createDirectMessage(this.contractID)
       } else {
         if (!this.ourGroupDirectMessages[chatRoomID].visible) {
           this.setDMVisibility(chatRoomID, true)
@@ -178,6 +181,9 @@ export default ({
       }
       this.toggleTooltip()
     }
+  },
+  beforeDestroy () {
+    console.log('!@# destroyed!!')
   }
 }: Object)
 </script>

--- a/frontend/views/components/ProfileCard.vue
+++ b/frontend/views/components/ProfileCard.vue
@@ -181,9 +181,6 @@ export default ({
       }
       this.toggleTooltip()
     }
-  },
-  beforeDestroy () {
-    console.log('!@# destroyed!!')
   }
 }: Object)
 </script>


### PR DESCRIPTION
closes #2393 

Apparently, the tooltip is dismissed immediately after the 'Send message' button when `this.createDirectMessage(this.contractID)` triggered by it is a series of async operation.
https://github.com/okTurtles/group-income/blob/83f11f1ed18c5d3740088cabd97f86e93ff9617e/frontend/views/components/ProfileCard.vue#L171

So replaced the button with `ButtonSubmit.vue` as the visual indicator so that it gets dismissed after the DM is created.

<img src='https://github.com/user-attachments/assets/4f333290-eb6c-4d89-bf8b-176d67c3ebb2' width='480'>

Hope it sounds good and let me know if there is addition al thing needed along with this.