### PR TITLE
#2449 - Improve UX for 'remove-member' proposal

### DIFF
--- a/frontend/views/components/ProfileCard.vue
+++ b/frontend/views/components/ProfileCard.vue
@@ -73,7 +73,7 @@ tooltip(
         i18n.button.is-outlined.is-small(
           v-if='groupShouldPropose || isGroupCreator'
           tag='button'
-          @click='openModal("RemoveMember", { memberID: contractID })'
+          @click.stop='onRemoveMemberClick'
           data-test='buttonRemoveMember'
         ) Remove member
 
@@ -91,7 +91,7 @@ import UserName from '@components/UserName.vue'
 import Tooltip from '@components/Tooltip.vue'
 import ModalClose from '@components/modal/ModalClose.vue'
 import DMMixin from '@containers/chatroom/DMMixin.js'
-import { OPEN_MODAL } from '@utils/events.js'
+import { OPEN_MODAL, REPLACE_MODAL } from '@utils/events.js'
 import { mapGetters } from 'vuex'
 import { PROFILE_STATUS } from '~/frontend/model/contracts/shared/constants.js'
 
@@ -159,11 +159,21 @@ export default ({
   },
   methods: {
     openModal (modal, props) {
-      if (this.deactivated) {
-        return
-      }
+      if (this.deactivated) { return }
       this.toggleTooltip()
+
       sbp('okTurtles.events/emit', OPEN_MODAL, modal, props)
+    },
+    onRemoveMemberClick () {
+      if (this.deactivated) { return }
+      this.toggleTooltip()
+
+      sbp(
+        'okTurtles.events/emit',
+        this.$route.query?.modal === 'GroupMembersAllModal' ? REPLACE_MODAL : OPEN_MODAL,
+        'RemoveMember',
+        { memberID: this.contractID }
+      )
     },
     toggleTooltip () {
       this.$refs.tooltip.toggle()

--- a/frontend/views/containers/dashboard/GroupMembersAllModal.vue
+++ b/frontend/views/containers/dashboard/GroupMembersAllModal.vue
@@ -180,7 +180,6 @@ export default ({
       this.$refs.modal.close()
     },
     removeMember (memberID) {
-      console.log('!@# is it here??')
       sbp('okTurtles.events/emit', REPLACE_MODAL, 'RemoveMember', { memberID })
     },
     addToChannel () {

--- a/frontend/views/containers/dashboard/GroupMembersAllModal.vue
+++ b/frontend/views/containers/dashboard/GroupMembersAllModal.vue
@@ -120,7 +120,7 @@ modal-base-template.has-background(
 <script>
 import sbp from '@sbp/sbp'
 import { L, LTags } from '@common/common.js'
-import { OPEN_MODAL } from '@utils/events.js'
+import { REPLACE_MODAL } from '@utils/events.js'
 import { mapGetters } from 'vuex'
 import ModalBaseTemplate from '@components/modal/ModalBaseTemplate.vue'
 import Search from '@components/Search.vue'
@@ -180,7 +180,8 @@ export default ({
       this.$refs.modal.close()
     },
     removeMember (memberID) {
-      sbp('okTurtles.events/emit', OPEN_MODAL, 'RemoveMember', { memberID })
+      console.log('!@# is it here??')
+      sbp('okTurtles.events/emit', REPLACE_MODAL, 'RemoveMember', { memberID })
     },
     addToChannel () {
       console.log('TODO addToChannel')


### PR DESCRIPTION
closes #2449 

The issue happens because 'Remove member' modal opens on top of 'GroupMembersAll' modal. So once the proposal is created and the modal is closed, it is revealed again. As a fix, I just have made it replace the (**a**)'GroupMembersAll' modal with (**b**)'RemoveMember' modal. (meaning it closes **a** before it opens **b**)