### PR TITLE
Recreate push subscription on new VAPID key

### DIFF
--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -221,7 +221,10 @@ sbp('sbp/selectors/register', {
           subscription = await registration.pushManager.getSubscription()
           if (subscription && !bufferEq(subscription.options.applicationServerKey, subscriptionOptions?.applicationServerKey)) {
             // This is a public key that belongs to the server
-            console.warn('VAPID server key changed; removing existing subscription and setting up a new one', { oldKey: subscription.options.applicationServerKey, newKey: subscriptionOptions.applicationServerKey })
+            console.warn('VAPID server key changed; removing existing subscription and setting up a new one', {
+              oldPubKey: subscription.options.applicationServerKey,
+              newPubKey: subscriptionOptions.applicationServerKey
+            })
             await subscription.unsubscribe()
             subscription = null
           }

--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -222,8 +222,8 @@ sbp('sbp/selectors/register', {
           if (subscription && !bufferEq(subscription.options.applicationServerKey, subscriptionOptions?.applicationServerKey)) {
             // This is a public key that belongs to the server
             console.warn('VAPID server key changed; removing existing subscription and setting up a new one', {
-              oldPubKey: subscription.options.applicationServerKey,
-              newPubKey: subscriptionOptions.applicationServerKey
+              oldApplicationServerPublicKey: subscription.options.applicationServerKey,
+              newApplicationServerPublicKey: subscriptionOptions.applicationServerKey
             })
             await subscription.unsubscribe()
             subscription = null

--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -11,7 +11,8 @@ import { deserializer, serializer } from '~/shared/serdes/index.js'
 import { getSubscriptionId } from '~/shared/functions.js'
 
 const bufferEq = (a?: ArrayBuffer | Uint8Array, b?: ArrayBuffer | Uint8Array) => {
-  if (a == null && b == null) return true
+  // eslint-disable-next-line eqeqeq
+  if (a == null || b == null) return a == b
   if (a.byteLength !== b.byteLength) return false
 
   const ab = new Uint8Array(a)
@@ -219,6 +220,7 @@ sbp('sbp/selectors/register', {
           const subscriptionOptions = await sbp('push/getSubscriptionOptions')
           subscription = await registration.pushManager.getSubscription()
           if (subscription && !bufferEq(subscription.options.applicationServerKey, subscriptionOptions?.applicationServerKey)) {
+            // This is a public key that belongs to the server
             console.warn('VAPID server key changed; removing existing subscription and setting up a new one', { oldKey: subscription.options.applicationServerKey, newKey: subscriptionOptions.applicationServerKey })
             await subscription.unsubscribe()
             subscription = null

--- a/frontend/controller/service-worker.js
+++ b/frontend/controller/service-worker.js
@@ -10,6 +10,18 @@ import { Secret } from '~/shared/domains/chelonia/Secret.js'
 import { deserializer, serializer } from '~/shared/serdes/index.js'
 import { getSubscriptionId } from '~/shared/functions.js'
 
+const bufferEq = (a?: ArrayBuffer | Uint8Array, b?: ArrayBuffer | Uint8Array) => {
+  if (a == null && b == null) return true
+  if (a.byteLength !== b.byteLength) return false
+
+  const ab = new Uint8Array(a)
+  const bb = new Uint8Array(b)
+  for (let i = ab.byteLength - 1; i >= 0; i--) {
+    if (ab[i] !== bb[i]) return false
+  }
+  return true
+}
+
 const pwa = {
   deferredInstallPrompt: null,
   installed: false
@@ -204,11 +216,17 @@ sbp('sbp/selectors/register', {
         let subID = null
         // get a real push subscription only if both browser permissions allow and user wants us to
         if (notificationEnabled && granted) {
+          const subscriptionOptions = await sbp('push/getSubscriptionOptions')
           subscription = await registration.pushManager.getSubscription()
+          if (subscription && !bufferEq(subscription.options.applicationServerKey, subscriptionOptions?.applicationServerKey)) {
+            console.warn('VAPID server key changed; removing existing subscription and setting up a new one', { oldKey: subscription.options.applicationServerKey, newKey: subscriptionOptions.applicationServerKey })
+            await subscription.unsubscribe()
+            subscription = null
+          }
           let newSub = false
           let endpoint = null
           if (!subscription || (subscription.expirationTime != null && subscription.expirationTime <= Date.now())) {
-            subscription = await registration.pushManager.subscribe(await sbp('push/getSubscriptionOptions'))
+            subscription = await registration.pushManager.subscribe(subscriptionOptions)
             newSub = true
           }
           if (subscription?.endpoint) {


### PR DESCRIPTION
Closes #2681 

With this PR, it should now be possible to use the non-persistent in-memory storage with existing subscriptions.