### PR TITLE
User-local snapshots

### DIFF
--- a/frontend/controller/app/identity.js
+++ b/frontend/controller/app/identity.js
@@ -120,15 +120,19 @@ sbp('okTurtles.events/on', LOGIN, async ({ identityContractID, encryptionParams,
 
       // NOTE: users could notice that they leave the group by someone
       // else when they log in
-      const currentState = sbp('state/vuex/state')
-      if (!currentState.currentGroupId) {
-        const gId = Object.keys(currentState.contracts)
-          .find(cID => currentState[identityContractID].groups[cID] && !currentState[identityContractID].groups[cID].hasLeft)
+      sbp('chelonia/queueInvocation', identityContractID, () => {
+        const currentState = sbp('state/vuex/state')
+        if (!currentState.currentGroupId && currentState[identityContractID]?.groups) {
+          const gId = Object.keys(currentState.contracts)
+            .find(cID => currentState[identityContractID].groups[cID] && !currentState[identityContractID].groups[cID].hasLeft)
 
-        if (gId) {
-          sbp('gi.app/group/switch', gId)
+          if (gId) {
+            sbp('gi.app/group/switch', gId)
+          }
         }
-      }
+      }).catch(e => {
+        console.error('[LOGIN] Error setting current group ID', e)
+      })
 
       // Whenever there's an active session, the encrypted save state should be
       // removed, as it is only used for recovering the state when logging in

--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -34,7 +34,8 @@ export const KV_KEYS = {
   UNREAD_MESSAGES: 'unreadMessages',
   LAST_LOGGED_IN: 'lastLoggedIn',
   PREFERENCES: 'preferences',
-  NOTIFICATIONS: 'notifications'
+  NOTIFICATIONS: 'notifications',
+  USER_STATE_SNAPSHOT: 'user-state-snapshot'
 }
 
 export const MAX_LOG_ENTRIES = 2000


### PR DESCRIPTION
This PR has the goal of speeding up login by:

1. Implementing a fast-path login, which doesn't require syncing all contracts before the state is persisted locally. This could allow for the login process to be interruptible.
2. Implementing an even faster path by saving the local state remotely on the sever (e.g., using the KV store), and restoring it when logging in, if possible. This would allow for an even faster login experience on new devices.