### PR TITLE
Timestamp meta on server

### DIFF
--- a/backend/database.js
+++ b/backend/database.js
@@ -52,7 +52,7 @@ export default ((sbp('sbp/selectors/register', {
     }
     // Number of entries pushed.
     let counter = 0
-    let { currentHash, ...serverMeta } = (
+    let { hash: currentHash, ...serverMeta } = (
       await sbp('chelonia/db/getEntryMeta', contractID, height)
     ) || {}
     let prefix = ''
@@ -69,13 +69,13 @@ export default ((sbp('sbp/selectors/register', {
           this.destroy()
           return
         }
-        if (!!currentHash && counter < limit) {
+        if (currentHash && counter < limit) {
           sbp('chelonia/db/getEntry', currentHash).then(async entry => {
             if (entry) {
               const currentPrefix = prefix
               prefix = ','
               counter++
-              const { currentHash: newCurrentHash, ...newServerMeta } = (
+              const { hash: newCurrentHash, ...newServerMeta } = (
                 await sbp('chelonia/db/getEntryMeta', contractID, entry.height() + 1)
               ) || {}
               this.push(

--- a/backend/database.js
+++ b/backend/database.js
@@ -41,7 +41,7 @@ if (!fs.existsSync(dataFolder)) {
 
 // Streams stored contract log entries since the given entry hash (inclusive!).
 export default ((sbp('sbp/selectors/register', {
-  'backend/db/streamEntriesAfter': async function (contractID: string, height: string, requestedLimit: ?number): Promise<*> {
+  'backend/db/streamEntriesAfter': async function (contractID: string, height: string, requestedLimit: ?number, options: { keyOps?: boolean } = {}): Promise<*> {
     const limit = Math.min(requestedLimit ?? Number.POSITIVE_INFINITY, process.env.MAX_EVENTS_BATCH_SIZE ?? 500)
     const latestHEADinfo = await sbp('chelonia/db/latestHEADinfo', contractID)
     if (latestHEADinfo === '') {
@@ -52,8 +52,9 @@ export default ((sbp('sbp/selectors/register', {
     }
     // Number of entries pushed.
     let counter = 0
+    let currentHeight = parseInt(height)
     let { currentHash, ...serverMeta } = (
-      await sbp('chelonia/db/getEntryMeta', contractID, height)
+      await sbp('chelonia/db/getEntryMeta', contractID, currentHeight)
     ) || {}
     let prefix = ''
     let ended = false
@@ -70,32 +71,51 @@ export default ((sbp('sbp/selectors/register', {
           return
         }
         if (!!currentHash && counter < limit) {
-          sbp('chelonia/db/getEntry', currentHash).then(async entry => {
-            if (entry) {
-              const currentPrefix = prefix
-              prefix = ','
-              counter++
-              const { currentHash: newCurrentHash, ...newServerMeta } = (
-                await sbp('chelonia/db/getEntryMeta', contractID, entry.height() + 1)
-              ) || {}
-              this.push(
+          (async () => {
+            try {
+              if (options.keyOps) {
+                while (!serverMeta.isKeyOp) {
+                  const { currentHash: newCurrentHash, ...newServerMeta } = (
+                    await sbp('chelonia/db/getEntryMeta', contractID, ++currentHeight)
+                  ) || {}
+                  if (!newCurrentHash) {
+                    this.push(']')
+                    this.push(null)
+                    ended = true
+                    return
+                  }
+                  currentHash = newCurrentHash
+                  serverMeta = newServerMeta
+                }
+              }
+              const entry = await sbp('chelonia/db/getEntry', currentHash)
+              if (entry) {
+                const currentPrefix = prefix
+                prefix = ','
+                counter++
+                currentHeight = entry.height() + 1
+                const { currentHash: newCurrentHash, ...newServerMeta } = (
+                  await sbp('chelonia/db/getEntryMeta', contractID, currentHeight)
+                ) || {}
+                this.push(
                 `${currentPrefix}"${strToB64(
                   JSON.stringify({ serverMeta, message: entry.serialize() })
                 )}"`
-              )
-              currentHash = newCurrentHash
-              serverMeta = newServerMeta
-            } else {
+                )
+                currentHash = newCurrentHash
+                serverMeta = newServerMeta
+              } else {
+                this.push(']')
+                this.push(null)
+                ended = true
+              }
+            } catch (e) {
+              console.error(`[backend] streamEntriesAfter: read(): ${e.message}:`, e.stack)
               this.push(']')
               this.push(null)
               ended = true
             }
-          }).catch(e => {
-            console.error(`[backend] streamEntriesAfter: read(): ${e.message}:`, e.stack)
-            this.push(']')
-            this.push(null)
-            ended = true
-          })
+          })()
         } else {
           this.push(']')
           this.push(null)

--- a/backend/database.js
+++ b/backend/database.js
@@ -49,38 +49,52 @@ sbp('sbp/selectors/register', {
     }
     // Number of entries pushed.
     let counter = 0
-    let currentHash = await sbp('chelonia.db/get', `_private_hidx=${contractID}#${height}`)
-    let prefix = '['
+    let { currentHash, ...serverMeta } = (
+      await sbp('chelonia/db/getEntryMeta', contractID, height)
+    ) || {}
+    let prefix = ''
     let ended = false
     // NOTE: if this ever stops working you can also try Readable.from():
     // https://nodejs.org/api/stream.html#stream_stream_readable_from_iterable_options
     const stream = new Readable({
+      construct (cb) {
+        this.push('[')
+        cb()
+      },
       read (): void {
         if (ended) {
           this.destroy()
           return
         }
-        if (currentHash && counter < limit) {
+        if (!!currentHash && counter < limit) {
           sbp('chelonia/db/getEntry', currentHash).then(async entry => {
             if (entry) {
               const currentPrefix = prefix
               prefix = ','
               counter++
-              currentHash = await sbp('chelonia.db/get', `_private_hidx=${contractID}#${entry.height() + 1}`)
-              this.push(`${currentPrefix}"${strToB64(entry.serialize())}"`)
+              const { currentHash: newCurrentHash, ...newServerMeta } = (
+                await sbp('chelonia/db/getEntryMeta', contractID, entry.height() + 1)
+              ) || {}
+              this.push(
+                `${currentPrefix}"${strToB64(
+                  JSON.stringify({ serverMeta, message: entry.serialize() })
+                )}"`
+              )
+              currentHash = newCurrentHash
+              serverMeta = newServerMeta
             } else {
-              this.push(counter > 0 ? ']' : '[]')
+              this.push(']')
               this.push(null)
               ended = true
             }
           }).catch(e => {
-            console.error(`[backend] streamEntriesAfter: read(): ${e.message}:`, e)
-            this.push(counter > 0 ? ']' : '[]')
+            console.error(`[backend] streamEntriesAfter: read(): ${e.message}:`, e.stack)
+            this.push(']')
             this.push(null)
             ended = true
           })
         } else {
-          this.push(counter > 0 ? ']' : '[]')
+          this.push(']')
           this.push(null)
           ended = true
         }

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -236,7 +236,7 @@ route.GET('/eventsAfter/{contractID}/{since}/{limit?}', {}, async function (requ
       return Boom.badRequest()
     }
 
-    const stream = await sbp('backend/db/streamEntriesAfter', contractID, since, limit, { keyOps: !!request.query['keyOps'] })
+    const stream = await sbp('backend/db/streamEntriesAfter', contractID, since, limit)
     // "On an HTTP server, make sure to manually close your streams if a request is aborted."
     // From: http://knexjs.org/#Interfaces-Streams
     //       https://github.com/tgriesser/knex/wiki/Manually-Closing-Streams

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -236,7 +236,7 @@ route.GET('/eventsAfter/{contractID}/{since}/{limit?}', {}, async function (requ
       return Boom.badRequest()
     }
 
-    const stream = await sbp('backend/db/streamEntriesAfter', contractID, since, limit)
+    const stream = await sbp('backend/db/streamEntriesAfter', contractID, since, limit, { keyOps: !!request.query['keyOps'] })
     // "On an HTTP server, make sure to manually close your streams if a request is aborted."
     // From: http://knexjs.org/#Interfaces-Streams
     //       https://github.com/tgriesser/knex/wiki/Manually-Closing-Streams

--- a/shared/domains/chelonia/db.js
+++ b/shared/domains/chelonia/db.js
@@ -105,8 +105,7 @@ export default ((sbp('sbp/selectors/register', {
     const entryMetaJson = await sbp('chelonia.db/get', `_private_hidx=${contractID}#${height}`)
     if (!entryMetaJson) return
 
-    const entryMeta = JSON.parse(entryMetaJson)
-    return entryMeta
+    return JSON.parse(entryMetaJson)
   },
   'chelonia/db/setEntryMeta': async (contractID: string, height: number, entryMeta: Object) => {
     const entryMetaJson = JSON.stringify(entryMeta)
@@ -169,7 +168,7 @@ export default ((sbp('sbp/selectors/register', {
       await sbp('chelonia.db/set', getLogHead(contractID), JSON.stringify({ HEAD: entry.hash(), height: entry.height() }))
       console.debug(`[chelonia.db] HEAD for ${contractID} updated to:`, entry.hash())
       await sbp('chelonia/db/setEntryMeta', contractID, entryHeight, {
-        currentHash: entry.hash(),
+        hash: entry.hash(),
         date: new Date().toISOString()
       })
       return entry.hash()

--- a/shared/domains/chelonia/db.js
+++ b/shared/domains/chelonia/db.js
@@ -98,6 +98,17 @@ const dbPrimitiveSelectors = process.env.LIGHTWEIGHT_CLIENT === 'true'
 
 export default ((sbp('sbp/selectors/register', {
   ...dbPrimitiveSelectors,
+  'chelonia/db/getEntryMeta': async (contractID: string, height: number) => {
+    const entryMetaJson = await sbp('chelonia.db/get', `_private_hidx=${contractID}#${height}`)
+    if (!entryMetaJson) return
+
+    const entryMeta = JSON.parse(entryMetaJson)
+    return entryMeta
+  },
+  'chelonia/db/setEntryMeta': async (contractID: string, height: number, entryMeta: Object) => {
+    const entryMetaJson = JSON.stringify(entryMeta)
+    await sbp('chelonia.db/set', `_private_hidx=${contractID}#${height}`, entryMetaJson)
+  },
   'chelonia/db/latestHEADinfo': (contractID: string): Promise<HEADInfo | void> => {
     return sbp('chelonia.db/get', getLogHead(contractID)).then((r) => r && JSON.parse(r))
   },
@@ -151,7 +162,10 @@ export default ((sbp('sbp/selectors/register', {
       await sbp('chelonia.db/set', entry.hash(), entry.serialize())
       await sbp('chelonia.db/set', getLogHead(contractID), JSON.stringify({ HEAD: entry.hash(), height: entry.height() }))
       console.debug(`[chelonia.db] HEAD for ${contractID} updated to:`, entry.hash())
-      await sbp('chelonia.db/set', `_private_hidx=${contractID}#${entryHeight}`, entry.hash())
+      await sbp('chelonia/db/setEntryMeta', contractID, entryHeight, {
+        currentHash: entry.hash(),
+        date: new Date().toISOString()
+      })
       return entry.hash()
     } catch (e) {
       if (e.name.includes('ErrorDB')) {

--- a/shared/domains/chelonia/db.js
+++ b/shared/domains/chelonia/db.js
@@ -99,9 +99,6 @@ const dbPrimitiveSelectors = process.env.LIGHTWEIGHT_CLIENT === 'true'
       }
     }
 
-// Operations that affect valid keys
-const keyOps = [SPMessage.OP_CONTRACT, SPMessage.OP_KEY_ADD, SPMessage.OP_KEY_DEL, SPMessage.OP_KEY_UPDATE]
-
 export default ((sbp('sbp/selectors/register', {
   ...dbPrimitiveSelectors,
   'chelonia/db/getEntryMeta': async (contractID: string, height: number) => {
@@ -171,20 +168,9 @@ export default ((sbp('sbp/selectors/register', {
       await sbp('chelonia.db/set', entry.hash(), entry.serialize())
       await sbp('chelonia.db/set', getLogHead(contractID), JSON.stringify({ HEAD: entry.hash(), height: entry.height() }))
       console.debug(`[chelonia.db] HEAD for ${contractID} updated to:`, entry.hash())
-      // `isKeyOp` is used to filter out non-key operations for providing an
-      // abbreviated chain fo snapshot validation
-      const isKeyOp =
-            !!(
-              keyOps.includes(entry.opType()) ||
-                // $FlowFixMe[prop-missing]
-                (entry.opType() === SPMessage.OP_ATOMIC && Array.isArray(entry.opValue()) && entry.opValue().some(([opT]) => {
-                  return keyOps.includes(opT)
-                }))
-            )
       await sbp('chelonia/db/setEntryMeta', contractID, entryHeight, {
         currentHash: entry.hash(),
-        date: new Date().toISOString(),
-        ...(isKeyOp && { isKeyOp })
+        date: new Date().toISOString()
       })
       return entry.hash()
     } catch (e) {

--- a/shared/domains/chelonia/utils.js
+++ b/shared/domains/chelonia/utils.js
@@ -681,7 +681,7 @@ export function eventsAfter (contractID: string, sinceHeight: number, limit?: nu
                   if (count === requestLimit) {
                     throw new Error('Received too many events')
                   }
-                  currentEvent = b64ToStr(JSON.parse(eventValue))
+                  currentEvent = JSON.parse(b64ToStr(JSON.parse(eventValue))).message
                   if (count === 0) {
                     const hash = SPMessage.deserializeHEAD(currentEvent).hash
                     const height = SPMessage.deserializeHEAD(currentEvent).head.height


### PR DESCRIPTION
Closes #2695.

**NB! The `date` header isn't implemented for `GET /file` due to limitations on doing this using the `_private_hidx=` key, which is based on the contract ID.** The `date` header for `/file` could be implemented, but using a key based on the CID (hash) of that particular message.

> [!CAUTION]
> This PR requires re-creating the database due to incompatible use some index keys.