### PR TITLE
Add `wsOnly` parameter to avoid broadcasting KV updates.

### DIFF
--- a/backend/pubsub.js
+++ b/backend/pubsub.js
@@ -332,7 +332,7 @@ const publicMethods = {
    */
   broadcast (
     message: Message | string,
-    { to, except }: { to?: Iterable<Object>, except?: Object }
+    { to, except, wsOnly }: { to?: Iterable<Object>, except?: Object, wsOnly?: boolean }
   ) {
     const server = this
 
@@ -355,7 +355,7 @@ const publicMethods = {
       // Duplicate message sending (over both WS and push) is handled on the
       // WS logic, for the `close` event (to remove the WS and send over push)
       // and for the `STORE_SUBSCRIPTION` WS action.
-      if (client.endpoint) {
+      if (!wsOnly && client.endpoint) {
         // `client.endpoint` means the client is a subscription info object
         // The max length for push notifications in many providers is 4 KiB.
         // However, encrypting adds a slight overhead of 17 bytes at the end

--- a/backend/server.js
+++ b/backend/server.js
@@ -147,7 +147,7 @@ sbp('sbp/selectors/register', {
     const pubsubMessage = createKvMessage(contractID, key, entry)
     const subscribers = pubsub.enumerateSubscribers(contractID)
     console.debug(chalk.blue.bold(`[pubsub] Broadcasting KV change on ${contractID} to key ${key}`))
-    await pubsub.broadcast(pubsubMessage, { to: subscribers })
+    await pubsub.broadcast(pubsubMessage, { to: subscribers, wsOnly: true })
   },
   'backend/server/broadcastEntry': async function (deserializedHEAD: Object, entry: string) {
     const pubsub = sbp('okTurtles.data/get', PUBSUB_INSTANCE)

--- a/frontend/controller/actions/group-kv.js
+++ b/frontend/controller/actions/group-kv.js
@@ -43,13 +43,6 @@ export default (sbp('sbp/selectors/register', {
     return sbp('okTurtles.eventQueue/queueEvent', KV_QUEUE, async () => {
       const data = await sbp('gi.actions/group/kv/fetchLastLoggedIn', { contractID })
       sbp('okTurtles.events/emit', NEW_LAST_LOGGED_IN, [contractID, data])
-
-      // If running in a SW, update lastLoggedIn record. This is comparable to
-      // what the browser does when receiving the NEW_LAST_LOGGED_IN event
-      if (typeof WorkerGlobalScope === 'function') {
-        const rootState = sbp('state/vuex/state')
-        rootState.lastLoggedIn[contractID] = data
-      }
     }).catch(e => {
       console.error('[gi.actions/group/kv/loadLastLoggedIn] Error loading last logged in', e)
     })

--- a/frontend/controller/serviceworkers/sw-primary.js
+++ b/frontend/controller/serviceworkers/sw-primary.js
@@ -532,3 +532,18 @@ sbp('okTurtles.events/on', NOTIFICATION_EMITTED, (notification) => {
     console.error('Error displaying native notification', e)
   })
 })
+
+// These `NEW_*` events are emitted in KV files. To keep things consistent with
+// the browser state, we update the state when these events are generated.
+sbp('okTurtles.events/on', NEW_LAST_LOGGED_IN, ([contractID, data]) => {
+  const rootState = sbp('state/vuex/state')
+  rootState.lastLoggedIn[contractID] = data
+})
+sbp('okTurtles.events/on', NEW_PREFERENCES, (preferences) => {
+  const rootState = sbp('state/vuex/state')
+  rootState.preferences = preferences
+})
+sbp('okTurtles.events/on', NEW_UNREAD_MESSAGES, (currentChatRoomUnreadMessages) => {
+  const rootState = sbp('state/vuex/state')
+  rootState.chatroom.unreadMessages = currentChatRoomUnreadMessages
+})

--- a/frontend/model/notifications/selectors.js
+++ b/frontend/model/notifications/selectors.js
@@ -36,7 +36,7 @@ sbp('sbp/selectors/register', {
       // Sets 'groupID' if this notification only pertains to a certain group.
       ...(template.scope === 'group' ? { groupID: data.groupID } : {}),
       // Store integer timestamps rather than ISO strings here to make age comparisons easier.
-      timestamp: data.createdDate ? new Date(data.createdDate).getTime() : Date.now(),
+      timestamp: data.createdDate ? new Date(data.createdDate).getTime() : Date.now(sbp('chelonia/time') * 1000),
       type
     }
     const rootState = sbp('chelonia/rootState')

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -1643,6 +1643,9 @@ function parseEncryptedOrUnencryptedMessage ({
   let innerSigningKeyId
 
   // Lazy unwrap function
+  // We don't use `unwrapMaybeEncryptedData`, which would almost do the same,
+  // because it swallows decryption errors, which we want to propagate to
+  // consumers of the KV API.
   const unwrap = (() => {
     let result
 

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -16,7 +16,7 @@ import { GIMessage } from './GIMessage.js'
 import type { Secret } from './Secret.js'
 import './chelonia-utils.js'
 import type { EncryptedData } from './encryptedData.js'
-import { encryptedOutgoingData, isEncryptedData, maybeEncryptedIncomingData, unwrapMaybeEncryptedData } from './encryptedData.js'
+import { encryptedOutgoingData, isEncryptedData, maybeEncryptedIncomingData } from './encryptedData.js'
 import './files.js'
 import './internals.js'
 import { isSignedData, signedIncomingData, signedOutgoingData, signedOutgoingDataWithRawKey } from './signedData.js'
@@ -1638,30 +1638,81 @@ function parseEncryptedOrUnencryptedMessage ({
     return maybeEncryptedIncomingData(contractID, state, message, numericHeight, this.transientSecretKeys, aad, undefined)
   })
 
-  const encryptedData = unwrapMaybeEncryptedData(v.valueOf())
+  // Cached values
+  let encryptionKeyId
+  let innerSigningKeyId
+
+  // Lazy unwrap function
+  const unwrap = (() => {
+    let result
+
+    return () => {
+      if (!result) {
+        try {
+          let unwrapped
+          // First, we unwrap the signed data
+          unwrapped = v.valueOf()
+          // If this is encrypted data, attempt decryption
+          if (isEncryptedData(unwrapped)) {
+            encryptionKeyId = unwrapped.encryptionKeyId
+            unwrapped = unwrapped.valueOf()
+
+            // There could be inner signed data (inner signatures), so we unwrap
+            // that too
+            if (isSignedData(unwrapped)) {
+              innerSigningKeyId = unwrapped.signingKeyId
+              unwrapped = unwrapped.valueOf()
+            } else {
+              innerSigningKeyId = null
+            }
+          } else {
+            encryptionKeyId = null
+            innerSigningKeyId = null
+          }
+          result = [unwrapped]
+        } catch (e) {
+          result = [undefined, e]
+        }
+      }
+
+      if (result.length === 2) {
+        throw result[1]
+      }
+      return result[0]
+    }
+  })()
 
   const result = {
     get contractID () {
       return contractID
     },
     get innerSigningKeyId () {
-      if (!encryptedData) return
-      if (isSignedData(encryptedData.data)) {
-        return encryptedData.data.signingKeyId
+      if (innerSigningKeyId === undefined) {
+        try {
+          unwrap()
+        } catch {
+          // We're not interested in an error, that'd only be for the 'data'
+          // accessor.
+        }
       }
+      return innerSigningKeyId
     },
     get encryptionKeyId () {
-      return encryptedData?.encryptionKeyId
+      if (encryptionKeyId === undefined) {
+        try {
+          unwrap()
+        } catch {
+          // We're not interested in an error, that'd only be for the 'data'
+          // accessor.
+        }
+      }
+      return encryptionKeyId
     },
     get signingKeyId () {
       return v.signingKeyId
     },
     get data () {
-      if (!encryptedData) return
-      if (isSignedData(encryptedData.data)) {
-        return encryptedData.data.valueOf()
-      }
-      return encryptedData.data
+      return unwrap()
     },
     get signingContractID () {
       return getContractIDfromKeyId(contractID, result.signingKeyId, state)

--- a/test/cypress/support/commands.js
+++ b/test/cypress/support/commands.js
@@ -91,8 +91,8 @@ const cySbpCheckCommand = (name, customCheckFn) => {
         sbp('okTurtles.events/on', EVENT_PUBLISHING_ERROR, check)
 
         // We also run the test manually in case there are no events
-        check()
         const x = setInterval(check, 1000)
+        check()
       })
     })
   })
@@ -113,8 +113,8 @@ Cypress.Commands.add('getByDT', (element, otherSelector = '') => {
 cySbpCheckCommand('giNoPendingGroupKeyShares', (sbp) => {
   const state = sbp('state/vuex/state')
   const pending = Object.keys(state.contracts)
-    .filter(contractID => state[contractID]._vm.type === 'gi.contracts/group')
-    .filter(contractID => Object.keys(state[contractID]._vm?.pendingKeyShares || {}).length)
+    .filter(contractID => state[contractID]?._vm?.type === 'gi.contracts/group')
+    .filter(contractID => Object.keys(state[contractID]._vm.pendingKeyShares || {}).length)
 
   console.info('giNoPendingGroupKeyShares', pending, pending.length === 0)
   return pending.length === 0


### PR DESCRIPTION
Changes to `kv/get` to propagate decryption errors (related to #2588).

Closes #2589.