### PR TITLE
Add Grunt file option to disable slim contract builds

### DIFF
--- a/frontend/setupChelonia.js
+++ b/frontend/setupChelonia.js
@@ -103,6 +103,7 @@ const setupChelonia = async (): Promise<*> => {
       defaults: {
         modules: { '@common/common.js': Common },
         allowedSelectors: [
+          'sbp/selectors/register',
           'namespace/lookup', 'namespace/lookupCached',
           // TODO: [SW] the `state/` selectors should _not_ be used from contracts
           // since they refer to Vuex (i.e., tab / window) state and not to

--- a/test/avatar-caching.test.js
+++ b/test/avatar-caching.test.js
@@ -72,7 +72,8 @@ describe('avatar file serving', function () {
         ...manifests,
         defaults: {
           allowedSelectors: [
-            'chelonia/queueInvocation'
+            'chelonia/queueInvocation',
+            'sbp/selectors/register'
           ],
           modules: { '@common/common.js': Common },
           preferSlim: true


### PR DESCRIPTION
Closes #2390

### Summary of changes
- New `BUILD_SLIM_CONTRACTS` top-level constant in `Gruntfile.js`. Defaults to `true`.
- SBP selector `'sbp/selectors/register'` now allowed in contracts.
    This change was not intentional, but a way to allow non-slim contract bundles to load `translations.js` (which registers the `'translations/init'` selector).