### PR TITLE
#2729 - update `currentChatRoomReadUntil` when the latest message is deleted

### DIFF
--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -82,14 +82,17 @@ export default (sbp('sbp/selectors/register', {
       }
     })
   },
-  'gi.actions/identity/kv/setChatRoomReadUntil': ({ contractID, messageHash, createdHeight }: {
-    contractID: string, messageHash: string, createdHeight: number
+  'gi.actions/identity/kv/setChatRoomReadUntil': ({ contractID, messageHash, createdHeight, forceUpdate = false }: {
+    contractID: string,
+    messageHash: string,
+    createdHeight: number,
+    forceUpdate: boolean // In a rare case, the 'readUntil' value needs to be set to the msg with lower 'createdHeight'. (reference: https://github.com/okTurtles/group-income/issues/2729)
   }) => {
     return sbp('okTurtles.eventQueue/queueEvent', KV_QUEUE, async () => {
       const getUpdatedUnreadMessages = async () => {
         const currentData = await sbp('gi.actions/identity/kv/fetchChatRoomUnreadMessages')
 
-        if (currentData[contractID]?.readUntil.createdHeight < createdHeight) {
+        if (forceUpdate || currentData[contractID]?.readUntil.createdHeight < createdHeight) {
           const { unreadMessages } = currentData[contractID]
           return {
             ...currentData,

--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -86,7 +86,11 @@ export default (sbp('sbp/selectors/register', {
     contractID: string,
     messageHash: string,
     createdHeight: number,
-    forceUpdate: boolean // In a rare case, the 'readUntil' value needs to be set to the msg with lower 'createdHeight'. (reference: https://github.com/okTurtles/group-income/issues/2729)
+    // In a rare case, such as when the latest message is deleted,
+    // the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
+    // 'forceUpdate' flag is used to override the 'createdHeight' check below to allow this kind of update.
+    // (reference: https://github.com/okTurtles/group-income/issues/2729)
+    forceUpdate: boolean
   }) => {
     return sbp('okTurtles.eventQueue/queueEvent', KV_QUEUE, async () => {
       const getUpdatedUnreadMessages = async () => {

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -981,7 +981,7 @@ export default ({
         if (!forceUpdate && this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
           // NOTE: skip adding useless invocations in KV_QUEUE queue.
           //       'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
-          //       (reference: https://github.com/okTurtles/group-income/issues/2729)
+          //       eg. when the latest message is deleted. (reference: https://github.com/okTurtles/group-income/issues/2729)
           return
         }
 

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -979,9 +979,9 @@ export default ({
       const chatRoomID = this.ephemeral.renderingChatRoomId
       if (chatRoomID && this.isJoinedChatRoom(chatRoomID)) {
         if (!forceUpdate && this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
-          // NOTE: skip adding useless invocations in KV_QUEUE queue.
-          //       'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
-          //       eg. when the latest message is deleted. (reference: https://github.com/okTurtles/group-income/issues/2729)
+          // NOTE-1: skip adding useless invocations in KV_QUEUE queue.
+          // NOTE-2: 'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
+          //         eg. when the latest message is deleted. (reference: https://github.com/okTurtles/group-income/issues/2729)
           return
         }
 

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -691,8 +691,14 @@ export default ({
       }
     },
     async deleteMessage (message) {
+      const msgHash = message.hash
       const contractID = this.ephemeral.renderingChatRoomId
       const manifestCids = (message.attachments || []).map(attachment => attachment.downloadData.manifestCid)
+
+      const lastMsg = this.messages[this.messages.length - 1]
+      const secondLastMsg = this.messages[this.messages.length - 2]
+      const isDeletingLastMsg = msgHash === lastMsg?.hash
+
       const question = message.attachments?.length
         ? L('Are you sure you want to delete this message and it\'s file attachments permanently?')
         : L('Are you sure you want to delete this message permanently?')
@@ -704,13 +710,33 @@ export default ({
         secondaryButton: L('Cancel')
       }
 
-      const primaryButtonSelected = await sbp('gi.ui/prompt', promptConfig)
-      if (primaryButtonSelected) {
-        sbp('gi.actions/chatroom/deleteMessage', {
-          contractID,
-          data: { hash: message.hash, manifestCids, messageSender: message.from }
-        }).catch((e) => {
-          console.error(`Error while deleting message(${message.hash}) for chatroom(${contractID})`, e)
+      try {
+        const primaryButtonSelected = await sbp('gi.ui/prompt', promptConfig)
+        if (primaryButtonSelected) {
+          await sbp('gi.actions/chatroom/deleteMessage', {
+            contractID,
+            data: { hash: msgHash, manifestCids, messageSender: message.from }
+          })
+
+          // If the deleted message is the most recent message and 'currentChatRoomReadUntil' is pointing to the deleted one,
+          // it needs to be updated to the second most recent one.
+          if (isDeletingLastMsg &&
+            this.currentChatRoomReadUntil?.messageHash === msgHash &&
+            secondLastMsg) {
+            this.updateReadUntilMessageHash({
+              messageHash: secondLastMsg.hash,
+              createdHeight: secondLastMsg.height,
+              forceUpdate: true
+            })
+          }
+        }
+      } catch (e) {
+        console.error(`Error while deleting message(${msgHash}) for chatroom(${contractID})`, e)
+
+        sbp('gi.ui/prompt', {
+          heading: L('Error while deleting a message'),
+          question: L('Error details: {reportError}', LError(e)),
+          primaryButton: L('Close')
         })
       }
     },
@@ -939,15 +965,18 @@ export default ({
         }
       }
     },
-    updateReadUntilMessageHash ({ messageHash, createdHeight }) {
+    updateReadUntilMessageHash ({ messageHash, createdHeight, forceUpdate = false }) {
       const chatRoomID = this.ephemeral.renderingChatRoomId
       if (chatRoomID && this.isJoinedChatRoom(chatRoomID)) {
-        if (this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
-          // NOTE: skip adding useless invocations in KV_QUEUE queue
+        if (!forceUpdate && this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
+          // NOTE: skip adding useless invocations in KV_QUEUE queue.
+          //       'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
+          //       (reference: https://github.com/okTurtles/group-income/issues/2729)
           return
         }
+
         sbp('gi.actions/identity/kv/setChatRoomReadUntil', {
-          contractID: chatRoomID, messageHash, createdHeight
+          contractID: chatRoomID, messageHash, createdHeight, forceUpdate
         }).catch(e => {
           console.error('[ChatMain.vue] Error setting read until', e)
         })


### PR DESCRIPTION
closes #2729 

**[Before fix]**

Delete the latest message -> visit another channel -> come back to `#general` -> **does not** scroll to the bottom. 

https://github.com/user-attachments/assets/63aacabe-e458-49c7-b7a0-7589a8aaae6b

**[After fix]**

Delete the latest message -> visit another channel -> come back to #general -> **does** scroll to the bottom as expected.

https://github.com/user-attachments/assets/28b914e6-1fde-42fc-aa14-1cbb959c775c

