### PR TITLE
#2597 - Global banner gets cut off with a long word

### DIFF
--- a/frontend/views/components/banners/BannerGeneral.vue
+++ b/frontend/views/components/banners/BannerGeneral.vue
@@ -82,6 +82,7 @@ export default ({
 
   .c-banner-content {
     text-align: left;
+    word-break: break-word;
   }
 }
 


### PR DESCRIPTION
closes #2597 

**[ Fix screenshot ]**

<img src='https://github.com/user-attachments/assets/6c8123f0-2492-44a4-9bdf-c9b59204599e' width='380'>