### PR TITLE
#2411 - Compress large images attached in the chat

### DIFF
--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -587,13 +587,13 @@ export default (sbp('sbp/selectors/register', {
     const { identityContractID } = sbp('state/vuex/state').loggedIn
     try {
       const attachmentsData = await Promise.all(attachments.map(async (attachment) => {
-        const { url, needsIamgeCompression } = attachment
+        const { url, needsImageCompression } = attachment
         // url here is an instance of URL.createObjectURL(), which needs to be converted to a 'Blob'
-        const attachmentBlob = needsIamgeCompression
+        const attachmentBlob = needsImageCompression
           ? await compressImage(url)
           : await objectURLtoBlob(url)
 
-        if (needsIamgeCompression) {
+        if (needsImageCompression) {
           // Update the attachment details to reflect the compressed image.
           const fileNameWithoutExtension = attachment.name.split('.').slice(0, -1).join('.')
           const extension = attachmentBlob.type.split('/')[1]
@@ -607,7 +607,7 @@ export default (sbp('sbp/selectors/register', {
         }, { billableContractID })
         const { delete: token, download: downloadData } = response
         return {
-          attributes: omit(attachment, ['url', 'needsIamgeCompression']),
+          attributes: omit(attachment, ['url', 'needsImageCompression']),
           downloadData,
           deleteData: { token }
         }

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -9,7 +9,7 @@ import {
 import { cloneDeep, has, omit } from '@model/contracts/shared/giLodash.js'
 import { SETTING_CHELONIA_STATE } from '@model/database.js'
 import sbp from '@sbp/sbp'
-import { imageUpload, objectURLtoBlob } from '@utils/image.js'
+import { imageUpload, objectURLtoBlob, compressImage } from '@utils/image.js'
 import { SETTING_CURRENT_USER } from '~/frontend/model/database.js'
 import { KV_QUEUE, LOGIN, LOGOUT } from '~/frontend/utils/events.js'
 import { GIMessage } from '~/shared/domains/chelonia/GIMessage.js'
@@ -587,15 +587,27 @@ export default (sbp('sbp/selectors/register', {
     const { identityContractID } = sbp('state/vuex/state').loggedIn
     try {
       const attachmentsData = await Promise.all(attachments.map(async (attachment) => {
-        const { mimeType, url } = attachment
+        const { url, needsIamgeCompression } = attachment
         // url here is an instance of URL.createObjectURL(), which needs to be converted to a 'Blob'
-        const attachmentBlob = await objectURLtoBlob(url)
+        const attachmentBlob = needsIamgeCompression
+          ? await compressImage(url)
+          : await objectURLtoBlob(url)
+
+        if (needsIamgeCompression) {
+          // Update the attachment details to reflect the compressed image.
+          const fileNameWithoutExtension = attachment.name.split('.').slice(0, -1).join('.')
+          const extension = attachmentBlob.type.split('/')[1]
+
+          attachment.mimeType = attachmentBlob.type
+          attachment.name = `${fileNameWithoutExtension}.${extension}`
+        }
         const response = await sbp('chelonia/fileUpload', attachmentBlob, {
-          type: mimeType, cipher: 'aes256gcm'
+          type: attachment.mimeType,
+          cipher: 'aes256gcm'
         }, { billableContractID })
         const { delete: token, download: downloadData } = response
         return {
-          attributes: omit(attachment, ['url']),
+          attributes: omit(attachment, ['url', 'needsIamgeCompression']),
           downloadData,
           deleteData: { token }
         }

--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -20,6 +20,7 @@ export const CHAT_ATTACHMENT_SUPPORTED_EXTENSIONS = [
 // TODO: fetch this value from a server API
 export const MEGABYTE = 1 << 20
 export const CHAT_ATTACHMENT_SIZE_LIMIT = 30 * MEGABYTE // in byte.
+export const IMAGE_ATTACHMENT_MAX_SIZE = 400000 // 400KB
 
 export const TextObjectType = {
   Text: 'TEXT',

--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -18,9 +18,10 @@ export const CHAT_ATTACHMENT_SUPPORTED_EXTENSIONS = [
 // NOTE: Below value was obtained from the '413 Payload Too Large' server error
 //       meaning if this limit is updated on the server-side, an update is required here too.
 // TODO: fetch this value from a server API
+export const KILOBYTE = 1 << 10
 export const MEGABYTE = 1 << 20
 export const CHAT_ATTACHMENT_SIZE_LIMIT = 30 * MEGABYTE // in byte.
-export const IMAGE_ATTACHMENT_MAX_SIZE = 400000 // 400KB
+export const IMAGE_ATTACHMENT_MAX_SIZE = 400 * KILOBYTE // 400KB
 
 export const TextObjectType = {
   Text: 'TEXT',

--- a/frontend/utils/image.js
+++ b/frontend/utils/image.js
@@ -104,7 +104,7 @@ export async function compressImage (imgUrl: string, sourceMimeType?: string): P
     const sizeDiff = blob.size - IMAGE_ATTACHMENT_MAX_SIZE
 
     if (sizeDiff <= 0 || // if the compressed image is already smaller than the max size, return the compressed image.
-      quality <= 0.4) { // Do not sacrifice the image quality too much.
+      quality <= 0.3) { // Do not sacrifice the image quality too much.
       return blob
     } else {
       // if the size difference is greater than 100KB, reduce the next compression factors by 10%, otherwise 5%.

--- a/frontend/utils/image.js
+++ b/frontend/utils/image.js
@@ -30,6 +30,20 @@ export const imageUpload = async (imageFile: File, params: ?Object): Promise<Obj
 }
 
 // Image compression
+
+export function supportsWebP (): Promise<boolean> {
+  // Uses a very small webP image to check if the browser supports 'image/webp' format.
+  // (reference: https://developers.google.com/speed/webp/faq#in_your_own_javascript)
+  const verySmallWebP = 'data:image/webp;base64,UklGRhIAAABXRUJQVlA4WAoAAAAQAAAAMwAAQUxQSAwAAAAwAQCdASoEAAQAAVAfCWkAQUwAAAABABgAAgAAAAAABAAAAAAAAAA'
+  const img = new Image()
+
+  return new Promise(resolve => {
+    img.onload = () => resolve(img.height > 0)
+    img.onerror = () => resolve(false)
+    img.src = verySmallWebP
+  })
+}
+
 function loadImage (url): any {
   const imgEl = new Image()
 

--- a/frontend/utils/image.js
+++ b/frontend/utils/image.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import sbp from '@sbp/sbp'
-import { IMAGE_ATTACHMENT_MAX_SIZE } from './constants.js'
+import { KILOBYTE, IMAGE_ATTACHMENT_MAX_SIZE } from './constants.js'
 
 // Copied from https://stackoverflow.com/questions/11876175/how-to-get-a-file-or-blob-from-an-object-url
 export function objectURLtoBlob (url: string): Promise<Blob> {
@@ -120,7 +120,7 @@ export async function compressImage (imgUrl: string, sourceMimeType?: string): P
       return blob
     } else {
       // if the size difference is greater than 100KB, reduce the next compression factors by 10%, otherwise 5%.
-      const minusFactor = sizeDiff > 100 * 1000 ? 0.1 : 0.05
+      const minusFactor = sizeDiff > 100 * KILOBYTE ? 0.1 : 0.05
       quality -= minusFactor
     }
   }

--- a/frontend/utils/image.js
+++ b/frontend/utils/image.js
@@ -84,9 +84,10 @@ function generateImageBlobByCanvas ({
 
 function getResizingFactor (sourceImage) {
   // If image's physical size is greater than the max dimension, resize the image to the max dimension.
-  const imageMaxDimension = { width: 1024, height: 768 }
+  const imageMaxDimension = { width: 2048, height: 1536 }
   const { naturalWidth, naturalHeight } = sourceImage
 
+  console.log(`!@# naturalWidth: ${naturalWidth}, naturalHeight: ${naturalHeight}`)
   if (naturalWidth > imageMaxDimension.width || naturalHeight > imageMaxDimension.height) {
     return Math.min(imageMaxDimension.width / naturalWidth, imageMaxDimension.height / naturalHeight)
   }
@@ -98,7 +99,8 @@ export async function compressImage (imgUrl: string, sourceMimeType?: string): P
   // Takes a source image url and generate a blob of the compressed image.
 
   // According to the testing result, webP format has a better compression ratio than jpeg.
-  const compressToType = await supportsWebP() ? 'image/webp' : 'image/jpeg'
+  // const compressToType = await supportsWebP() ? 'image/webp' : 'image/jpeg'
+  const compressToType = 'image/jpeg'
   const sourceImage = await loadImage(imgUrl)
 
   // According to the testing result, 0.8 is a good starting point for quality for .jpeg and .webp.
@@ -106,6 +108,7 @@ export async function compressImage (imgUrl: string, sourceMimeType?: string): P
   let quality = ['image/jpeg', 'image/webp'].includes(sourceMimeType) ? 0.8 : 0.9
   const resizingFactor = getResizingFactor(sourceImage)
 
+  console.log(`!@# resizingFactor: ${resizingFactor}`)
   while (true) {
     const blob = await generateImageBlobByCanvas({
       sourceImage,

--- a/frontend/utils/image.js
+++ b/frontend/utils/image.js
@@ -87,7 +87,6 @@ function getResizingFactor (sourceImage) {
   const imageMaxDimension = { width: 2048, height: 1536 }
   const { naturalWidth, naturalHeight } = sourceImage
 
-  console.log(`!@# naturalWidth: ${naturalWidth}, naturalHeight: ${naturalHeight}`)
   if (naturalWidth > imageMaxDimension.width || naturalHeight > imageMaxDimension.height) {
     return Math.min(imageMaxDimension.width / naturalWidth, imageMaxDimension.height / naturalHeight)
   }
@@ -99,8 +98,7 @@ export async function compressImage (imgUrl: string, sourceMimeType?: string): P
   // Takes a source image url and generate a blob of the compressed image.
 
   // According to the testing result, webP format has a better compression ratio than jpeg.
-  // const compressToType = await supportsWebP() ? 'image/webp' : 'image/jpeg'
-  const compressToType = 'image/jpeg'
+  const compressToType = await supportsWebP() ? 'image/webp' : 'image/jpeg'
   const sourceImage = await loadImage(imgUrl)
 
   // According to the testing result, 0.8 is a good starting point for quality for .jpeg and .webp.
@@ -108,7 +106,6 @@ export async function compressImage (imgUrl: string, sourceMimeType?: string): P
   let quality = ['image/jpeg', 'image/webp'].includes(sourceMimeType) ? 0.8 : 0.9
   const resizingFactor = getResizingFactor(sourceImage)
 
-  console.log(`!@# resizingFactor: ${resizingFactor}`)
   while (true) {
     const blob = await generateImageBlobByCanvas({
       sourceImage,

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -690,7 +690,7 @@ export default ({
         'send',
         msgToSend,
         this.hasAttachments
-          ? cloneDeep(this.ephemeral.attachments).map(this.compressImage)
+          ? cloneDeep(this.ephemeral.attachments)
           : null,
         this.replyingMessage
       ) // TODO remove first / last empty lines
@@ -698,12 +698,6 @@ export default ({
       this.updateTextArea()
       this.endMention()
       if (this.hasAttachments) { this.clearAllAttachments() }
-    },
-    compressImage (attachment) {
-      if (attachment.needsIamgeCompression) {
-        console.log('TODO: implement image compression logic here')
-      }
-      return attachment
     },
     openCreatePollModal () {
       const bbox = this.$el.getBoundingClientRect()

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -756,7 +756,7 @@ export default ({
           img.src = fileUrl
 
           // Determine if the image needs lossy-compression before upload.
-          attachment.needsIamgeCompression = fileSize > IMAGE_ATTACHMENT_MAX_SIZE
+          attachment.needsImageCompression = fileSize > IMAGE_ATTACHMENT_MAX_SIZE
         }
 
         list.push(attachment)

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -279,7 +279,7 @@ import {
   CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR,
   CHATROOM_MAX_MESSAGE_LEN
 } from '@model/contracts/shared/constants.js'
-import { CHAT_ATTACHMENT_SIZE_LIMIT } from '~/frontend/utils/constants.js'
+import { CHAT_ATTACHMENT_SIZE_LIMIT, IMAGE_ATTACHMENT_MAX_SIZE } from '~/frontend/utils/constants.js'
 import { OPEN_MODAL, CHATROOM_USER_TYPING, CHATROOM_USER_STOP_TYPING } from '@utils/events.js'
 import { uniq, throttle, cloneDeep } from '@model/contracts/shared/giLodash.js'
 import {
@@ -689,13 +689,21 @@ export default ({
       this.$emit(
         'send',
         msgToSend,
-        this.hasAttachments ? cloneDeep(this.ephemeral.attachments) : null,
+        this.hasAttachments
+          ? cloneDeep(this.ephemeral.attachments).map(this.compressImage)
+          : null,
         this.replyingMessage
       ) // TODO remove first / last empty lines
       this.$refs.textarea.value = ''
       this.updateTextArea()
       this.endMention()
       if (this.hasAttachments) { this.clearAllAttachments() }
+    },
+    compressImage (attachment) {
+      if (attachment.needsIamgeCompression) {
+        console.log('TODO: implement image compression logic here')
+      }
+      return attachment
     },
     openCreatePollModal () {
       const bbox = this.$el.getBoundingClientRect()
@@ -752,6 +760,9 @@ export default ({
             attachment.dimension = { width, height }
           }
           img.src = fileUrl
+
+          // Determine if the image needs lossy-compression before upload.
+          attachment.needsIamgeCompression = fileSize > IMAGE_ATTACHMENT_MAX_SIZE
         }
 
         list.push(attachment)


### PR DESCRIPTION
closes #2411

<img src='https://github.com/user-attachments/assets/150a99d8-969a-452f-9279-19683356fac6' width='580'>

<br>

<img src='https://github.com/user-attachments/assets/44a87feb-7c76-437b-8305-a7fd01b045a7' width='450'>

---
**[NOTE]**

- As @taoeffect suggested in the issue, `400KB` will be the size value to determine compression is needed.

- The app uses HTML canvas API ([toBlob()](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/toBlob), [drawImage()](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/drawImage)) to compress the image on the browser, which is a popular client-side image-compression [npm package](https://www.npmjs.com/package/compressorjs) internally uses as well.

- The compression outcome will be one of two most popular images formats on the web that support lossy-compression (`image/webp` or `image/jpeg`). According to tests I've done (pls feel free to check out [this codepen](https://codepen.io/freenaturalsoul/pen/vYoMWWv?editors=0100) I created for testing for yourself too), **converting to 'webp' format apparently has a better compression efficiency than 'jpeg'** (meaning it drops the file size below **400KB** without sacrificing too much quality). So if the browser supports `webp` format, the outcome will always be `webp` and otherwise `jpeg`.
