### PR TITLE
#2490 - Implement image-attachment by pasting it

### DIFF
--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -562,6 +562,11 @@ export default ({
       }
     },
     handlePaste (e) {
+      if (e.clipboardData.files.length > 0) {
+        this.fileAttachmentHandler(e.clipboardData.files, true)
+        return
+      }
+
       // fix for the edge-case related to 'paste' action when nothing has been typed
       // (reference: https://github.com/okTurtles/group-income/issues/2369)
       const currVal = this.$refs.textarea.value


### PR DESCRIPTION
closes #2490 

Apparently the existing logic in `this.fileAttachmentHandler(...)` already handles file-attachment related jobs properly. So all we need to do is pass the pasted file blobs to it.