### PR TITLE
#2492 - Tooltip issue on iOS-Safari

### DIFF
--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -144,6 +144,19 @@ export default ({
         this.isActive = false
       }
     },
+    isIOSSafari () {
+      const ua = window.navigator.userAgent
+      return /iP(hone|od|ad)/.test(ua) && /Safari/.test(ua)
+    },
+    hideTooltipOnTouchOutside (e) {
+      // NOTE: This is a fix for the iOS-Safari-only issue https://github.com/okTurtles/group-income/issues/2492
+      //       where the tooltip does not close when the user touches outside the tooltip.
+      //       The issue happens because 'blur' event in iOS-Safari does not fire and as a workaround,
+      //       we listen for 'touchstart' event attached to the document.body and manually check if user touches outside the tooltip wrapper.
+      if (this.isActive && !this.triggerDOM.contains(e.target)) {
+        this.hide()
+      }
+    },
     adjustPosition () {
       this.trigger = (this.triggerDOM || this.$el).getBoundingClientRect()
 
@@ -325,6 +338,12 @@ export default ({
     if (this.triggerElementSelector) {
       this.triggerDOM.style.cursor = 'pointer'
       this.triggerDOM.style.position = 'relative'
+
+      if (this.isIOSSafari()) {
+        // This is a fix for the iOS-Safari-only issue https://github.com/okTurtles/group-income/issues/2492
+        // Check hideTooltipOnTouchOutside() method for more details.
+        document.body.addEventListener('touchstart', this.hideTooltipOnTouchOutside)
+      }
     }
   },
   beforeDestory () {
@@ -333,6 +352,10 @@ export default ({
     this.triggerDOM.removeEventListener('mouseleave', this.hide)
     this.triggerDOM.removeEventListener('focus', this.show)
     this.triggerDOM.removeEventListener('blur', this.hide)
+
+    if (this.triggerElementSelector && this.isIOSSafari()) {
+      document.body.removeEventListener('touchstart', this.hideTooltipOnTouchOutside)
+    }
   }
 }: Object)
 </script>

--- a/frontend/views/components/Tooltip.vue
+++ b/frontend/views/components/Tooltip.vue
@@ -346,7 +346,7 @@ export default ({
       }
     }
   },
-  beforeDestory () {
+  beforeDestroy () {
     this.triggerDOM.removeEventListener('click', this.toggle)
     this.triggerDOM.removeEventListener('mouseenter', this.show)
     this.triggerDOM.removeEventListener('mouseleave', this.hide)

--- a/frontend/views/containers/dashboard/GroupMembersActivity.vue
+++ b/frontend/views/containers/dashboard/GroupMembersActivity.vue
@@ -24,7 +24,7 @@
             .c-item-copy
               //- Todo: discuss if tooltip better than toggle
               sentence-with-member-tooltip(:members='onTimePayments' :noEllpsis='true')
-                .member-count-sentence(v-safe-html='memberCountSentences["onTimePayments"]')
+                .member-count-sentence(v-safe-html:button='memberCountSentences["onTimePayments"]')
 
     .c-column
       i18n.is-title-3(tag='h2') Inactivity
@@ -36,28 +36,28 @@
             .icon-user.icon-round.has-background-general
             .c-item-copy
               sentence-with-member-tooltip(:members='haventLoggedIn')
-                .member-count-sentence(v-safe-html='memberCountSentences["haventLoggedIn"]')
+                .member-count-sentence(v-safe-html:button='memberCountSentences["haventLoggedIn"]')
 
         li.c-item-wrapper
           .c-item
             .icon-comment-dollar.icon-round.has-background-general
             .c-item-copy
               sentence-with-member-tooltip(:members='noIncomeDetails')
-                .member-count-sentence(v-safe-html='memberCountSentences["noIncomeDetails"]')
+                .member-count-sentence(v-safe-html:button='memberCountSentences["noIncomeDetails"]')
 
         li.c-item-wrapper
           .c-item
             .icon-dollar-sign.icon-round.has-background-general
             .c-item-copy
               sentence-with-member-tooltip(:members='missedPayments')
-                .member-count-sentence(v-safe-html='memberCountSentences["missedPayments"]')
+                .member-count-sentence(v-safe-html:button='memberCountSentences["missedPayments"]')
 
         li.c-item-wrapper
           .c-item
             .icon-vote-yea.icon-round.has-background-general
             .c-item-copy
               sentence-with-member-tooltip(:members='noVotes')
-                .member-count-sentence(v-safe-html='memberCountSentences["noVotes"]')
+                .member-count-sentence(v-safe-html:button='memberCountSentences["noVotes"]')
 
 </template>
 
@@ -142,8 +142,8 @@ export default ({
     memberCountSentences () {
       const argsCommon = {
         ...this.LTags('strong'),
-        'span_': '<span class="link t-trigger">',
-        '_span': '</span>'
+        'btn_': '<button type="button" class="is-unstyled link t-trigger">',
+        '_btn': '</button>'
       }
       const argsMap = {
         'onTimePayments': { ...argsCommon, membercount: this.onTimePayments.length },
@@ -155,20 +155,20 @@ export default ({
 
       return {
         'onTimePayments': this.onTimePayments.length === 1
-          ? L('{span_}1 member{_span} has {strong_} on-time payment streaks{_strong}', argsMap['onTimePayments'])
-          : L('{span_}{membercount} members{_span} have {strong_} on-time payment streaks{_strong}', argsMap['onTimePayments']),
+          ? L('{btn_}1 member{_btn} has {strong_} on-time payment streaks{_strong}', argsMap['onTimePayments'])
+          : L('{btn_}{membercount} members{_btn} have {strong_} on-time payment streaks{_strong}', argsMap['onTimePayments']),
         'haventLoggedIn': this.haventLoggedIn.length === 1
-          ? L('{span_}1 member{_span} hasn\'t {strong_} logged in past {days} days or more {_strong}', argsMap['haventLoggedIn'])
-          : L('{span_}{membercount} members{_span} haven\'t {strong_} logged in past {days} days or more {_strong}', argsMap['haventLoggedIn']),
+          ? L('{btn_}1 member{_btn} hasn\'t {strong_} logged in past {days} days or more {_strong}', argsMap['haventLoggedIn'])
+          : L('{btn_}{membercount} members{_btn} haven\'t {strong_} logged in past {days} days or more {_strong}', argsMap['haventLoggedIn']),
         'noIncomeDetails': this.noIncomeDetails.length === 1
-          ? L('{span_}1 member{_span} hasn\'t {strong_} entered income details{_strong}', argsMap['noIncomeDetails'])
-          : L('{span_}{membercount} members{_span} haven\'t {strong_} entered income details{_strong}', argsMap['noIncomeDetails']),
+          ? L('{btn_}1 member{_btn} hasn\'t {strong_} entered income details{_strong}', argsMap['noIncomeDetails'])
+          : L('{btn_}{membercount} members{_btn} haven\'t {strong_} entered income details{_strong}', argsMap['noIncomeDetails']),
         'missedPayments': this.missedPayments.length === 1
-          ? L('{span_}1 member{_span} has {strong_} missed payments {_strong}', argsMap['missedPayments'])
-          : L('{span_}{membercount} members{_span} have {strong_} missed payments {_strong}', argsMap['missedPayments']),
+          ? L('{btn_}1 member{_btn} has {strong_} missed payments {_strong}', argsMap['missedPayments'])
+          : L('{btn_}{membercount} members{_btn} have {strong_} missed payments {_strong}', argsMap['missedPayments']),
         'noVotes': this.noVotes.length === 1
-          ? L('{span_}1 member{_span} hasn\'t {strong_} voted in the last {proposalcount} proposals {_strong}', argsMap['noVotes'])
-          : L('{span_}{membercount} members{_span} haven\'t {strong_} voted in the last {proposalcount} proposals {_strong}', argsMap['noVotes'])
+          ? L('{btn_}1 member{_btn} hasn\'t {strong_} voted in the last {proposalcount} proposals {_strong}', argsMap['noVotes'])
+          : L('{btn_}{membercount} members{_btn} haven\'t {strong_} voted in the last {proposalcount} proposals {_strong}', argsMap['noVotes'])
       }
     }
   }

--- a/frontend/views/containers/loading-error/ErrorPage.vue
+++ b/frontend/views/containers/loading-error/ErrorPage.vue
@@ -52,7 +52,7 @@ export default ({
     window.addEventListener('online', this.onlineHandler)
     window.addEventListener('offline', this.offlineHandler)
   },
-  beforeDestory () {
+  beforeDestroy () {
     window.removeEventListener('online', this.onlineHandler)
     window.removeEventListener('offline', this.offlineHandler)
   }

--- a/frontend/views/utils/vSafeHtml.js
+++ b/frontend/views/utils/vSafeHtml.js
@@ -31,11 +31,17 @@ export const defaultConfig = {
 const transform = (el, binding) => {
   if (binding.oldValue !== binding.value) {
     let config = defaultConfig
-    if (binding.arg === 'a') {
-      config = cloneDeep(config)
-      config.ALLOWED_ATTR.push('href', 'target')
-      config.ALLOWED_TAGS.push('a')
+    const tagAllowedAttrs = {
+      'a': ['href', 'target'],
+      'button': ['type']
     }
+
+    if (Object.keys(tagAllowedAttrs).includes(binding.arg)) {
+      config = cloneDeep(config)
+      config.ALLOWED_TAGS.push(binding.arg)
+      config.ALLOWED_ATTR.push(...(tagAllowedAttrs[binding.arg] || []))
+    }
+
     el.textContent = ''
     el.appendChild(dompurify.sanitize(binding.value, config))
   }


### PR DESCRIPTION
closes #2492 

**[ video recording for bug-fix ]**

https://github.com/user-attachments/assets/54f8c25d-df93-48a0-b2f4-f977a5436b5d

The issue happens because `blur` event does not fire on iOS Safari when user touches outside a target element. I've tried various other events suggested on the internet(eg. `mouseout`, `focusout` etc..) but nothing worked. So had to implement a workaround logic that uses `touchstart` event attached to `document.body` (details are commented inline). 