### PR TITLE
#2479 - Normalize group name string in 'GroupLeaveModal.vue'

### DIFF
--- a/frontend/model/contracts/shared/giLodash.js
+++ b/frontend/model/contracts/shared/giLodash.js
@@ -78,6 +78,15 @@ export function randomHexString (length: number): string {
   return Array.from(randomBytes(length), byte => (byte % 16).toString(16)).join('')
 }
 
+export function normalizeString (str: string): string {
+  return str
+    // [1]. Normalize strings by replacing both apostrophes and single quotes with a standard character (reference issue: https://github.com/okTurtles/group-income/issues/2479)
+    .replace(/['’]/g, "'")
+    // [2]. Normalize the string based on 'Canonical equivalence'. eg) 'Amélie' !== 'Amélie' even when they are visually identical because their unicode sequences are different.
+    //      (reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#canonical_equivalence_normalization)
+    .normalize('NFC')
+}
+
 export function randomIntFromRange (min: number, max: number): number {
   return Math.floor(Math.random() * (max - min + 1) + min)
 }

--- a/frontend/views/containers/group-settings/GroupLeaveModal.vue
+++ b/frontend/views/containers/group-settings/GroupLeaveModal.vue
@@ -63,6 +63,7 @@ import BannerSimple from '@components/banners/BannerSimple.vue'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 import validationsDebouncedMixins from '@view-utils/validationsDebouncedMixins.js'
+import { normalizeString } from '@model/contracts/shared/giLodash.js'
 
 export default ({
   name: 'GroupLeaveModal',
@@ -132,7 +133,7 @@ export default ({
       confirmation: {
         [L('This field is required')]: required,
         [L('Does not match')]: function (value) {
-          return value === this.code
+          return normalizeString(value) === normalizeString(this.code)
         }
       }
     }


### PR DESCRIPTION
closes #2479 

**[Fix screenshot]**

<img width="480" alt="fix-for-string-comparison" src="https://github.com/user-attachments/assets/49aa1101-e8d1-4ed4-81f2-4eed4feb4c3a" />

---
As a fix for the issue, I created `normalizeString` function in `giLodash.js` where two conversions happen:

1]  `'` and `’` are both considered `'`
2] [Canonical equivalence normalization](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize#canonical_equivalence_normalization)
