### PR TITLE
#2450 - Anchor tooltip to the element in 'Group Activity' area

### DIFF
--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -166,6 +166,31 @@ export default ({
             y = '-50%'
             absPosition = { top: '50%', right: `-${spacing}px` }
             break
+          case 'left':
+            x = '-100%'
+            y = '-50%'
+            absPosition = { top: '50%', left: `-${spacing}px` }
+            break
+          case 'bottom-left':
+            x = 0
+            y = '100%'
+            absPosition = { bottom: `-${spacing}px` }
+            break
+          case 'bottom-right':
+            x = 0
+            y = '100%'
+            absPosition = { bottom: `-${spacing}px`, right: 0 }
+            break
+          case 'top':
+            x = '-50%'
+            y = '-100%'
+            absPosition = { top: `-${spacing}px`, left: '50%' }
+            break
+          case 'top-left':
+            x = 0
+            y = '-100%'
+            absPosition = { top: `-${spacing}px`, left: 0 }
+            break
           default: // defaults to 'bottom'
             x = '-50%'
             y = '100%'

--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -279,11 +279,12 @@ export default ({
     anchorToTrigger: {
       inserted (el, bindings, vnode) {
         const $this = vnode.context
-        if ($this.triggerDOM) {
-          console.log('!@# here - aaa')
+        if ($this.triggerElementSelector) {
+          // Append the tooltip to a particular element (which is specified by a selector)
           $this.triggerDOM.appendChild(el)
-          $this.adjustPosition()
         }
+
+        $this.adjustPosition()
       }
     }
   },

--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -9,6 +9,7 @@ span.c-twrapper(
     .c-anchored-tooltip(
       v-if='anchorToElement'
       :class='tooltipClasses'
+      :style='{ "opacity": opacity }'
     )
       // Default tooltip is text
       template(v-if='text') {{text}}
@@ -191,7 +192,7 @@ export default ({
       this.styles = {
         transform: `translate(${x}px, ${y}px)`,
         pointerEvents: this.manual ? 'initial' : 'none',
-        backgroundColor: this.manual ? 'transparent' : 'var(--text_0)',
+        backgroundColor: this.manual ? 'transparent' : undefined,
         opacity: this.opacity
       }
     }
@@ -314,12 +315,8 @@ export default ({
     max-width: unset;
   }
 
-  &.is-dark-theme {
+  &.is-dark-theme .card {
     background-color: $general_1;
-
-    .card {
-      background-color: $general_1;
-    }
   }
 
   &.in-reduced-motion {

--- a/frontend/views/containers/dashboard/SentenceWithMemberTooltip.vue
+++ b/frontend/views/containers/dashboard/SentenceWithMemberTooltip.vue
@@ -4,7 +4,7 @@ component(
   :key='members.length'
   :opacity='members.length === 0 ? 0 : 0.95'
   triggerElementSelector='.t-trigger'
-  direction='bottom'
+  direction='bottom-left'
   :anchorToElement='true'
 )
   // The reason for using <component /> tag here instead of <tooltip /> and specifying 'key' attr is,
@@ -41,5 +41,6 @@ export default ({
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  font-weight: normal;
 }
 </style>

--- a/frontend/views/containers/dashboard/SentenceWithMemberTooltip.vue
+++ b/frontend/views/containers/dashboard/SentenceWithMemberTooltip.vue
@@ -5,6 +5,7 @@ component(
   :opacity='members.length === 0 ? 0 : 0.95'
   triggerElementSelector='.t-trigger'
   direction='bottom'
+  :anchorToElement='true'
 )
   // The reason for using <component /> tag here instead of <tooltip /> and specifying 'key' attr is,
   // to fix the bug where the link between the tooltip content(template(slot='tooltip') below) and the trigger target element(.t-trigger)
@@ -34,10 +35,6 @@ export default ({
 </script>
 
 <style lang="scss" scoped>
-.has-zero-members ::v-deep .c-tooltip {
-  display: none !important;
-}
-
 .c-member-name {
   // Turn the parent element into flex-box to render ellipsis style properly.
   position: relative;


### PR DESCRIPTION
closes #2450 

**[Before fix]**

https://github.com/user-attachments/assets/4d517cf8-61cc-47e2-b8ef-febc3bb433eb

**[After fix]**

https://github.com/user-attachments/assets/25de2166-f1c7-4d27-9fc6-61fb42fe1613

---
(cc. @taoeffect )
There are two issues pointed out in the issue which are,

**1]** Tooltip should be anchored to the app (rather than user's screen).
**2]** Tooltip should be closable.

Firstly, (As you can see in the video attached above too) I noticed **1.** is not a mobile-specific issue but does happen in desktop too. Apparently, this behaviour was intentionally implemented by the component author as you can read in below comment too:

https://github.com/okTurtles/group-income/blob/b6dc54d0a00fc21026dccb61651edb21b24ce71a/frontend/views/components/Tooltip.vue#L169-L173

The logic to determine tooltip position written as part of this custom-directive is currently widely used across the app. So as a fix for the issue, I added a component prop(`anchorToElement`) that allows to opt out of this behaviour and attach the tooltip to the trigger element instead.

@dotmacro Regarding **2**. you pointed out, the tooltip does look unable to close on mobile-browser but it actually remains there because the trigger element stays focused once we tap on it on mobile. We can just unfocus it to make it disappear  (it means not only clicking on other call-to-actions in the page but also merely clicking on a random position in the background too), which I think is right behaviour. So I haven't made any changes regarding **2.**. Hope it sounds good.

Thanks,