### PR TITLE
#2728 - Truncate long message in chat

### DIFF
--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -22,8 +22,8 @@ export const KILOBYTE = 1 << 10
 export const MEGABYTE = 1 << 20
 export const CHAT_ATTACHMENT_SIZE_LIMIT = 30 * MEGABYTE // in byte.
 export const IMAGE_ATTACHMENT_MAX_SIZE = 400 * KILOBYTE // 400KB
-export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 750 * 2 // in px
-export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 750 * 3 // The value of mobile is more tolerant considering smaller screen size.
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 750 * 1.5 // in px
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 750 * 2 // The value of mobile is more tolerant considering smaller screen size.
 
 export const TextObjectType = {
   Text: 'TEXT',

--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -22,6 +22,8 @@ export const KILOBYTE = 1 << 10
 export const MEGABYTE = 1 << 20
 export const CHAT_ATTACHMENT_SIZE_LIMIT = 30 * MEGABYTE // in byte.
 export const IMAGE_ATTACHMENT_MAX_SIZE = 400 * KILOBYTE // 400KB
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 750 * 2 // in px
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 750 * 3 // The value of mobile is more tolerant considering smaller screen size.
 
 export const TextObjectType = {
   Text: 'TEXT',

--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -22,8 +22,8 @@ export const KILOBYTE = 1 << 10
 export const MEGABYTE = 1 << 20
 export const CHAT_ATTACHMENT_SIZE_LIMIT = 30 * MEGABYTE // in byte.
 export const IMAGE_ATTACHMENT_MAX_SIZE = 400 * KILOBYTE // 400KB
-export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 750 * 1.25 // in px
-export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 750 * 1.5 // The value of mobile is more tolerant considering smaller screen size.
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 500 * 1.25 // in px
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 500 * 1.5 // The value of mobile is more tolerant considering smaller screen size.
 
 export const TextObjectType = {
   Text: 'TEXT',

--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -22,8 +22,8 @@ export const KILOBYTE = 1 << 10
 export const MEGABYTE = 1 << 20
 export const CHAT_ATTACHMENT_SIZE_LIMIT = 30 * MEGABYTE // in byte.
 export const IMAGE_ATTACHMENT_MAX_SIZE = 400 * KILOBYTE // 400KB
-export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 750 * 1.5 // in px
-export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 750 * 2 // The value of mobile is more tolerant considering smaller screen size.
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 750 * 1.25 // in px
+export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 750 * 1.5 // The value of mobile is more tolerant considering smaller screen size.
 
 export const TextObjectType = {
   Text: 'TEXT',

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -75,6 +75,7 @@
           :replyingMessage='replyingMessageText(message)'
           :datetime='time(message.datetime)'
           :edited='!!message.updatedDate'
+          :updatedDate='message.updatedDate'
           :emoticonsList='message.emoticons'
           :who='who(message)'
           :currentUserID='currentUserAttr.id'

--- a/frontend/views/containers/chatroom/Message.vue
+++ b/frontend/views/containers/chatroom/Message.vue
@@ -38,6 +38,10 @@ export default ({
       type: Date,
       required: true
     },
+    updatedDate: {
+      type: String,
+      required: false
+    },
     edited: Boolean,
     variant: {
       type: String,

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -105,14 +105,17 @@
     @unpinFromChannel='$emit("unpin-from-channel")'
   )
 
-  .c-truncate-toggle-container(v-if='ephemeral.truncateToggle.enabled')
+  .c-truncate-toggle-container(
+    v-if='ephemeral.truncateToggle.enabled'
+    :class='{ "should-indent": isTypeText }'
+  )
     button.is-unstyled.c-truncate-toggle(
       :class='{ "is-showing": ephemeral.truncateToggle.isShowingAll }'
       type='button'
       @click.stop='toggleMessageTruncation'
     )
-      i18n(v-if='ephemeral.truncateToggle.isShowingAll') Show less
-      i18n(v-else) Show more
+      i18n.c-btn-text(v-if='ephemeral.truncateToggle.isShowingAll') Show less
+      i18n.c-btn-text(v-else) Show more
       i.icon-angle-down
 </template>
 
@@ -300,15 +303,19 @@ export default ({
 
       if (msgBodyEl) {
         const height = msgBodyEl.clientHeight
-        console.log('!@# msgHeight: ', height)
 
         if (height > threshold) {
           this.ephemeral.truncateToggle.enabled = true
         }
       }
     },
-    toggleMessageTruncation () {
-      this.ephemeral.truncateToggle.isShowingAll = !this.ephemeral.truncateToggle.isShowingAll
+    toggleMessageTruncation (e) {
+      const currentValue = this.ephemeral.truncateToggle.isShowingAll
+      this.ephemeral.truncateToggle.isShowingAll = !currentValue
+
+      if (currentValue) {
+        this.$el.scrollIntoView({ behavior: 'instant' })
+      }
     }
   },
   watch: {
@@ -503,18 +510,11 @@ export default ({
 
 .c-message.has-truncate-toggle {
   padding-bottom: 2.5rem;
-  --c-container-bg: linear-gradient(to bottom, rgba(0, 0, 0, 0) 45%, var(--c-bg-color) 95%);
-  --c-container-bg-opacity: 0.57;
-
-  .is-dark-theme & {
-    --c-container-bg: linear-gradient(to bottom, rgba(0, 0, 0, 0) 27.5%, var(--c-bg-color) 87.5%);
-    --c-container-bg-opacity: 0.825;
-  }
 
   .c-body,
   .c-full-width-body {
     &.is-truncated {
-      max-height: 36rem;
+      max-height: 28rem;
       overflow-y: hidden;
     }
   }
@@ -531,25 +531,36 @@ export default ({
     padding-bottom: 0.5rem;
     pointer-events: none;
 
+    &.should-indent {
+      padding-left: 4.25rem;
+    }
+
     button.c-truncate-toggle {
       z-index: 1;
       pointer-events: initial;
       color: $primary_0;
       font-size: $size_5;
-      padding: 0 1rem;
       display: inline-flex;
       align-items: center;
       justify-content: center;
       column-gap: 6px;
 
-      i {
-        font-size: 1.15em;
+      &:hover,
+      &:focus,
+      &:focus-within {
+        .c-btn-text {
+          text-decoration: underline;
+        }
       }
 
       &.is-showing {
         i {
           transform: rotate(180deg);
         }
+      }
+
+      i {
+        font-size: 1.15em;
       }
     }
   }

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -370,7 +370,6 @@ export default ({
 @import "@assets/style/_variables.scss";
 
 .c-message {
-  --c-bg-color: var(--background_0);
   padding: 0.5rem 1rem;
   scroll-margin: 20px;
 
@@ -411,7 +410,6 @@ export default ({
   }
 
   &:hover {
-    --c-bg-color: var(--general_2);
     background-color: $general_2;
 
     &:not(.pending, .failed) {

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -300,7 +300,9 @@ export default ({
       return cleaned
     },
     determineToEnableTruncationToggle () {
-      const msgBodyEl = this.isTypePoll ? this.$refs.msgFullWidthBody : this.$refs.msgBody
+      const msgBodyEl = this.isTypePoll
+        ? this.$refs.msgFullWidthBody // poll message is rendered in .c-full-width-body container.
+        : this.$refs.msgBody
       const threshold = this.chatMainConfig.isPhone
         ? CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE
         : CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP
@@ -317,6 +319,7 @@ export default ({
       this.ephemeral.truncateToggle.isShowingAll = !currentValue
 
       if (currentValue) {
+        // When folding the expanded message, scroll to the message so that it stays in the screen.
         this.$el.scrollIntoView({ behavior: 'instant' })
       }
     }
@@ -553,6 +556,10 @@ export default ({
       justify-content: center;
       column-gap: 6px;
 
+      i {
+        font-size: 1.15em;
+      }
+
       &:hover,
       &:focus,
       &:focus-within {
@@ -565,10 +572,6 @@ export default ({
         i {
           transform: rotate(180deg);
         }
-      }
-
-      i {
-        font-size: 1.15em;
       }
     }
   }

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -64,7 +64,7 @@
           :createdAt='datetime'
           :isGroupCreator='isGroupCreator'
           @delete-attachment='deleteAttachment'
-          @image-attachments-render-complete='checkMessageBodyHeight'
+          @image-attachments-render-complete='checkIfTruncateToggleEnabled'
         )
 
       .c-failure-message-wrapper
@@ -295,18 +295,18 @@ export default ({
       const cleaned = tString.replace(/[^\d:]/g, '')
       return cleaned
     },
-    checkMessageBodyHeight () {
+    checkIfTruncateToggleEnabled () {
       const msgBodyEl = this.isTypePoll ? this.$refs.msgFullWidthBody : this.$refs.msgBody
       const threshold = this.chatMainConfig.isPhone
         ? CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE
         : CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP
+      const { enabled, isShowingAll } = this.ephemeral.truncateToggle
 
       if (msgBodyEl) {
-        const height = msgBodyEl.clientHeight
+        const isMsgCurrentlyTruncated = enabled && !isShowingAll
+        const height = isMsgCurrentlyTruncated ? msgBodyEl.scrollHeight : msgBodyEl.clientHeight
 
-        if (height > threshold) {
-          this.ephemeral.truncateToggle.enabled = true
-        }
+        this.ephemeral.truncateToggle.enabled = height > threshold
       }
     },
     toggleMessageTruncation (e) {
@@ -321,7 +321,7 @@ export default ({
   watch: {
     'chatMainConfig.isPhone' () {
       if (this.shouldCheckToTruncate) {
-        this.checkMessageBodyHeight()
+        this.checkIfTruncateToggleEnabled()
       }
     }
   },
@@ -332,7 +332,7 @@ export default ({
       //       (which is detected via 'image-attachments-render-complete' custom event in ChatAttachmentPreview.vue)
       !this.hasImageAttachment
     ) {
-      this.checkMessageBodyHeight()
+      this.checkIfTruncateToggleEnabled()
     }
   }
 }: Object)
@@ -509,7 +509,7 @@ export default ({
 // message-truncation related styles
 
 .c-message.has-truncate-toggle {
-  padding-bottom: 2.5rem;
+  padding-bottom: 2.25rem;
 
   .c-body,
   .c-full-width-body {
@@ -524,12 +524,17 @@ export default ({
     bottom: 0;
     left: 0;
     width: 100%;
-    height: 2.5rem;
+    height: 2.25rem;
     display: flex;
     align-items: flex-end;
     justify-content: flex-start;
+    padding-left: 1rem;
     padding-bottom: 0.5rem;
     pointer-events: none;
+
+    @include tablet {
+      padding-left: 3.5rem;
+    }
 
     &.should-indent {
       padding-left: 4.25rem;

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -17,7 +17,10 @@
         profile-card(:contractID='from' direction='top-left')
           avatar.c-avatar(:src='avatar' aria-hidden='true' size='md')
 
-    .c-body(ref='msgBody')
+    .c-body(
+      ref='msgBody'
+      :class='{ "is-truncated": ephemeral.truncateToggle.enabled && !ephemeral.truncateToggle.isShowingAll }'
+    )
       slot(name='header')
         .c-who(v-if='!isEditing' :class='{ "sr-only": isSameSender }')
           profile-card(:contractID='from' direction='top-left')
@@ -68,7 +71,10 @@
         i18n(tag='span') Message failed to send.
         i18n.c-failure-link(tag='span' @click='$emit("retry")') Resend message
 
-  .c-full-width-body(ref='msgFullWidthBody')
+  .c-full-width-body(
+    ref='msgFullWidthBody'
+    :class='{ "is-truncated": ephemeral.truncateToggle.enabled && !ephemeral.truncateToggle.isShowingAll }'
+  )
     slot(name='full-width-body')
 
   message-reactions(
@@ -101,11 +107,13 @@
 
   .c-truncate-toggle-container(v-if='ephemeral.truncateToggle.enabled')
     button.is-unstyled.c-truncate-toggle(
+      :class='{ "is-showing": ephemeral.truncateToggle.isShowingAll }'
       type='button'
       @click.stop='toggleMessageTruncation'
     )
       i18n(v-if='ephemeral.truncateToggle.isShowingAll') Show less
-      i18n(v-else) Show all
+      i18n(v-else) Show more
+      i.icon-angle-down
 </template>
 
 <script>
@@ -328,7 +336,6 @@ export default ({
 
 .c-message {
   --c-bg-color: var(--background_0);
-
   padding: 0.5rem 1rem;
   scroll-margin: 20px;
 
@@ -495,8 +502,21 @@ export default ({
 // message-truncation related styles
 
 .c-message.has-truncate-toggle {
-  &.truncate-toggle__showing-all {
-    padding-bottom: 2rem;
+  padding-bottom: 2.5rem;
+  --c-container-bg: linear-gradient(to bottom, rgba(0, 0, 0, 0) 45%, var(--c-bg-color) 95%);
+  --c-container-bg-opacity: 0.57;
+
+  .is-dark-theme & {
+    --c-container-bg: linear-gradient(to bottom, rgba(0, 0, 0, 0) 27.5%, var(--c-bg-color) 87.5%);
+    --c-container-bg-opacity: 0.825;
+  }
+
+  .c-body,
+  .c-full-width-body {
+    &.is-truncated {
+      max-height: 36rem;
+      overflow-y: hidden;
+    }
   }
 
   .c-truncate-toggle-container {
@@ -504,30 +524,33 @@ export default ({
     bottom: 0;
     left: 0;
     width: 100%;
-    height: 1.5rem;
+    height: 2.5rem;
     display: flex;
-    align-items: center;
-    justify-content: center;
+    align-items: flex-end;
+    justify-content: flex-start;
+    padding-bottom: 0.5rem;
     pointer-events: none;
-
-    &::after {
-      content: '';
-      position: absolute;
-      z-index: 0;
-      left: 0;
-      bottom: 0;
-      width: 100%;
-      height: 150%;
-      background: linear-gradient(to bottom, rgba(0, 0, 0, 0), var(--c-bg-color) 50%);
-      opacity: 0.885;
-    }
 
     button.c-truncate-toggle {
       z-index: 1;
       pointer-events: initial;
-      color: $text_0;
+      color: $primary_0;
       font-size: $size_5;
       padding: 0 1rem;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      column-gap: 6px;
+
+      i {
+        font-size: 1.15em;
+      }
+
+      &.is-showing {
+        i {
+          transform: rotate(180deg);
+        }
+      }
     }
   }
 }

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -301,7 +301,7 @@ export default ({
     },
     determineToEnableTruncationToggle () {
       const msgBodyEl = this.isTypePoll
-        ? this.$refs.msgFullWidthBody // poll message is rendered in .c-full-width-body container.
+        ? this.$refs.msgFullWidthBody // poll message is rendered in .c-full-width-body container
         : this.$refs.msgBody
       const threshold = this.chatMainConfig.isPhone
         ? CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE

--- a/frontend/views/containers/chatroom/MessagePoll.vue
+++ b/frontend/views/containers/chatroom/MessagePoll.vue
@@ -61,6 +61,10 @@ export default ({
       type: Date,
       required: true
     },
+    updatedDate: {
+      type: String,
+      required: false
+    },
     variant: {
       type: String,
       validator (value) {

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -275,6 +275,9 @@ export default {
         this.loadedURLList = uniq([...this.loadedURLList, url])
 
         if (this.allImageAttachments.length === this.loadedURLList.length) {
+          // Check if all image attachments are loaded in the DOM, notify the parent component.
+          // (This can be enhanced to something like sbp('okTurtles.events/emit', IMAGE_ATTACHMENTS_RENDER_COMPLETE, messageHash) in the future,
+          //  if this becomes useful in more places.)
           this.$nextTick(() => this.$emit('image-attachments-render-complete'))
         }
       }

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -5,7 +5,7 @@
   template(v-if='isForDownload')
     .c-attachment-preview(
       v-for='(entry, entryIndex) in attachmentList'
-      :key='entryIndex'
+      :key='getAttachmentId(entry)'
       class='is-download-item'
       tabindex='0'
     )
@@ -281,6 +281,9 @@ export default {
           this.$nextTick(() => this.$emit('image-attachments-render-complete'))
         }
       }
+    },
+    getAttachmentId (attachment) {
+      return attachment.downloadData?.manifestCid || attachment.name.replaceAll(' ', '_')
     }
   },
   watch: {

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -25,7 +25,8 @@
           :src='objectURLList[entryIndex]'
           :alt='entry.name'
           @click='openImageViewer(objectURLList[entryIndex])'
-          @load='onImageLoad(objectURLList[entryIndex])'
+          @load='onImageSettled(objectURLList[entryIndex])'
+          @error='onImageSettled(objectURLList[entryIndex])'
         )
         .loading-box(v-else :style='loadingBoxStyles[entryIndex]')
 
@@ -125,7 +126,7 @@ export default {
   data () {
     return {
       objectURLList: [],
-      loadedURLList: [],
+      settledURLList: [],
       loadingBoxStyles: []
     }
   },
@@ -270,11 +271,11 @@ export default {
         }
       )
     },
-    onImageLoad (url) {
+    onImageSettled (url) {
       if (this.isForDownload) {
-        this.loadedURLList = uniq([...this.loadedURLList, url])
+        this.settledURLList = uniq([...this.settledURLList, url])
 
-        if (this.allImageAttachments.length === this.loadedURLList.length) {
+        if (this.allImageAttachments.length === this.settledURLList.length) {
           // Check if all image attachments are loaded in the DOM, notify the parent component.
           // (This can be enhanced to something like sbp('okTurtles.events/emit', IMAGE_ATTACHMENTS_RENDER_COMPLETE, messageHash) in the future,
           //  if this becomes useful in more places.)

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -545,7 +545,7 @@ export default {
 }
 
 .c-invisible-link {
-  position: relative;
+  position: absolute;
   top: -10rem;
   left: -10rem;
   opacity: 0;


### PR DESCRIPTION
closes #2728 

**[ screenshot1 - very large text only message ]**

<img src="https://github.com/user-attachments/assets/13f1244f-d256-462c-a942-e7f454972ba4" />

<br><br>

**[ screenshot2 - large message due to big images ]**

<img width="901" alt="truncated_attachment" src="https://github.com/user-attachments/assets/403e70e2-12ee-4719-9eae-3c4a3f79e64f" />

<br><br>

**[ screenshot3 - large markdown ]**

<img width="846" alt="long-content-by-markdown" src="https://github.com/user-attachments/assets/ad1f928b-1424-4cdb-a7eb-a6e190db977b" />

<br><br>

**[ screenshot4 - large chat-poll ]**

<img width="844" alt="truncated_large-poll" src="https://github.com/user-attachments/assets/51bc52e9-450e-4cda-935c-4c2fc9f312e3" />

---
@taoeffect 
regarding the 'show more/less' button design, my initial attempt was to make it as a button on a linear-gradient background, which is similar to the example video you posted [here](https://github.com/okTurtles/group-income/issues/2728#issuecomment-2762200769).
This looked fine for a dark background just like in the video, but could not really find gradient style that looks presentable enough for the light-theme of the app(No matter what I tried, they all looked ugly). So I changed to the current one.
This is the best I could come up with but if you would like another design, maybe we could discuss it with a new designer the company will have. Then I can come back to update this in the future.