### PR TITLE
#2467 - Broken mention in blockquotes

### DIFF
--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -159,7 +159,7 @@ export function splitStringByMarkdownCode (
   // This function takes a markdown string and split it by texts written as either inline/block code.
   // (e.g. `asdf`, ```const var = 123```)
 
-  const regExCodeMultiple = /(^[\s]*```\n[\s\S]*?```$)/gm // Detecting multi-line code-block by reg-exp - reference: https://regexr.com/4h9sh
+  const regExCodeMultiple = /(```\n[\s\S]*?```$)/gm // Detecting multi-line code-block by reg-exp - reference: https://regexr.com/4h9sh
   const regExCodeInline = /(`.+`)/g
   const splitByMulitpleCode = str.split(regExCodeMultiple)
   const finalArr = []

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -168,7 +168,7 @@ export function splitStringByMarkdownCode (
     if (regExCodeMultiple.test(segment)) {
       finalArr.push({ type: 'code', text: segment })
     } else {
-      const splitByInlineCode = segment.split(regExCodeInline)
+      const splitByInlineCode = segment.split(regExCodeInline) // Check for inline codes and mark them as type: 'code'
         .map(piece => {
           return regExCodeInline.test(piece)
             ? { type: 'code', text: piece }


### PR DESCRIPTION
closes #2467 

The cause of the issue was that the regular expression to capture multi-line code blocks was not working correctly, especially in a complicated context. (eg. when ``` is preceeded by `>` character) So made a fix.

**[Screenshot]**

<img width="486" alt="markdown-fix-1" src="https://github.com/user-attachments/assets/92b4a130-eaa6-44d3-afce-c4a9e3149587" />

**[Screenshot 2 for a more complicated context] - Within list elements**

<img width="492" alt="markdown-fix-2" src="https://github.com/user-attachments/assets/b3a16e92-6311-42cc-bf97-a24ac5ef6586" />
