### PR TITLE
#2447 - Content overflowing issue in proposal widget on mobile size screen

### DIFF
--- a/frontend/views/components/PageSection.vue
+++ b/frontend/views/components/PageSection.vue
@@ -51,5 +51,6 @@ export default ({
   align-items: center;
   justify-content: space-between;
   flex-wrap: wrap;
+  row-gap: 1rem; // There should be a space between the title and the cta when they become two rows.
 }
 </style>

--- a/frontend/views/containers/proposals/ProposalItem.vue
+++ b/frontend/views/containers/proposals/ProposalItem.vue
@@ -24,7 +24,7 @@ li.c-item-wrapper(data-test='proposalItem')
             .button.is-icon-smaller.is-primary
               i.icon-question
 
-        p(data-test='title' v-safe-html='subtitle')
+        p.c-content-title(data-test='title' v-safe-html='subtitle')
 
         p.has-text-1(
           :class='{ "has-text-danger": proposal.status === statuses.STATUS_FAILED, "has-text-success": proposal.status === statuses.STATUS_PASSED }'
@@ -379,6 +379,10 @@ export default ({
 
   &-content {
     flex-grow: 1;
+  }
+
+  .c-content-title {
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
closes #2447 


**[Fix screenshot]**

<img src='https://github.com/user-attachments/assets/4f5c3f77-eec8-4940-a645-ebcc935089c3' width='320'>