### PR TITLE
#2518 - HTML rendering bug in `BannerGeneral.vue`

### DIFF
--- a/frontend/views/components/banners/BannerGeneral.vue
+++ b/frontend/views/components/banners/BannerGeneral.vue
@@ -7,19 +7,17 @@
       aria-live='polite'
     )
       i(:class='`icon-${ephemeral.icon} is-prefix`')
-      render-message-with-markdown(:text='ephemeral.message')
+      .c-banner-content(v-safe-html:a='ephemeral.message')
 </template>
 
 <script>
 import TransitionExpand from '@components/TransitionExpand.vue'
 import { debounce } from '@model/contracts/shared/giLodash.js'
-import RenderMessageWithMarkdown from '@containers/chatroom/chat-mentions/RenderMessageWithMarkdown.js'
 
 export default ({
   name: 'BannerGeneral',
   components: {
-    TransitionExpand,
-    RenderMessageWithMarkdown
+    TransitionExpand
   },
   data: () => ({
     ephemeral: {
@@ -81,6 +79,10 @@ export default ({
   display: flex;
   justify-content: center;
   align-items: flex-start;
+
+  .c-banner-content {
+    text-align: left;
+  }
 }
 
 .l-banner ::v-deep .link {


### PR DESCRIPTION
closes #2518 

**[ Fix screenshot ]**
Can see the `<a />` tag is rendered correctly in the DOM.

![image](https://github.com/user-attachments/assets/dd7eb626-6703-4abd-a429-7c5aa4529499)

---

BTW, [This comment](https://github.com/okTurtles/group-income/issues/2518#issuecomment-2599149664) mentions that https://github.com/okTurtles/group-income/pull/2139 introduced this bug but that is not correct...

That PR is a fix for chatroom-specific bugs and `RenderMessageWithMarkdown.vue`(I built it) is not designed to be used inside a banner. So I think it's somewhere further up in the past commit history.