### PR TITLE
#2718 - Replying to a message shouldn't quote the entire message

### DIFF
--- a/frontend/model/contracts/shared/constants.js
+++ b/frontend/model/contracts/shared/constants.js
@@ -107,6 +107,7 @@ export const GROUP_PERMISSIONS_PRESET = {
 export const CHATROOM_GENERAL_NAME = 'general' // Chatroom name must be lowercase-only.
 export const CHATROOM_NAME_LIMITS_IN_CHARS = 50
 export const CHATROOM_DESCRIPTION_LIMITS_IN_CHARS = 280
+export const CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS = 180
 export const CHATROOM_MAX_MESSAGE_LEN = 20000
 export const CHATROOM_MAX_MESSAGES = 20
 export const CHATROOM_ACTIONS_PER_PAGE = 40

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -155,7 +155,7 @@ import { proximityDate, MINS_MILLIS } from '@model/contracts/shared/time.js'
 import { cloneDeep, debounce, throttle, delay } from 'turtledash'
 import { EVENT_HANDLED } from '~/shared/domains/chelonia/events.js'
 import { compressImage } from '@utils/image.js'
-import { stripMarkdownSyntax } from '@view-utils/markdown-utils.js'
+import { swapMentionIDForDisplayname } from '@model/chatroom/utils.js'
 
 const ignorableScrollDistanceInPixel = 500
 
@@ -640,9 +640,14 @@ export default ({
       } else if (!text && attachments.length) {
         this.ephemeral.replyingMessage = { hash, text: attachments[0].name }
       } else {
-        this.ephemeral.replyingMessage = {
-          hash, text: stripMarkdownSyntax(text, CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS)
+        const sanitizeAndTruncate = text => {
+          return swapMentionIDForDisplayname(text)
+            .replace(/\s+/g, ' ') // Normalize spaces
+            .trim()
+            .slice(0, CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS)
         }
+
+        this.ephemeral.replyingMessage = { hash, text: sanitizeAndTruncate(text) }
       }
 
       this.ephemeral.replyingTo = isTypeInteractive ? L('Proposal notification') : this.who(message)

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -150,6 +150,7 @@ import { proximityDate, MINS_MILLIS } from '@model/contracts/shared/time.js'
 import { cloneDeep, debounce, throttle, delay } from 'turtledash'
 import { EVENT_HANDLED } from '~/shared/domains/chelonia/events.js'
 import { compressImage } from '@utils/image.js'
+import { stripMarkdownSyntax } from '@view-utils/markdown-utils.js'
 
 const ignorableScrollDistanceInPixel = 500
 
@@ -641,7 +642,7 @@ export default ({
         }
         this.ephemeral.replyingTo = L('Proposal notification')
       } else {
-        this.ephemeral.replyingMessage = { text, hash }
+        this.ephemeral.replyingMessage = { hash, text: stripMarkdownSyntax(text, 180) } // !@#
         this.ephemeral.replyingTo = this.who(message)
       }
     },

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -86,7 +86,7 @@
           :isGroupCreator='isGroupCreator'
           :class='{removed: message.delete}'
           @retry='retryMessage(index)'
-          @reply='replyMessage(message)'
+          @reply='replyToMessage(message)'
           @scroll-to-replying-message='scrollToMessage(message.replyingMessage.hash)'
           @edit-message='(newMessage) => editMessage(message, newMessage)'
           @pin-to-channel='pinToChannel(message)'
@@ -143,7 +143,12 @@ import ViewArea from './ViewArea.vue'
 import Emoticons from './Emoticons.vue'
 import TouchLinkHelper from './TouchLinkHelper.vue'
 import DragActiveOverlay from './file-attachment/DragActiveOverlay.vue'
-import { MESSAGE_TYPES, MESSAGE_VARIANTS, CHATROOM_ACTIONS_PER_PAGE, CHATROOM_MEMBER_MENTION_SPECIAL_CHAR } from '@model/contracts/shared/constants.js'
+import {
+  MESSAGE_TYPES, MESSAGE_VARIANTS,
+  CHATROOM_ACTIONS_PER_PAGE,
+  CHATROOM_MEMBER_MENTION_SPECIAL_CHAR,
+  CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS
+} from '@model/contracts/shared/constants.js'
 import { CHATROOM_EVENTS, NEW_CHATROOM_UNREAD_POSITION, DELETE_ATTACHMENT_FEEDBACK } from '@utils/events.js'
 import { findMessageIdx } from '@model/contracts/shared/functions.js'
 import { proximityDate, MINS_MILLIS } from '@model/contracts/shared/time.js'
@@ -401,15 +406,7 @@ export default ({
 
       const data = { type: MESSAGE_TYPES.TEXT, text }
       if (replyingMessage) {
-        // NOTE: If not replying to a message, use original data; otherwise, append replyingMessage to data.
         data.replyingMessage = replyingMessage
-        // NOTE: for the messages with only images, the text should be updated with file name
-        if (!replyingMessage.text) {
-          const msg = this.messages.find(m => (m.hash === replyingMessage.hash))
-          if (msg) {
-            data.replyingMessage.text = msg.attachments[0].name
-          }
-        }
       }
 
       const sendMessage = (beforePrePublish) => {
@@ -630,21 +627,25 @@ export default ({
       this.messages.splice(index, 1)
       this.handleSendMessage(message.text, message.attachments, message.replyingMessage)
     },
-    replyMessage (message) {
-      const { text, hash, type } = message
+    replyToMessage (message) {
+      const { text, hash, type, attachments } = message
+      const isTypeInteractive = type === MESSAGE_TYPES.INTERACTIVE
 
-      if (type === MESSAGE_TYPES.INTERACTIVE) {
+      if (isTypeInteractive) {
         const proposal = message.proposal
 
         this.ephemeral.replyingMessage = {
-          text: interactiveMessage(proposal, { from: `${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${proposal.creatorID}` }),
-          hash
+          hash, text: interactiveMessage(proposal, { from: `${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${proposal.creatorID}` })
         }
-        this.ephemeral.replyingTo = L('Proposal notification')
+      } else if (!text && attachments.length) {
+        this.ephemeral.replyingMessage = { hash, text: attachments[0].name }
       } else {
-        this.ephemeral.replyingMessage = { hash, text: stripMarkdownSyntax(text, 180) } // !@#
-        this.ephemeral.replyingTo = this.who(message)
+        this.ephemeral.replyingMessage = {
+          hash, text: stripMarkdownSyntax(text, CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS)
+        }
       }
+
+      this.ephemeral.replyingTo = isTypeInteractive ? L('Proposal notification') : this.who(message)
     },
     editMessage (message, newMessage) {
       message.text = newMessage

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -376,7 +376,9 @@ export default ({
       }
     },
     replyingMessageText (message) {
-      return message.replyingMessage?.text || ''
+      return message.replyingMessage?.text
+        ? message.replyingMessage.text.slice(0, CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS)
+        : ''
     },
     time (strTime) {
       return new Date(strTime)
@@ -637,7 +639,7 @@ export default ({
         this.ephemeral.replyingMessage = {
           hash, text: interactiveMessage(proposal, { from: `${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${proposal.creatorID}` })
         }
-      } else if (!text && attachments.length) {
+      } else if (!text && attachments?.length) {
         this.ephemeral.replyingMessage = { hash, text: attachments[0].name }
       } else {
         const sanitizeAndTruncate = text => {

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -25,19 +25,12 @@
           span.has-text-1 {{ humanDate(datetime, { hour: 'numeric', minute: 'numeric' }) }}
 
       slot(name='body')
-        template(v-if='replyingMessage')
-          render-message-with-markdown(
-            v-if='shouldRenderMarkdown'
-            :isReplyingMessage='true'
-            :text='replyingMessage'
-            @click='$emit("reply-message-clicked")'
-          )
-          render-message-text.c-replying(
-            v-else
-            :isReplyingMessage='true'
-            :text='replyingMessage'
-            @click='$emit("reply-message-clicked")'
-          )
+        render-message-text.c-replying(
+          v-if='replyingMessage'
+          :isReplyingMessage='true'
+          :text='replyingMessage'
+          @click='$emit("reply-message-clicked")'
+        )
 
         send-area.c-edit-send-area(
           v-if='isEditing'

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
@@ -222,7 +222,6 @@ export default ({
     &.has-trailing-ellipsis::after {
       content: "...";
       position: relative;
-      display: block;
       margin-top: 0.25rem;
     }
   }

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
@@ -3,7 +3,7 @@ component.c-message-text(
   :is='tag'
   v-bind='$attrs'
   v-on='$listeners'
-  :class='{ "is-replying": isReplyingMessage }'
+  :class='{ "is-replying": isReplyingMessage, "has-trailing-ellipsis": showTrailingEllipsis }'
 )
   template(v-for='objText in textObjects')
     span(
@@ -36,7 +36,8 @@ import ProfileCard from '@components/ProfileCard.vue'
 import {
   CHATROOM_PRIVACY_LEVEL,
   CHATROOM_MEMBER_MENTION_SPECIAL_CHAR,
-  CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR
+  CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR,
+  CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS
 } from '@model/contracts/shared/constants.js'
 import { makeMentionFromUserID, makeChannelMention, getIdFromChannelMention } from '@model/chatroom/utils.js'
 import { TextObjectType } from '@utils/constants.js'
@@ -74,6 +75,9 @@ export default ({
         ...Object.keys(this.ourContactProfilesById).map(u => makeMentionFromUserID(u).me).filter(v => !!v),
         makeChannelMention('[^\\s]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
       ]
+    },
+    showTrailingEllipsis () {
+      return this.isReplyingMessage && this.text.length === CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS
     }
   },
   methods: {
@@ -202,6 +206,7 @@ export default ({
     font-style: italic;
     padding-left: 0.25rem;
     white-space: pre-line;
+    margin-bottom: 0.5rem;
 
     &:hover {
       cursor: pointer;
@@ -212,6 +217,13 @@ export default ({
     .c-member-mention,
     .c-channel-mention {
       background-color: transparent;
+    }
+
+    &.has-trailing-ellipsis::after {
+      content: "...";
+      position: relative;
+      display: block;
+      margin-top: 0.25rem;
     }
   }
 }

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -1,5 +1,6 @@
 import { marked } from 'marked'
 import { validateURL } from './misc.js'
+import { swapMentionIDForDisplayname } from '@model/chatroom/utils.js'
 
 export type MarkdownSegment = {
   type: 'code' | 'plain',
@@ -192,4 +193,21 @@ export function combineMarkdownSegmentListIntoString (
     (concatenated: string, entry: MarkdownSegment) => concatenated + entry.text,
     ''
   )
+}
+
+export function stripMarkdownSyntax (markdownString: string, truncateTo: number = -1): string {
+  markdownString = swapMentionIDForDisplayname(markdownString) // eg. '@identityContractID' -> '@user1'
+
+  const sanitized = markdownString
+    .replace(/\*\*(.*?)\*\*/g, '$1') // 'bold'
+    .replace(/_(.*?)_/g, '$1') // 'italic'
+    .replace(/~(.*?)~/g, '$1') // 'strike-through'
+    .replace(/`(.*?)`/g, '$1') // 'inline code'
+    .replace(/```/g, '') // 'code block'
+    .replace(/\[(.*?)\]\((.*?)\)/g, '$1') // links ([text](url) -> text)
+    .replace(/^>\s*/gm, '') // block-quote
+    .replace(/\s+/g, ' ') // Normalize spaces
+    .trim()
+
+  return truncateTo > 0 ? sanitized.slice(0, truncateTo) : sanitized
 }

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -202,8 +202,8 @@ export function stripMarkdownSyntax (markdownString: string, truncateTo: number 
     .replace(/\*\*(.*?)\*\*/g, '$1') // 'bold'
     .replace(/_(.*?)_/g, '$1') // 'italic'
     .replace(/~(.*?)~/g, '$1') // 'strike-through'
-    .replace(/`(.*?)`/g, '$1') // 'inline code'
     .replace(/```/g, '') // 'code block'
+    .replace(/`(.*?)`/g, '$1') // 'inline code'
     .replace(/\[(.*?)\]\((.*?)\)/g, '$1') // links ([text](url) -> text)
     .replace(/^>\s*/gm, '') // block-quote
     .replace(/\s+/g, ' ') // Normalize spaces


### PR DESCRIPTION
closes #2718 

As requested the replied message UI:

**1.** strips out all the markdown syntaxes. (eg  `"is **bold**"` ->  `"is bold"`, `"is ~strike-through~"` -> `"is strike-through"`)
**2.** truncate the text to 180 characters (Pls let me know if this limit should be changed)


<img width="530" alt="truncated-replying-msg" src="https://github.com/user-attachments/assets/4c817af9-f3ff-4609-87d2-ae5bed887093" />

---
Please note that the transformations **1.** and **2.** above are done **before** the message is sent and the intention is to reduce the message size in the DB. What I've noticed is that this `replyingMessage` field(below) of the chat message contains the whole text currently (The comment says `(if too long, truncate)` but it has not been implemented yet)

https://github.com/okTurtles/group-income/blob/22c56d5807d7875e00a245d855b23ed90d75f34e/frontend/model/contracts/shared/types.js#L82-L85

 If the replied message content is huge, this is clearly a waste of data (Imagine multiple users reply to this huge content message). 
But this also means that the fix by this PR will only be applied to the messages that are sent **after** the fix is deployed. Hope it sounds good.