### PR TITLE
#2427 - Add 'reply' menu for a proposal notification message.

### DIFF
--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -137,7 +137,7 @@ import ViewArea from './ViewArea.vue'
 import Emoticons from './Emoticons.vue'
 import TouchLinkHelper from './TouchLinkHelper.vue'
 import DragActiveOverlay from './file-attachment/DragActiveOverlay.vue'
-import { MESSAGE_TYPES, MESSAGE_VARIANTS, CHATROOM_ACTIONS_PER_PAGE } from '@model/contracts/shared/constants.js'
+import { MESSAGE_TYPES, MESSAGE_VARIANTS, CHATROOM_ACTIONS_PER_PAGE, CHATROOM_MEMBER_MENTION_SPECIAL_CHAR } from '@model/contracts/shared/constants.js'
 import { CHATROOM_EVENTS, NEW_CHATROOM_UNREAD_POSITION, DELETE_ATTACHMENT_FEEDBACK } from '@utils/events.js'
 import { findMessageIdx } from '@model/contracts/shared/functions.js'
 import { proximityDate, MINS_MILLIS } from '@model/contracts/shared/time.js'
@@ -621,13 +621,13 @@ export default ({
 
       if (type === MESSAGE_TYPES.INTERACTIVE) {
         const proposal = message.proposal
-        const getDisplayName = (memberID) => {
+        const getNameFromMemberID = (memberID) => {
           const profile = this.globalProfile(memberID)
-          return profile?.displayName || profile?.username || memberID
+          return profile ? `${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${memberID}` : L('Unknown user')
         }
 
         this.ephemeral.replyingMessage = {
-          text: interactiveMessage(proposal, { from: getDisplayName(proposal.creatorID) }),
+          text: interactiveMessage(proposal, { from: getNameFromMemberID(proposal.creatorID) }),
           hash
         }
         this.ephemeral.replyingTo = L('Proposal notification')

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -304,8 +304,7 @@ export default ({
       'isGroupDirectMessage',
       'currentChatRoomScrollPosition',
       'currentChatRoomReadUntil',
-      'isReducedMotionMode',
-      'globalProfile'
+      'isReducedMotionMode'
     ]),
     currentUserAttr () {
       return {
@@ -621,13 +620,9 @@ export default ({
 
       if (type === MESSAGE_TYPES.INTERACTIVE) {
         const proposal = message.proposal
-        const getNameFromMemberID = (memberID) => {
-          const profile = this.globalProfile(memberID)
-          return profile ? `${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${memberID}` : L('Unknown user')
-        }
 
         this.ephemeral.replyingMessage = {
-          text: interactiveMessage(proposal, { from: getNameFromMemberID(proposal.creatorID) }),
+          text: interactiveMessage(proposal, { from: `${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${proposal.creatorID}` }),
           hash
         }
         this.ephemeral.replyingTo = L('Proposal notification')

--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -23,7 +23,7 @@ menu-parent.c-message-menu(ref='menu')
         i.icon-pencil-alt
 
     tooltip(
-      v-if='isText'
+      v-if='isReplyable'
       direction='top'
       :text='L("Reply")'
     )
@@ -107,6 +107,9 @@ export default ({
     isPoll () {
       return this.type === MESSAGE_TYPES.POLL
     },
+    isReplyable () {
+      return [MESSAGE_TYPES.TEXT, MESSAGE_TYPES.INTERACTIVE].includes(this.type)
+    },
     isPinnable () {
       return this.isText || this.isPoll
     },
@@ -130,9 +133,9 @@ export default ({
         conditionToShow: !this.isDesktopScreen && this.isEditable
       }, {
         name: L('Reply'),
-        action: 'Reply',
+        action: 'reply',
         icon: 'reply',
-        conditionToShow: !this.isDesktopScreen && this.isText
+        conditionToShow: !this.isDesktopScreen && this.isReplyable
       }, {
         name: L('Retry'),
         action: 'retry',

--- a/frontend/views/containers/chatroom/MessageInteractive.vue
+++ b/frontend/views/containers/chatroom/MessageInteractive.vue
@@ -44,7 +44,7 @@ import SvgYellowHorn from '@svgs/yellow-horn.svg'
 import { humanDate } from '@model/contracts/shared/time.js'
 import { get } from '@model/contracts/shared/giLodash.js'
 
-const interactiveMessage = (proposal, baseOptions = {}) => {
+export const interactiveMessage = (proposal, baseOptions = {}) => {
   const { status, creatorID, proposalType, proposalData } = proposal
   const { options: proposalDetails } = getProposalDetails({
     status,

--- a/frontend/views/containers/chatroom/MessageInteractive.vue
+++ b/frontend/views/containers/chatroom/MessageInteractive.vue
@@ -1,5 +1,8 @@
 <template lang='pug'>
-message-base(v-bind='$props' @wrapperAction='action')
+message-base(v-bind='$props'
+  @wrapperAction='action'
+  @reply='$emit("reply")'
+)
   template(#image='')
     .c-icon(:class='{"is-warning": isYellowHorn}')
       svg-yellow-horn(v-if='isYellowHorn')

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -51,7 +51,7 @@
 
     .c-reply-wrapper
       .c-reply(v-if='replyingMessage')
-        i18n(:args='{ replyingTo, text: replyingMessage.text }') Replying to {replyingTo}: "{text}"
+        i18n(:args='{ replyingTo, text: swapMentionIDForDisplayname(replyingMessage.text) }') Replying to {replyingTo}: "{text}"
         button.c-clear.is-icon-small(
           :aria-label='L("Stop replying")'
           @click='stopReplying'
@@ -272,7 +272,7 @@ import CreatePoll from './CreatePoll.vue'
 import Avatar from '@components/Avatar.vue'
 import Tooltip from '@components/Tooltip.vue'
 import ChatAttachmentPreview from './file-attachment/ChatAttachmentPreview.vue'
-import { makeMentionFromUsername, makeChannelMention } from '@model/chatroom/utils.js'
+import { makeMentionFromUsername, makeChannelMention, swapMentionIDForDisplayname } from '@model/chatroom/utils.js'
 import {
   CHATROOM_PRIVACY_LEVEL,
   CHATROOM_MEMBER_MENTION_SPECIAL_CHAR,
@@ -922,7 +922,8 @@ export default ({
       }).catch(e => {
         console.error('Error emitting user stopped typing event', e)
       })
-    }
+    },
+    swapMentionIDForDisplayname
   }
 }: Object)
 </script>


### PR DESCRIPTION
closes #2427 

I have worked on this issue for `MessageInteractive.vue` component, which is used for various proposal-related notifications in the chat .

**[Screenshot - Menu added]**

<img src='https://github.com/user-attachments/assets/7bd67813-cc9f-45b0-bd01-7581efab23bd' width='380'>

<br>

**[Screenshot - When the 'reply' menu is clicked]**

<img src='https://github.com/user-attachments/assets/1e84a325-9b95-4162-b9c7-4a74577519b6' width='380'>

<br>

**[Screenshot - replied message]**

<img src='https://github.com/user-attachments/assets/ca2ab69e-4ac4-42ad-af30-d20e8a23af2a' width='430'>
