### PR TITLE
#2662 - Add version info to exported logs

### DIFF
--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -2,10 +2,10 @@
   .settings-container
     section.card
       .c-loader-container(v-if='ephemeral.versionInfos.loading')
-        .loading-box.c-load-ani.is-1
-        .loading-box.c-load-ani.is-2
-        .loading-box.c-load-ani.is-3
-        .loading-box.c-load-ani.is-4
+        .loading-box
+        .loading-box
+        .loading-box
+        .loading-box
 
       template(v-else)
         .c-header
@@ -371,25 +371,25 @@ export default ({
 .c-loader-container {
   position: relative;
   width: 100%;
-}
 
-.c-load-ani {
-  display: block;
-  width: 100%;
-  min-height: unset;
+  .loading-box {
+    display: block;
+    width: 100%;
+    min-height: unset;
 
-  &.is-1 {
-    height: 1.25rem;
-    max-width: 20rem;
+    &:first-child {
+      height: 1.25rem;
+      max-width: 20rem;
+    }
+
+    &:nth-child(2),
+    &:nth-child(3) {
+      height: 1.25rem;
+    }
+
+    &:nth-child(2) { max-width: 31.25rem; }
+
+    &:last-child { height: 16.25rem; }
   }
-
-  &.is-2,
-  &.is-3 {
-    height: 1.25rem;
-  }
-
-  &.is-2 { max-width: 31.25rem; }
-
-  &.is-4 { height: 16.25rem; }
 }
 </style>

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
   .settings-container
     section.card
-      .c-loader-container(v-if='ephemeral.versions.loading')
+      .c-loader-container(v-if='ephemeral.versionInfos.loading')
         .loading-box.c-load-ani.is-1
         .loading-box.c-load-ani.is-2
         .loading-box.c-load-ani.is-3
@@ -73,6 +73,7 @@ import { CAPTURED_LOGS } from '@utils/events.js'
 import { MAX_LOG_ENTRIES } from '@utils/constants.js'
 import safeLinkTag from '@view-utils/safeLinkTag.js'
 import { L, LError } from '@common/common.js'
+import { omit } from '@model/contracts/shared/giLodash.js'
 import BannerScoped from '@components/banners/BannerScoped.vue'
 import ButtonSubmit from '@components/ButtonSubmit.vue'
 
@@ -92,11 +93,11 @@ export default ({
         ready: false,
         logs: [],
         useWebShare: false,
-        versions: {
+        versionInfos: {
           loading: true,
-          app: '',
-          contracts: '',
-          sw: ''
+          app_version: '',
+          contracts_version: '',
+          service_worker_version: ''
         }
       }
     }
@@ -157,11 +158,11 @@ export default ({
       } catch (e) {
         console.error('TroubleShooting.vue caught: ', e)
       } finally {
-        this.ephemeral.versions = {
+        this.ephemeral.versionInfos = {
           loading: false,
-          app: process.env.GI_VERSION.split('@')[0],
-          contracts: process.env.CONTRACTS_VERSION,
-          sw: swVersion
+          app_version: process.env.GI_VERSION.split('@')[0],
+          contracts_version: process.env.CONTRACTS_VERSION,
+          service_worker_version: swVersion
         }
       }
     },
@@ -202,6 +203,7 @@ export default ({
         // Add instructions in case the user opens the file.
           _instructions: 'GROUP INCOME - Application Logs - Attach this file when reporting an issue: https://github.com/okTurtles/group-income/issues',
           ua: navigator.userAgent,
+          version_info: omit(this.ephemeral.versionInfos, ['loading']),
           logs: this.ephemeral.logs
         }, undefined, 2)], { type: mimeType })
 

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -1,61 +1,68 @@
 <template lang='pug'>
   .settings-container
     section.card
-      .c-header
-        p.c-instructions
-          i18n(
-            v-if='errorMsg'
-            :args='{ a_: issuePageTag, _a: "</a>", errorMsg }'
-          ) Recent error: "{errorMsg}". Please download the logs and {a_}send them to us{_a}, so we can help troubleshoot.
-          i18n(
-            v-else
-            :args='{ a_: issuePageTag, _a: "</a>" }'
-          ) If you encounter problems, please download the logs and {a_}send them to us{_a}.
+      .c-loader-container(v-if='ephemeral.versions.loading')
+        .loading-box.c-load-ani.is-1
+        .loading-box.c-load-ani.is-2
+        .loading-box.c-load-ani.is-3
+        .loading-box.c-load-ani.is-4
 
-        fieldset.c-filters
-          .c-filters-inner
-            legend.c-filters-legend Optional logs:
-            label.checkbox
-              input.input(type='checkbox' name='filter' v-model='form.filter' value='debug')
-              i18n Debug
-            label.checkbox
-              input.input(type='checkbox' name='filter' v-model='form.filter' value='info')
-              i18n Info
-            label.checkbox
-              input.input(type='checkbox' name='filter' v-model='form.filter' value='log')
-              i18n Log
+      template(v-else)
+        .c-header
+          p.c-instructions
+            i18n(
+              v-if='errorMsg'
+              :args='{ a_: issuePageTag, _a: "</a>", errorMsg }'
+            ) Recent error: "{errorMsg}". Please download the logs and {a_}send them to us{_a}, so we can help troubleshoot.
+            i18n(
+              v-else
+              :args='{ a_: issuePageTag, _a: "</a>" }'
+            ) If you encounter problems, please download the logs and {a_}send them to us{_a}.
 
-        fieldset.c-source(:aria-label='L("Source:")')
-          .c-source-inner
-            label.c-label
-              i18n.c-source-legend Log source:
-              .selectbox
-                select.select(v-model='form.source')
-                  option(value='combined')
-                    i18n Combined
-                  option(value='browser')
-                    i18n Browser
-                  option(value='serviceworker')
-                    i18n Service worker
+          fieldset.c-filters
+            .c-filters-inner
+              legend.c-filters-legend Optional logs:
+              label.checkbox
+                input.input(type='checkbox' name='filter' v-model='form.filter' value='debug')
+                i18n Debug
+              label.checkbox
+                input.input(type='checkbox' name='filter' v-model='form.filter' value='info')
+                i18n Info
+              label.checkbox
+                input.input(type='checkbox' name='filter' v-model='form.filter' value='log')
+                i18n Log
 
-        button-submit.is-small.c-download(@click='downloadOrShareLogs')
-          template(v-if='ephemeral.useWebShare')
-            i.icon-share-alt.is-prefix
-            i18n Share
-          template(v-else)
-            i.icon-download.is-prefix
-            i18n Download
+          fieldset.c-source(:aria-label='L("Source:")')
+            .c-source-inner
+              label.c-label
+                i18n.c-source-legend Log source:
+                .selectbox
+                  select.select(v-model='form.source')
+                    option(value='combined')
+                      i18n Combined
+                    option(value='browser')
+                      i18n Browser
+                    option(value='serviceworker')
+                      i18n Service worker
 
-        a(ref='linkDownload' hidden)
+          button-submit.is-small.c-download(@click='downloadOrShareLogs')
+            template(v-if='ephemeral.useWebShare')
+              i.icon-share-alt.is-prefix
+              i18n Share
+            template(v-else)
+              i.icon-download.is-prefix
+              i18n Download
 
-      banner-scoped.c-err-banner(ref='errBanner')
+          a(ref='linkDownload' hidden)
 
-      textarea.textarea.c-logs(ref='textarea' rows='12' v-if='ephemeral.ready' readonly)
-        | {{ prettyLogs }}
-      div(v-else)
-        i18n Loading
+        banner-scoped.c-err-banner(ref='errBanner')
 
-      i18n.link(tag='button' @click='openTroubleshooting') Troubleshooting
+        textarea.textarea.c-logs(ref='textarea' rows='12' v-if='ephemeral.ready' readonly)
+          | {{ prettyLogs }}
+        div(v-else)
+          i18n Loading
+
+        i18n.link(tag='button' @click='openTroubleshooting') Troubleshooting
 
 </template>
 
@@ -84,13 +91,20 @@ export default ({
       ephemeral: {
         ready: false,
         logs: [],
-        useWebShare: false
+        useWebShare: false,
+        versions: {
+          loading: true,
+          app: '',
+          contracts: '',
+          sw: ''
+        }
       }
     }
   },
   created () {
     sbp('okTurtles.events/on', CAPTURED_LOGS, this.addLog)
     this.getLogs()
+    this.loadVersionInfo()
   },
   mounted () {
     window.addEventListener('resize', this.checkWebShareAvailable)
@@ -135,6 +149,22 @@ export default ({
     ...mapMutations([
       'setAppLogsFilter'
     ]),
+    async loadVersionInfo () {
+      let swVersion = ''
+
+      try {
+        swVersion = (await sbp('sw/version')).GI_GIT_VERSION.slice(1)
+      } catch (e) {
+        console.error('TroubleShooting.vue caught: ', e)
+      } finally {
+        this.ephemeral.versions = {
+          loading: false,
+          app: process.env.GI_VERSION.split('@')[0],
+          contracts: process.env.CONTRACTS_VERSION,
+          sw: swVersion
+        }
+      }
+    },
     addLog (entry: Object) {
       if (entry) {
         if (this.form.source === 'browser' && entry.source !== 'browser') return
@@ -268,6 +298,8 @@ export default ({
 @import "@assets/style/_variables.scss";
 
 .settings-container {
+  width: 100%;
+
   @include desktop {
     padding-top: 1.5rem;
   }
@@ -332,5 +364,30 @@ export default ({
   ::v-deep .c-banner {
     margin-top: 0;
   }
+}
+
+.c-loader-container {
+  position: relative;
+  width: 100%;
+}
+
+.c-load-ani {
+  display: block;
+  width: 100%;
+  min-height: unset;
+
+  &.is-1 {
+    height: 1.25rem;
+    max-width: 20rem;
+  }
+
+  &.is-2,
+  &.is-3 {
+    height: 1.25rem;
+  }
+
+  &.is-2 { max-width: 31.25rem; }
+
+  &.is-4 { height: 16.25rem; }
 }
 </style>

--- a/frontend/views/containers/user-settings/AppLogs.vue
+++ b/frontend/views/containers/user-settings/AppLogs.vue
@@ -156,7 +156,7 @@ export default ({
       try {
         swVersion = (await sbp('sw/version')).GI_GIT_VERSION.slice(1)
       } catch (e) {
-        console.error('TroubleShooting.vue caught: ', e)
+        console.error('AppLogs.vue caught:', e)
       } finally {
         this.ephemeral.versionInfos = {
           loading: false,

--- a/frontend/views/containers/user-settings/Troubleshooting.vue
+++ b/frontend/views/containers/user-settings/Troubleshooting.vue
@@ -47,6 +47,11 @@ export default ({
         progress: {
           part: '', // e.g. 'Downloading...'
           percentage: 0 // Number: e.g. 0.75
+        },
+        versions: {
+          app: '',
+          contracts: '',
+          sw: ''
         }
       }
     }

--- a/frontend/views/containers/user-settings/Troubleshooting.vue
+++ b/frontend/views/containers/user-settings/Troubleshooting.vue
@@ -47,11 +47,6 @@ export default ({
         progress: {
           part: '', // e.g. 'Downloading...'
           percentage: 0 // Number: e.g. 0.75
-        },
-        versions: {
-          app: '',
-          contracts: '',
-          sw: ''
         }
       }
     }


### PR DESCRIPTION
closes #2662 

<img src='https://github.com/user-attachments/assets/c303ddd5-f29e-4b81-9a80-1f2a9758b227' width='480'>