### PR TITLE
#2712 - Implement 'mark message as unread' feature in the chatroom

### DIFF
--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -124,17 +124,20 @@ export default (sbp('sbp/selectors/register', {
     return sbp('okTurtles.eventQueue/queueEvent', KV_QUEUE, async () => {
       const getUpdatedUnreadMessages = async () => {
         const currentData = await sbp('gi.actions/identity/kv/fetchChatRoomUnreadMessages')
-        const existingMessageHash = currentData[contractID]?.readUntil?.messageHash
+        const existingReadUntil = currentData[contractID]?.readUntil
 
-        if (existingMessageHash !== messageHash) {
-          return {
-            ...currentData,
-            [contractID]: {
-              readUntil: { messageHash, createdHeight, isManuallyMarked: true },
-              unreadMessages
-            }
+        // If the requested mark-unread hash has already been set, ignore it.
+        if (existingReadUntil &&
+          existingReadUntil.isManuallyMarked &&
+          existingReadUntil?.messageHash === messageHash) { return null }
+
+        return {
+          ...currentData,
+          [contractID]: {
+            readUntil: { messageHash, createdHeight, isManuallyMarked: true },
+            unreadMessages
           }
-        } else { return null }
+        }
       }
 
       const data = await getUpdatedUnreadMessages()

--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -124,13 +124,17 @@ export default (sbp('sbp/selectors/register', {
     return sbp('okTurtles.eventQueue/queueEvent', KV_QUEUE, async () => {
       const getUpdatedUnreadMessages = async () => {
         const currentData = await sbp('gi.actions/identity/kv/fetchChatRoomUnreadMessages')
+        const existingMessageHash = currentData[contractID]?.readUntil?.messageHash
 
-        return {
-          ...currentData,
-          [contractID]: {
-            readUntil: { messageHash, createdHeight }, unreadMessages
+        if (existingMessageHash !== messageHash) {
+          return {
+            ...currentData,
+            [contractID]: {
+              readUntil: { messageHash, createdHeight },
+              unreadMessages
+            }
           }
-        }
+        } else { return null }
       }
 
       const data = await getUpdatedUnreadMessages()

--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -130,7 +130,7 @@ export default (sbp('sbp/selectors/register', {
           return {
             ...currentData,
             [contractID]: {
-              readUntil: { messageHash, createdHeight },
+              readUntil: { messageHash, createdHeight, isManuallyMarked: true },
               unreadMessages
             }
           }
@@ -173,7 +173,7 @@ export default (sbp('sbp/selectors/register', {
       const getUpdatedUnreadMessages = async () => {
         const currentData = await sbp('gi.actions/identity/kv/fetchChatRoomUnreadMessages')
 
-        const index = currentData[contractID]?.unreadMessages.findIndex(msg => msg.messageHash === messageHash)
+        const index = currentData[contractID]?.unreadMessages?.findIndex(msg => msg.messageHash === messageHash)
         // NOTE: index could be undefined if unreadMessages is not initialized
         if (Number.isInteger(index) && index >= 0) {
           currentData[contractID].unreadMessages.splice(index, 1)

--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -82,14 +82,17 @@ export default (sbp('sbp/selectors/register', {
       }
     })
   },
-  'gi.actions/identity/kv/setChatRoomReadUntil': ({ contractID, messageHash, createdHeight }: {
-    contractID: string, messageHash: string, createdHeight: number
+  'gi.actions/identity/kv/setChatRoomReadUntil': ({ contractID, messageHash, createdHeight, forceUpdate = false }: {
+    contractID: string,
+    messageHash: string,
+    createdHeight: number,
+    forceUpdate: boolean // In a rare case, the 'readUntil' value needs to be set to the msg with lower 'createdHeight'. (reference: https://github.com/okTurtles/group-income/issues/2729)
   }) => {
     return sbp('okTurtles.eventQueue/queueEvent', KV_QUEUE, async () => {
       const getUpdatedUnreadMessages = async () => {
         const currentData = await sbp('gi.actions/identity/kv/fetchChatRoomUnreadMessages')
 
-        if (currentData[contractID]?.readUntil.createdHeight < createdHeight) {
+        if (forceUpdate || currentData[contractID]?.readUntil.createdHeight < createdHeight) {
           const { unreadMessages } = currentData[contractID]
           return {
             ...currentData,

--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -86,7 +86,7 @@ export default (sbp('sbp/selectors/register', {
     contractID: string,
     messageHash: string,
     createdHeight: number,
-    // In a rare case, such as when the latest message is deleted,
+    // In some cases, such as when the latest message is deleted or the user uses the 'mark-unread' feature,
     // the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
     // 'forceUpdate' flag is used to override the 'createdHeight' check below to allow this kind of update.
     // (reference: https://github.com/okTurtles/group-income/issues/2729)

--- a/frontend/controller/actions/identity-kv.js
+++ b/frontend/controller/actions/identity-kv.js
@@ -86,7 +86,11 @@ export default (sbp('sbp/selectors/register', {
     contractID: string,
     messageHash: string,
     createdHeight: number,
-    forceUpdate: boolean // In a rare case, the 'readUntil' value needs to be set to the msg with lower 'createdHeight'. (reference: https://github.com/okTurtles/group-income/issues/2729)
+    // In a rare case, such as when the latest message is deleted,
+    // the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
+    // 'forceUpdate' flag is used to override the 'createdHeight' check below to allow this kind of update.
+    // (reference: https://github.com/okTurtles/group-income/issues/2729)
+    forceUpdate: boolean
   }) => {
     return sbp('okTurtles.eventQueue/queueEvent', KV_QUEUE, async () => {
       const getUpdatedUnreadMessages = async () => {

--- a/frontend/model/chatroom/getters.js
+++ b/frontend/model/chatroom/getters.js
@@ -142,6 +142,11 @@ const getters: { [x: string]: (state: Object, getters: { [x: string]: any }, roo
       return getters.ourUnreadMessages[chatRoomID]?.unreadMessages || []
     }
   },
+  isChatRoomManuallyMarkedUnread (state, getters) {
+    return (chatroomID: string) => {
+      return Boolean(getters.ourUnreadMessages[chatroomID || getters.currentChatRoomId]?.readUntil?.isManuallyMarked)
+    }
+  },
   groupUnreadMessages (state, getters, rootState) {
     return (groupID: string) => {
       const isGroupDirectMessage = cID => Object.keys(getters.directMessagesByGroup(groupID)).includes(cID)

--- a/frontend/model/chatroom/vuexModule.js
+++ b/frontend/model/chatroom/vuexModule.js
@@ -10,10 +10,9 @@ const defaultState = {
   pendingChatRoomIDs: {}, // { [groupId]: currentChatRoomId }
   chatRoomScrollPosition: {}, // [chatRoomID]: messageHash
   unreadMessages: null, // [chatRoomID]: { readUntil: { messageHash, createdHeight }, unreadMessages: [{ messageHash, createdHeight }]}
+  unreadMessagesMarkedByUser: null, // [chatRoomID]: { readUntil: { messageHash, createdHeight }, unreadMessages: [{ messageHash, createdHeight }]}
   chatNotificationSettings: {} // { [chatRoomID]: { messageNotification: MESSAGE_NOTIFY_SETTINGS, messageSound: MESSAGE_NOTIFY_SETTINGS } }
 }
-
-// getters
 
 // mutations
 const mutations = {

--- a/frontend/model/chatroom/vuexModule.js
+++ b/frontend/model/chatroom/vuexModule.js
@@ -9,8 +9,7 @@ const defaultState = {
   currentChatRoomIDs: {}, // { [groupId]: currentChatRoomId }
   pendingChatRoomIDs: {}, // { [groupId]: currentChatRoomId }
   chatRoomScrollPosition: {}, // [chatRoomID]: messageHash
-  unreadMessages: null, // [chatRoomID]: { readUntil: { messageHash, createdHeight }, unreadMessages: [{ messageHash, createdHeight }]}
-  unreadMessagesMarkedByUser: null, // [chatRoomID]: { readUntil: { messageHash, createdHeight }, unreadMessages: [{ messageHash, createdHeight }]}
+  unreadMessages: null, // [chatRoomID]: { readUntil: { messageHash, createdHeight, isManuallyMarked?: boolean }, unreadMessages: [{ messageHash, createdHeight }]}
   chatNotificationSettings: {} // { [chatRoomID]: { messageNotification: MESSAGE_NOTIFY_SETTINGS, messageSound: MESSAGE_NOTIFY_SETTINGS } }
 }
 

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -981,7 +981,7 @@ export default ({
         if (!forceUpdate && this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
           // NOTE: skip adding useless invocations in KV_QUEUE queue.
           //       'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
-          //       (reference: https://github.com/okTurtles/group-income/issues/2729)
+          //       eg. when the latest message is deleted. (reference: https://github.com/okTurtles/group-income/issues/2729)
           return
         }
 

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -155,7 +155,7 @@ import { proximityDate, MINS_MILLIS } from '@model/contracts/shared/time.js'
 import { cloneDeep, debounce, throttle, delay } from 'turtledash'
 import { EVENT_HANDLED } from '~/shared/domains/chelonia/events.js'
 import { compressImage } from '@utils/image.js'
-import { swapMentionIDForDisplayname } from '@model/chatroom/utils.js'
+import { swapMentionIDForDisplayname, makeMentionFromUserID } from '@model/chatroom/utils.js'
 
 const ignorableScrollDistanceInPixel = 500
 
@@ -1003,6 +1003,27 @@ export default ({
       const isFirstMessage = index === 0
       const targetMsg = isFirstMessage ? this.messages[index] : this.messages[index - 1]
 
+      const getUpdatedUnreadMessages = () => {
+        // This method filters the messages to store in 'unreadMessages' property (eg. messages that mentions me or contains '@all'),
+        // which are reflected as the unread-count badge in the UI.
+        const isInDM = this.isGroupDirectMessage(this.ephemeral.renderingChatRoomId)
+        const mentions = makeMentionFromUserID(this.ourIdentityContractId)
+        const messageMentionsMe = msg => {
+          return msg.type === MESSAGE_TYPES.TEXT &&
+            msg.text &&
+            (msg.text.includes(mentions.me) || msg.text.includes(mentions.all))
+        }
+
+        return this.messages.slice(index)
+          .filter(msg => {
+            if (this.isMsgSender(msg.from)) { return false }
+
+            return isInDM ||
+              [MESSAGE_TYPES.INTERACTIVE, MESSAGE_TYPES.POLL].includes(msg.type) ||
+              messageMentionsMe(msg)
+          }).map(msg => ({ messageHash: msg.hash, createdHeight: msg.height }))
+      }
+
       try {
         this.ephemeral.messageHashToMarkUnread = targetMsg.hash
         await sbp('gi.actions/identity/kv/markAsUnread', {
@@ -1014,8 +1035,7 @@ export default ({
           //       we need to manually specify the decremented 'createdHeight' value here, so that [1] above does not break in the UI.
           createdHeight: isFirstMessage ? createdHeight - 1 : targetMsg.height,
           // When marked as unread, all the messages after the target message are stored in 'unreadMessages' property.
-          unreadMessages: this.messages.slice(index)
-            .map(msg => ({ messageHash: msg.hash, createdHeight: msg.height }))
+          unreadMessages: getUpdatedUnreadMessages()
         })
       } catch (e) {
         console.error('[ChatMain.vue] Error while marking message unread', e)
@@ -1138,6 +1158,17 @@ export default ({
                 }
               }
             }
+          }
+
+          if (addedOrDeleted !== 'NONE' && this.ephemeral.messageHashToMarkUnread) {
+            // If user has used 'Mark unread' but then messages are either added or deleted,
+            // 'unreadMessages' data in the store should be updated accordingly.
+            const action = addedOrDeleted === 'ADDED' ? 'addChatRoomUnreadMessage' : 'removeChatRoomUnreadMessage'
+            sbp(`gi.actions/identity/kv/${action}`, {
+              contractID: this.ephemeral.renderingChatRoomId,
+              messageHash: value.data.hash,
+              createdHeight: value.data.height
+            })
           }
         })
       })

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -1001,8 +1001,11 @@ export default ({
 
       try {
         this.ephemeral.messageHashToMarkUnread = messageHash
-        await sbp('gi.actions/identity/kv/setChatRoomReadUntil', {
-          contractID: chatRoomID, messageHash, createdHeight, forceUpdate: true
+        await sbp('gi.actions/identity/kv/markAsUnread', {
+          contractID: chatRoomID,
+          messageHash,
+          createdHeight,
+          unreadMessages: [] // TODO: implement here!
         })
       } catch (e) {
         console.error('[ChatMain.vue] Error while marking message unread', e)

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -979,9 +979,9 @@ export default ({
       const chatRoomID = this.ephemeral.renderingChatRoomId
       if (chatRoomID && this.isJoinedChatRoom(chatRoomID)) {
         if (!forceUpdate && this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
-          // NOTE: skip adding useless invocations in KV_QUEUE queue.
-          //       'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
-          //       eg. when the latest message is deleted. (reference: https://github.com/okTurtles/group-income/issues/2729)
+          // NOTE-1: skip adding useless invocations in KV_QUEUE queue.
+          // NOTE-2: 'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
+          //         eg. when the latest message is deleted. (reference: https://github.com/okTurtles/group-income/issues/2729)
           return
         }
 

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -691,8 +691,14 @@ export default ({
       }
     },
     async deleteMessage (message) {
+      const msgHash = message.hash
       const contractID = this.ephemeral.renderingChatRoomId
       const manifestCids = (message.attachments || []).map(attachment => attachment.downloadData.manifestCid)
+
+      const lastMsg = this.messages[this.messages.length - 1]
+      const secondLastMsg = this.messages[this.messages.length - 2]
+      const isDeletingLastMsg = msgHash === lastMsg?.hash
+
       const question = message.attachments?.length
         ? L('Are you sure you want to delete this message and it\'s file attachments permanently?')
         : L('Are you sure you want to delete this message permanently?')
@@ -704,13 +710,33 @@ export default ({
         secondaryButton: L('Cancel')
       }
 
-      const primaryButtonSelected = await sbp('gi.ui/prompt', promptConfig)
-      if (primaryButtonSelected) {
-        sbp('gi.actions/chatroom/deleteMessage', {
-          contractID,
-          data: { hash: message.hash, manifestCids, messageSender: message.from }
-        }).catch((e) => {
-          console.error(`Error while deleting message(${message.hash}) for chatroom(${contractID})`, e)
+      try {
+        const primaryButtonSelected = await sbp('gi.ui/prompt', promptConfig)
+        if (primaryButtonSelected) {
+          await sbp('gi.actions/chatroom/deleteMessage', {
+            contractID,
+            data: { hash: msgHash, manifestCids, messageSender: message.from }
+          })
+
+          // If the deleted message is the most recent message and 'currentChatRoomReadUntil' is pointing to the deleted one,
+          // it needs to be updated to the second most recent one.
+          if (isDeletingLastMsg &&
+            this.currentChatRoomReadUntil?.messageHash === msgHash &&
+            secondLastMsg) {
+            this.updateReadUntilMessageHash({
+              messageHash: secondLastMsg.hash,
+              createdHeight: secondLastMsg.height,
+              forceUpdate: true
+            })
+          }
+        }
+      } catch (e) {
+        console.error(`Error while deleting message(${msgHash}) for chatroom(${contractID})`, e)
+
+        sbp('gi.ui/prompt', {
+          heading: L('Error while deleting a message'),
+          question: L('Error details: {reportError}', LError(e)),
+          primaryButton: L('Close')
         })
       }
     },
@@ -939,15 +965,18 @@ export default ({
         }
       }
     },
-    updateReadUntilMessageHash ({ messageHash, createdHeight }) {
+    updateReadUntilMessageHash ({ messageHash, createdHeight, forceUpdate = false }) {
       const chatRoomID = this.ephemeral.renderingChatRoomId
       if (chatRoomID && this.isJoinedChatRoom(chatRoomID)) {
-        if (this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
-          // NOTE: skip adding useless invocations in KV_QUEUE queue
+        if (!forceUpdate && this.currentChatRoomReadUntil?.createdHeight >= createdHeight) {
+          // NOTE: skip adding useless invocations in KV_QUEUE queue.
+          //       'forceUpdate' flag here is for the rare case where the 'readUntil' value needs to be set to the msg with lower 'createdHeight'.
+          //       (reference: https://github.com/okTurtles/group-income/issues/2729)
           return
         }
+
         sbp('gi.actions/identity/kv/setChatRoomReadUntil', {
-          contractID: chatRoomID, messageHash, createdHeight
+          contractID: chatRoomID, messageHash, createdHeight, forceUpdate
         }).catch(e => {
           console.error('[ChatMain.vue] Error setting read until', e)
         })

--- a/frontend/views/containers/chatroom/ChatMembers.vue
+++ b/frontend/views/containers/chatroom/ChatMembers.vue
@@ -22,7 +22,10 @@
       .profile-wrapper(v-if='isDMToMyself')
         profile-card(:contractID='ourIdentityContractId' deactivated)
           avatar-user(:contractID='ourIdentityContractId' :picture='picture' size='sm' data-test='openMemberProfileCard')
-          span.is-unstyled.c-name.has-ellipsis(:data-test='title')
+          span.is-unstyled.c-name.has-ellipsis(
+            :class='{ "has-text-bold": shouldStyleBold(chatRoomID) }'
+            :data-test='title'
+          )
             span {{ title }}
             i18n.c-you (you)
 
@@ -30,18 +33,24 @@
         .profile-wrapper(v-if='partners.length === 1')
           profile-card(:contractID='partners[0].contractID' deactivated)
             avatar-user(:contractID='partners[0].contractID' :picture='picture' size='sm' data-test='openMemberProfileCard')
-            span.is-unstyled.c-name.has-ellipsis(:data-test='partners[0].username') {{ title }}
+            span.is-unstyled.c-name.has-ellipsis(
+              :class='{ "has-text-bold": shouldStyleBold(chatRoomID) }'
+              :data-test='partners[0].username'
+            ) {{ title }}
 
         .group-wrapper(v-else)
           .picture-wrapper
             avatar(:src='picture' :alt='title' size='xs')
             .c-badge {{ partners.length }}
-          span.is-unstyled.c-name.has-ellipsis(:data-test='title') {{ title }}
+          span.is-unstyled.c-name.has-ellipsis(
+            :data-test='title'
+            :class='{ "has-text-bold": shouldStyleBold(chatRoomID) }'
+          ) {{ title }}
 
       .c-unreadcount-wrapper
         .pill.is-danger(
           v-if='getUnreadMsgCount(chatRoomID)'
-        ) {{limitedUnreadCount(getUnreadMsgCount(chatRoomID))}}
+        ) {{ limitedUnreadCount(getUnreadMsgCount(chatRoomID)) }}
 </template>
 
 <script>
@@ -80,7 +89,8 @@ export default ({
       'groupShouldPropose',
       'ourGroupDirectMessages',
       'ourIdentityContractId',
-      'chatRoomUnreadMessages'
+      'chatRoomUnreadMessages',
+      'isChatRoomManuallyMarkedUnread'
     ])
   },
   methods: {
@@ -106,6 +116,10 @@ export default ({
     },
     getUnreadMsgCount (chatRoomID) {
       return this.chatRoomUnreadMessages(chatRoomID).length
+    },
+    shouldStyleBold (chatRoomID) {
+      return this.isChatRoomManuallyMarkedUnread(chatRoomID) ||
+        this.getUnreadMsgCount(chatRoomID) > 0
     },
     limitedUnreadCount (n) {
       const nLimit = 99
@@ -156,7 +170,6 @@ export default ({
   display: inline-block;
   margin-left: 0.25rem;
   font-size: 0.875em;
-  font-weight: normal;
 }
 
 .c-menu {

--- a/frontend/views/containers/chatroom/ConversationsList.vue
+++ b/frontend/views/containers/chatroom/ConversationsList.vue
@@ -27,7 +27,9 @@
         size='sm'
       )
 
-      span.c-channel-name {{list.channels[id].displayName || list.channels[id].name}}
+      span.c-channel-name(
+        :class='{ "has-text-bold": list.channels[id].unreadMessagesCount > 0 }'
+      ) {{list.channels[id].displayName || list.channels[id].name}}
 
       .c-unreadcount-wrapper
         .pill.is-danger(

--- a/frontend/views/containers/chatroom/ConversationsList.vue
+++ b/frontend/views/containers/chatroom/ConversationsList.vue
@@ -28,17 +28,18 @@
       )
 
       span.c-channel-name(
-        :class='{ "has-text-bold": list.channels[id].unreadMessagesCount > 0 }'
+        :class='{ "has-text-bold": shouldStyleBold(id) }'
       ) {{list.channels[id].displayName || list.channels[id].name}}
 
       .c-unreadcount-wrapper
         .pill.is-danger(
-          v-if='list.channels[id].unreadMessagesCount'
-        ) {{limitedUnreadCount(list.channels[id].unreadMessagesCount)}}
+          v-if='list.channels[id].unreadMessagesCount > 0'
+        ) {{ limitedUnreadCount(list.channels[id].unreadMessagesCount) }}
 </template>
 
 <script>
 import sbp from '@sbp/sbp'
+import { mapGetters } from 'vuex'
 import { OPEN_MODAL } from '@utils/events.js'
 import ListItem from '@components/ListItem.vue'
 import Avatar from '@components/Avatar.vue'
@@ -63,6 +64,9 @@ export default ({
     */
     list: Object,
     routeName: String
+  },
+  computed: {
+    ...mapGetters(['isChatRoomManuallyMarkedUnread'])
   },
   methods: {
     onClickedNewChannel () {
@@ -102,6 +106,10 @@ export default ({
       } else {
         return `${n}`
       }
+    },
+    shouldStyleBold (chatRoomID) {
+      return this.isChatRoomManuallyMarkedUnread(chatRoomID) ||
+        this.list.channels[chatRoomID].unreadMessagesCount > 0
     }
   }
 }: Object)

--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -135,7 +135,7 @@ export default ({
         conditionToShow: !this.isDesktopScreen
       }, {
         name: L('Mark unread'),
-        action: 'markUnread',
+        action: 'markAsUnread',
         icon: 'envelope',
         conditionToShow: true
       }, {

--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -137,7 +137,7 @@ export default ({
         name: L('Mark unread'),
         action: 'markAsUnread',
         icon: 'envelope',
-        conditionToShow: true
+        conditionToShow: !this.isMsgSender
       }, {
         name: L('Edit'),
         action: 'editMessage',

--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -10,7 +10,7 @@ menu-parent.c-message-menu(ref='menu')
         @click.stop='action("openEmoticon", $event)'
       )
         i.icon-smile-beam
-  
+
     tooltip(
       v-if='isEditable'
       direction='top'
@@ -303,7 +303,7 @@ export default ({
   }
 
   .c-menuItem ::v-deep .c-item-link {
-    @extend %floating-panel-item;
+    height: 2.31rem;
   }
 }
 

--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -137,7 +137,7 @@ export default ({
         name: L('Mark unread'),
         action: 'markAsUnread',
         icon: 'envelope',
-        conditionToShow: !this.isMsgSender
+        conditionToShow: true
       }, {
         name: L('Edit'),
         action: 'editMessage',

--- a/frontend/views/containers/chatroom/MessageActions.vue
+++ b/frontend/views/containers/chatroom/MessageActions.vue
@@ -10,7 +10,7 @@ menu-parent.c-message-menu(ref='menu')
         @click.stop='action("openEmoticon", $event)'
       )
         i.icon-smile-beam
-
+  
     tooltip(
       v-if='isEditable'
       direction='top'
@@ -133,6 +133,11 @@ export default ({
         action: 'openEmoticon',
         icon: 'smile-beam',
         conditionToShow: !this.isDesktopScreen
+      }, {
+        name: L('Mark unread'),
+        action: 'markUnread',
+        icon: 'envelope',
+        conditionToShow: true
       }, {
         name: L('Edit'),
         action: 'editMessage',

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -103,7 +103,7 @@
     @retry='$emit("retry")'
     @pinToChannel='$emit("pin-to-channel")'
     @unpinFromChannel='$emit("unpin-from-channel")'
-    @markUnread='markUnread'
+    @markAsUnread='markAsUnread'
   )
 
   .c-truncate-toggle-container(
@@ -341,7 +341,7 @@ export default ({
         this.$el.scrollIntoView({ behavior: 'instant' })
       }
     },
-    markUnread () {
+    markAsUnread () {
       this.chatMainUtils.markAsUnread({
         messageHash: this.messageHash,
         createdHeight: this.height

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -103,6 +103,7 @@
     @retry='$emit("retry")'
     @pinToChannel='$emit("pin-to-channel")'
     @unpinFromChannel='$emit("unpin-from-channel")'
+    @markUnread='markUnread'
   )
 
   .c-truncate-toggle-container(
@@ -145,7 +146,10 @@ import { getFileType } from '@view-utils/filters.js'
 export default ({
   name: 'MessageBase',
   mixins: [emoticonsMixins],
-  inject: ['chatMainConfig'],
+  inject: [
+    'chatMainConfig',
+    'chatMainUtils'
+  ],
   components: {
     Avatar,
     ProfileCard,
@@ -336,6 +340,12 @@ export default ({
         // When folding the expanded message, scroll to the message so that it stays in the screen.
         this.$el.scrollIntoView({ behavior: 'instant' })
       }
+    },
+    markUnread () {
+      this.chatMainUtils.markAsUnread({
+        messageHash: this.messageHash,
+        createdHeight: this.height
+      })
     }
   },
   watch: {


### PR DESCRIPTION
closes #2712 

**[Video demo for the feature]**
As you can see, once 'mark unread' operation is processed, it is immediately reflected in the UI(eg. 'is-new' blue divider and also notification badge **if** there are any message where the user is mentioned). This state does not disappear until the user leaves and re-enters the chatroom. Hope it sounds good.

https://github.com/user-attachments/assets/7d785a4d-a344-4894-9e7d-71650de26632

Please let me know if we would love to change the icon to something else BTW:

<img src='https://github.com/user-attachments/assets/b166914e-98d3-44eb-8b70-f860f7f47627' width='280'>

