### PR TITLE
#2406 - payment table UI issue

### DIFF
--- a/frontend/assets/style/_mixins.scss
+++ b/frontend/assets/style/_mixins.scss
@@ -48,6 +48,13 @@
   }
 }
 
+$payment-table-desktop-bp: 1290px;
+@mixin payment-table-desktop {
+  @media screen and (min-width: $payment-table-desktop-bp) {
+    @content;
+  }
+}
+
 %unselectable {
   -webkit-touch-callout: none;
   -webkit-user-select: none;

--- a/frontend/views/containers/payments/PaymentRowReceived.vue
+++ b/frontend/views/containers/payments/PaymentRowReceived.vue
@@ -129,7 +129,7 @@ export default ({
 .c-relative-to {
   display: none;
 
-  @include desktop {
+  @include payment-table-desktop {
     display: block;
   }
 }

--- a/frontend/views/containers/payments/PaymentRowSent.vue
+++ b/frontend/views/containers/payments/PaymentRowSent.vue
@@ -117,7 +117,7 @@ export default ({
 .c-relative-to {
   display: none;
 
-  @include desktop {
+  @include payment-table-desktop {
     display: block;
   }
 }

--- a/frontend/views/containers/payments/PaymentsList.vue
+++ b/frontend/views/containers/payments/PaymentsList.vue
@@ -174,8 +174,11 @@ export default ({
   }
 
   ::v-deep td.c-td-user {
-    @include desktop {
+    @include tablet {
       padding-right: 0.5rem;
+    }
+
+    @include desktop {
       max-width: 12rem;
       min-width: 10rem;
       overflow: hidden;
@@ -208,19 +211,31 @@ export default ({
       width: 40%;
 
       @include tablet {
-        width: 27%;
+        width: 35%;
       }
     }
 
     th.c-th-method {
       width: 20%;
+
+      @include tablet {
+        padding-right: 0.5rem;
+        min-width: 8rem;
+      }
     }
 
     th.c-th-amount {
       width: 55%;
 
       @include tablet {
-        width: 24%;
+        width: 16%;
+      }
+    }
+
+    th.c-th-date {
+      @include desktop {
+        padding-right: 1.5rem;
+        min-width: 4.25rem;
       }
     }
   }
@@ -241,7 +256,7 @@ export default ({
         width: 20%;
       }
 
-      @include payment-table-desktop {
+      @include desktop {
         width: 14%;
       }
     }
@@ -249,6 +264,7 @@ export default ({
     th.c-th-method {
       @include tablet {
         width: 24%;
+        padding-right: 0.5rem;
       }
 
       @include payment-table-desktop {
@@ -259,6 +275,10 @@ export default ({
     th.c-th-date {
       width: 18%;
       padding-right: 0.5rem;
+
+      @include desktop {
+        width: 22%;
+      }
     }
 
     th.c-th-relative-to {

--- a/frontend/views/containers/payments/PaymentsList.vue
+++ b/frontend/views/containers/payments/PaymentsList.vue
@@ -150,25 +150,25 @@ export default ({
       text-align: right;
     }
 
-    @include desktop {
+    @include payment-table-desktop {
       min-width: 4.5rem;
     }
   }
 
   th.c-th-method {
-    @include desktop {
+    @include payment-table-desktop {
       min-width: 7.25rem;
     }
   }
 
   th.c-th-date {
-    @include desktop {
+    @include payment-table-desktop {
       min-width: 6.25rem;
     }
   }
 
   th.c-th-relative-to {
-    @include desktop {
+    @include payment-table-desktop {
       min-width: 5.25rem;
     }
   }
@@ -176,6 +176,21 @@ export default ({
   ::v-deep td.c-td-user {
     @include desktop {
       padding-right: 0.5rem;
+      max-width: 12rem;
+      min-width: 10rem;
+      overflow: hidden;
+
+      .c-user {
+        max-width: inherit;
+
+        .c-twrapper {
+          width: 100%;
+        }
+      }
+    }
+
+    @include from (1360px) {
+      max-width: 16rem;
     }
   }
 
@@ -226,7 +241,7 @@ export default ({
         width: 20%;
       }
 
-      @include desktop {
+      @include payment-table-desktop {
         width: 14%;
       }
     }
@@ -236,7 +251,7 @@ export default ({
         width: 24%;
       }
 
-      @include desktop {
+      @include payment-table-desktop {
         width: 19%;
       }
     }
@@ -250,7 +265,7 @@ export default ({
       display: none;
       padding-right: 0;
 
-      @include desktop {
+      @include payment-table-desktop {
         display: table-cell;
         width: 14%;
       }
@@ -259,7 +274,7 @@ export default ({
     th.c-th-action {
       display: none;
 
-      @include desktop {
+      @include payment-table-desktop {
         display: table-cell;
         width: 5%;
       }

--- a/frontend/views/containers/payments/payment-row/PaymentRow.vue
+++ b/frontend/views/containers/payments/payment-row/PaymentRow.vue
@@ -27,7 +27,7 @@
     td(v-if='$slots["cellRelativeTo"]')
       slot(name='cellRelativeTo')
 
-    td
+    td.c-td-actions
       .cpr-actions
         slot(name='cellActions')
 
@@ -109,6 +109,12 @@ export default ({
   @include phone {
     display: inline-block;
     margin-left: 0;
+  }
+}
+
+td.c-td-actions {
+  @include desktop {
+    padding-right: 1.5rem;
   }
 }
 </style>

--- a/frontend/views/pages/Payments.vue
+++ b/frontend/views/pages/Payments.vue
@@ -90,14 +90,13 @@ page(
 
       .tab-section
         .c-container(v-if='paymentsFiltered.length')
-          .c-payments-table-container
-            payments-list(
-              ref='paymentList'
-              :titles='tableTitles'
-              :paymentsList='paginateList(paymentsFiltered)'
-              :paymentsType='ephemeral.activeTab'
-              :selectedTodoItems.sync='ephemeral.selectedTodoItems'
-            )
+          payments-list(
+            ref='paymentList'
+            :titles='tableTitles'
+            :paymentsList='paginateList(paymentsFiltered)'
+            :paymentsType='ephemeral.activeTab'
+            :selectedTodoItems.sync='ephemeral.selectedTodoItems'
+          )
 
           .c-footer
             .c-payment-record(v-if='ephemeral.activeTab === "PaymentRowTodo"')
@@ -655,16 +654,6 @@ export default ({
       // if the text input element is empty.
       padding-right: 1.375rem;
     }
-  }
-}
-
-.c-payments-table-container {
-  position: relative;
-
-  @include desktop {
-    width: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
   }
 }
 


### PR DESCRIPTION
closes #2406 
closes #2415 

As mentioned in [this Slack thread](https://okturtles.slack.com/archives/C0EH7P20Y/p1730230979030599), horizontal scrollbar creates another critical issue where the menu dropdown is cropped or even not visible at all in some cases.
So decided to revert the previous fix and instead extended current css media-queries settings to make sure nothing overflows the table layout.

**[case 1 - table has enough space]**

![image](https://github.com/user-attachments/assets/4532b78d-3492-4685-8bb7-5f803f8a1aae)

<br>

**[case 2- table does not have enough space]**

![image](https://github.com/user-attachments/assets/e6ba6255-df58-4e5c-85c6-fcb94dbd9efc)


Hope it looks good!