### PR TITLE
#2457 - Fix the broken blockquotes in the chat markdown

### DIFF
--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -115,6 +115,7 @@
     position: relative;
     padding-left: 1rem;
     white-space: pre-line;
+    margin: 0.25rem 0;
 
     &::before {
       content: "";
@@ -126,6 +127,11 @@
       bottom: 0;
       border-radius: 8px;
       background-color: $general_0;
+    }
+
+    p:has(+ p, + pre),
+    pre:has(+ p, + pre) {
+      margin-bottom: 1rem;
     }
   }
 

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -37,12 +37,13 @@ export function renderMarkdown (str: string): any {
   strSplitByCodeMarkdown.forEach((entry, index) => {
     if (entry.type === 'plain' && strSplitByCodeMarkdown[index - 1]?.text !== '```') {
       let entryText = entry.text
-      entryText = entryText.replace(/</g, '&lt;').replace(/>/g, '&gt;')
+      entryText = entryText.replace(/</g, '&lt;')
+        .replace(/(?<!(^|\n))>/g, '&gt;') // Replace all '>' with '&gt;' except for the ones that are not preceded by a line-break or start of the string (e.g. '> asdf' is a blockquote).
 
       entryText = entryText.replace(/\n(?=\n)/g, '\n<br>')
-        .replace(/<br>\n(\s*)(\d+\.|-)/g, '\n\n$1$2') // [1] custom-handling the case where <br> is directly followed by the start of ordered/unordered lists
-        .replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // [2] this is a custom-logic added so that the end of ordered/un-ordered lists are correctly detected by markedjs.
-
+        .replace(/<br>\n(\s*)(>|\d+\.|-)/g, '\n\n$1$2') // [1] custom-handling the case where <br> is directly followed by the start of ordered/unordered lists
+        .replace(/(>|\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // [2] this is a custom-logic added so that the end of ordered/un-ordered lists are correctly detected by markedjs.
+        .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // [3] this is a custom-logic added so that the end of blockquotes are correctly detected by markedjs. ('s' flag is needed to account for multi-line strings)
       entry.text = entryText
     }
   })

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -44,12 +44,15 @@ export function renderMarkdown (str: string): any {
         .replace(/<br>\n(\s*)(>|\d+\.|-)/g, '\n\n$1$2') // [1] custom-handling the case where <br> is directly followed by the start of ordered/unordered lists
         .replace(/(>|\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // [2] this is a custom-logic added so that the end of ordered/un-ordered lists are correctly detected by markedjs.
         .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // [3] this is a custom-logic added so that the end of blockquotes are correctly detected by markedjs. ('s' flag is needed to account for multi-line strings)
+
+      console.log('!@# entryText after all transformations: ', entryText)
       entry.text = entryText
     }
   })
 
   str = combineMarkdownSegmentListIntoString(strSplitByCodeMarkdown)
-  str = str.replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // Check for [2] above once more to resolve edge-cases (reference: https://github.com/okTurtles/group-income/issues/2356)
+  str = str.replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n')
+    .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n')  // Check for [2], [3] above once more to resolve edge-cases (reference: https://github.com/okTurtles/group-income/issues/2356)
 
   // STEP 2. convert the markdown into html DOM string.
   let converted = marked.parse(str, { gfm: true })

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -51,7 +51,7 @@ export function renderMarkdown (str: string): any {
 
   str = combineMarkdownSegmentListIntoString(strSplitByCodeMarkdown)
   str = str.replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n')
-    .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // Check for [2], [3] above once more to resolve edge-cases. (reference: https://github.com/okTurtles/group-income/issues/2356)
+    .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // Check for [2], [3] above once more to resolve edge-cases (reference: https://github.com/okTurtles/group-income/issues/2356)
 
   // STEP 2. convert the markdown into html DOM string.
   let converted = marked.parse(str, { gfm: true })

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -45,7 +45,6 @@ export function renderMarkdown (str: string): any {
         .replace(/(>|\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n') // [2] this is a custom-logic added so that the end of ordered/un-ordered lists are correctly detected by markedjs.
         .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // [3] this is a custom-logic added so that the end of blockquotes are correctly detected by markedjs. ('s' flag is needed to account for multi-line strings)
 
-      console.log('!@# entryText after all transformations: ', entryText)
       entry.text = entryText
     }
   })

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -51,7 +51,7 @@ export function renderMarkdown (str: string): any {
 
   str = combineMarkdownSegmentListIntoString(strSplitByCodeMarkdown)
   str = str.replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n')
-    .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n')  // Check for [2], [3] above once more to resolve edge-cases (reference: https://github.com/okTurtles/group-income/issues/2356)
+    .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // Check for [2], [3] above once more to resolve edge-cases (reference: https://github.com/okTurtles/group-income/issues/2356)
 
   // STEP 2. convert the markdown into html DOM string.
   let converted = marked.parse(str, { gfm: true })

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -51,7 +51,7 @@ export function renderMarkdown (str: string): any {
 
   str = combineMarkdownSegmentListIntoString(strSplitByCodeMarkdown)
   str = str.replace(/(\d+\.|-)(\s.+)\n<br>/g, '$1$2\n\n')
-    .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // Check for [2], [3] above once more to resolve edge-cases (reference: https://github.com/okTurtles/group-income/issues/2356)
+    .replace(/(>)(\s.+)\n<br>/gs, '$1$2\n\n') // Check for [2], [3] above once more to resolve edge-cases. (reference: https://github.com/okTurtles/group-income/issues/2356)
 
   // STEP 2. convert the markdown into html DOM string.
   let converted = marked.parse(str, { gfm: true })


### PR DESCRIPTION
closes #2457 

[ Fix screenshot ]

<img width="480" src="https://github.com/user-attachments/assets/b4597722-82eb-4c6a-a6ca-406879a0f8a7" />

Made sure this fix does not revert the fix for #2130 too.