### PR TITLE
fetch Chelonia option

### DIFF
--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -1254,7 +1254,7 @@ export default (sbp('sbp/selectors/register', {
       throw new TypeError('A contract ID must be provided')
     }
 
-    const response = await fetch(`${this.config.connectionURL}/ownResources`, {
+    const response = await this.config.fetch(`${this.config.connectionURL}/ownResources`, {
       method: 'GET',
       signal: this.abortController.signal,
       headers: new Headers([
@@ -1289,7 +1289,7 @@ export default (sbp('sbp/selectors/register', {
         throw new TypeError(`Either a token or a billable contract ID must be provided for ${cid}`)
       }
 
-      const response = await fetch(`${this.config.connectionURL}/deleteContract/${cid}`, {
+      const response = await this.config.fetch(`${this.config.connectionURL}/deleteContract/${cid}`, {
         method: 'POST',
         signal: this.abortController.signal,
         headers: new Headers([

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -5,6 +5,7 @@ import '@sbp/okturtles.events'
 import sbp from '@sbp/sbp'
 import { handleFetchResult } from '~/frontend/controller/utils/misc.js'
 import { cloneDeep, delay, difference, has, intersection, merge, randomHexString, randomIntFromRange } from 'turtledash'
+import { createCID, parseCID } from '~/shared/functions.js'
 import { NOTIFICATION_TYPE, createClient } from '~/shared/pubsub.js'
 import type { SPKey, SPOpActionUnencrypted, SPOpContract, SPOpKeyAdd, SPOpKeyDel, SPOpKeyRequest, SPOpKeyRequestSeen, SPOpKeyShare, SPOpKeyUpdate } from './SPMessage.js'
 import type { Key } from '@chelonia/crypto'
@@ -210,6 +211,7 @@ export default (sbp('sbp/selectors/register', {
       },
       whitelisted: (action: string): boolean => !!this.whitelistedActions[action],
       reactiveSet: (obj, key, value) => { obj[key] = value; return value }, // example: set to Vue.set
+      fetch: (...args) => fetch(...args),
       reactiveDel: (obj, key) => { delete obj[key] },
       // acceptAllMessages disables checking whether we are expecting a message
       // or not for processing
@@ -317,6 +319,7 @@ export default (sbp('sbp/selectors/register', {
   'chelonia/config': function () {
     return {
       ...cloneDeep(this.config),
+      fetch: this.config.fetch,
       reactiveSet: this.config.reactiveSet,
       reactiveDel: this.config.reactiveDel
     }
@@ -801,7 +804,7 @@ export default (sbp('sbp/selectors/register', {
     //
     //        // The following could take a long time. We want Chelonia
     //        // to still work and process events as normal.
-    //        return fetch(profilePictureUrl).then(doSomeWorkWithTheFile)
+    //        return this.config.fetch(profilePictureUrl).then(doSomeWorkWithTheFile)
     //      })
     //    }
     return sbp('chelonia/private/queueEvent', contractID, ['chelonia/private/noop']).then(() => sbp('chelonia/private/queueEvent', 'public:' + contractID, sbpInvocation))
@@ -1066,8 +1069,26 @@ export default (sbp('sbp/selectors/register', {
       return state
     })
   },
+  'chelonia/out/entry': async function (cid: string, { code }: { code?: number } = {}) {
+    const parsedCID = parseCID(cid)
+    if (Number.isInteger(code)) {
+      if (parsedCID.code !== code) {
+        throw new Error('Invalid CID content type')
+      }
+    }
+    const local = await sbp('chelonia.db/get', cid)
+    if (local) return local
+    const url = `${this.config.connectionURL}/file/${cid}`
+    const data = await this.config.fetch(url, { signal: this.abortController.signal }).then(handleFetchResult('text'))
+    const ourHash = createCID(data, parsedCID.code)
+    if (ourHash !== cid) {
+      throw new Error(`expected hash ${cid}. Got: ${ourHash}`)
+    }
+    await sbp('chelonia.db/set', cid, data)
+    return data
+  },
   'chelonia/out/latestHEADInfo': function (contractID: string) {
-    return fetch(`${this.config.connectionURL}/latestHEADinfo/${contractID}`, {
+    return this.config.fetch(`${this.config.connectionURL}/latestHEADinfo/${contractID}`, {
       cache: 'no-store',
       signal: this.abortController.signal
     }).then(handleFetchResult('json'))
@@ -1089,7 +1110,7 @@ export default (sbp('sbp/selectors/register', {
     let reader: ReadableStreamReader
     const s = new ReadableStream({
       start: async (controller) => {
-        const first = await fetch(`${this.config.connectionURL}/file/${startHash}`, { signal: this.abortController.signal }).then(handleFetchResult('text'))
+        const first = await this.config.fetch(`${this.config.connectionURL}/file/${startHash}`, { signal: this.abortController.signal }).then(handleFetchResult('text'))
         const deserializedHEAD = SPMessage.deserializeHEAD(first)
         if (deserializedHEAD.contractID !== contractID) {
           controller.error(new Error('chelonia/out/eventsBetween: Mismatched contract ID'))
@@ -1642,7 +1663,7 @@ export default (sbp('sbp/selectors/register', {
         data,
         meta: key
       })
-      const response = await fetch(`${this.config.connectionURL}/kv/${encodeURIComponent(contractID)}/${encodeURIComponent(key)}`, {
+      const response = await this.config.fetch(`${this.config.connectionURL}/kv/${encodeURIComponent(contractID)}/${encodeURIComponent(key)}`, {
         headers: new Headers([[
           'authorization', buildShelterAuthorizationHeader.call(this, contractID)
         ]]),
@@ -1668,7 +1689,7 @@ export default (sbp('sbp/selectors/register', {
     }
   },
   'chelonia/kv/get': async function (contractID: string, key: string) {
-    const response = await fetch(`${this.config.connectionURL}/kv/${encodeURIComponent(contractID)}/${encodeURIComponent(key)}`, {
+    const response = await this.config.fetch(`${this.config.connectionURL}/kv/${encodeURIComponent(contractID)}/${encodeURIComponent(key)}`, {
       headers: new Headers([[
         'authorization', buildShelterAuthorizationHeader.call(this, contractID)
       ]]),

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -1069,15 +1069,18 @@ export default (sbp('sbp/selectors/register', {
       return state
     })
   },
-  'chelonia/out/entry': async function (cid: string, { code }: { code?: number } = {}) {
+  'chelonia/out/fetchResource': async function (cid: string, { code }: { code?: number } = {}) {
     const parsedCID = parseCID(cid)
-    if (Number.isInteger(code)) {
+    if (code != null) {
       if (parsedCID.code !== code) {
-        throw new Error('Invalid CID content type')
+        throw new Error(`Invalid CID content type. Expected ${code}, got ${parsedCID.code}`)
       }
     }
+    // Note that chelonia.db/get (set) is a no-op for lightweight clients
+    // This was added for consistency (processing an event also adds it to the DB)
     const local = await sbp('chelonia.db/get', cid)
-    if (local) return local
+    // We don't verify the CID because it's already been verified when it was set
+    if (local != null) return local
     const url = `${this.config.connectionURL}/file/${cid}`
     const data = await this.config.fetch(url, { signal: this.abortController.signal }).then(handleFetchResult('text'))
     const ourHash = createCID(data, parsedCID.code)

--- a/shared/domains/chelonia/internals.js
+++ b/shared/domains/chelonia/internals.js
@@ -251,7 +251,7 @@ export default (sbp('sbp/selectors/register', {
       console.warn('[chelonia]: already loaded manifest', manifestHash)
       return
     }
-    const manifestSource = await sbp('chelonia/out/entry', manifestHash, { code: multicodes.SHELTER_CONTRACT_MANIFEST })
+    const manifestSource = await sbp('chelonia/out/fetchResource', manifestHash, { code: multicodes.SHELTER_CONTRACT_MANIFEST })
     const manifest = JSON.parse(manifestSource)
     const body = sbp('chelonia/private/verifyManifestSignature', contractName, manifestHash, manifest)
     if (body.name !== contractName) {
@@ -259,7 +259,7 @@ export default (sbp('sbp/selectors/register', {
     }
     const contractInfo = (this.config.contracts.defaults.preferSlim && body.contractSlim) || body.contract
     console.info(`[chelonia] loading contract '${contractInfo.file}'@'${body.version}' from manifest: ${manifestHash}`)
-    const source = await sbp('chelonia/out/entry', contractInfo.hash, { code: multicodes.SHELTER_CONTRACT_TEXT })
+    const source = await sbp('chelonia/out/fetchResource', contractInfo.hash, { code: multicodes.SHELTER_CONTRACT_TEXT })
     function reduceAllow (acc, v) { acc[v] = true; return acc }
     const allowedSels = ['okTurtles.events/on', 'chelonia/defineContract', 'chelonia/out/keyRequest']
       .concat(this.config.contracts.defaults.allowedSelectors)

--- a/shared/domains/chelonia/internals.js
+++ b/shared/domains/chelonia/internals.js
@@ -2,7 +2,7 @@
 
 import sbp, { domainFromSelector } from '@sbp/sbp'
 import { handleFetchResult } from '~/frontend/controller/utils/misc.js'
-import { createCID, multicodes } from '~/shared/functions.js'
+import { multicodes } from '~/shared/functions.js'
 import { cloneDeep, debounce, delay, has, pick, randomIntFromRange } from 'turtledash'
 import type { SPKey, SPOpActionEncrypted, SPOpActionUnencrypted, SPOpAtomic, SPOpContract, SPOpKeyAdd, SPOpKeyDel, SPOpKeyRequest, SPOpKeyRequestSeen, SPOpKeyShare, SPOpKeyUpdate, SPOpPropSet, SPOpType, ProtoSPOpKeyRequestSeen, ProtoSPOpKeyShare } from './SPMessage.js'
 import { SPMessage } from './SPMessage.js'
@@ -251,12 +251,7 @@ export default (sbp('sbp/selectors/register', {
       console.warn('[chelonia]: already loaded manifest', manifestHash)
       return
     }
-    const manifestURL = `${this.config.connectionURL}/file/${manifestHash}`
-    const manifestSource = await fetch(manifestURL, { signal: this.abortController.signal }).then(handleFetchResult('text'))
-    const manifestHashOurs = createCID(manifestSource, multicodes.SHELTER_CONTRACT_MANIFEST)
-    if (manifestHashOurs !== manifestHash) {
-      throw new Error(`expected manifest hash ${manifestHash}. Got: ${manifestHashOurs}`)
-    }
+    const manifestSource = await sbp('chelonia/out/entry', manifestHash, { code: multicodes.SHELTER_CONTRACT_MANIFEST })
     const manifest = JSON.parse(manifestSource)
     const body = sbp('chelonia/private/verifyManifestSignature', contractName, manifestHash, manifest)
     if (body.name !== contractName) {
@@ -264,12 +259,7 @@ export default (sbp('sbp/selectors/register', {
     }
     const contractInfo = (this.config.contracts.defaults.preferSlim && body.contractSlim) || body.contract
     console.info(`[chelonia] loading contract '${contractInfo.file}'@'${body.version}' from manifest: ${manifestHash}`)
-    const source = await fetch(`${this.config.connectionURL}/file/${contractInfo.hash}`, { signal: this.abortController.signal })
-      .then(handleFetchResult('text'))
-    const sourceHash = createCID(source, multicodes.SHELTER_CONTRACT_TEXT)
-    if (sourceHash !== contractInfo.hash) {
-      throw new Error(`bad hash ${sourceHash} for contract '${contractInfo.file}'! Should be: ${contractInfo.hash}`)
-    }
+    const source = await sbp('chelonia/out/entry', contractInfo.hash, { code: multicodes.SHELTER_CONTRACT_TEXT })
     function reduceAllow (acc, v) { acc[v] = true; return acc }
     const allowedSels = ['okTurtles.events/on', 'chelonia/defineContract', 'chelonia/out/keyRequest']
       .concat(this.config.contracts.defaults.allowedSelectors)
@@ -374,7 +364,7 @@ export default (sbp('sbp/selectors/register', {
         // with other client's clocks.
         // See: https://github.com/okTurtles/group-income/issues/531
         try {
-          const response = await fetch(`${this.config.connectionURL}/time`, { signal: this.abortController.signal })
+          const response = await this.config.fetch(`${this.config.connectionURL}/time`, { signal: this.abortController.signal })
           return handleFetchResult('text')(response)
         } catch (e) {
           if (fallback) {
@@ -587,7 +577,7 @@ export default (sbp('sbp/selectors/register', {
         await hooks?.beforeRequest?.(newEntry, entry)
         entry = newEntry
 
-        const r = await fetch(`${this.config.connectionURL}/event`, {
+        const r = await this.config.fetch(`${this.config.connectionURL}/event`, {
           method: 'POST',
           body: entry.serialize(),
           headers: {
@@ -644,7 +634,7 @@ export default (sbp('sbp/selectors/register', {
     })
   },
   'chelonia/private/out/latestHEADinfo': function (contractID: string) {
-    return fetch(`${this.config.connectionURL}/latestHEADinfo/${contractID}`, {
+    return this.config.fetch(`${this.config.connectionURL}/latestHEADinfo/${contractID}`, {
       cache: 'no-store',
       signal: this.abortController.signal
     }).then(handleFetchResult('json'))
@@ -2279,7 +2269,7 @@ function sesImportVM (url): Promise<Object> {
       },
       // eslint-disable-next-line require-await
       async importHook (moduleSpecifier: string, ...args) {
-        const source = await fetch(moduleSpecifier).then(handleFetchResult('text'))
+        const source = await this.config.fetch(moduleSpecifier).then(handleFetchResult('text'))
         console.debug('importHook', { fetch: moduleSpecifier, args, source })
         const execute = (moduleExports, compartment, resolvedImports) => {
           console.debug('execute called with:', { moduleExports, resolvedImports })

--- a/shared/domains/chelonia/time-sync.js
+++ b/shared/domains/chelonia/time-sync.js
@@ -21,7 +21,7 @@ const syncServerTime = async function () {
   // Get our current monotonic time
   const startTime = performance.now()
   // Now, ask the server for the time
-  const time = await fetch(`${this.config.connectionURL}/time`, { signal: this.abortController.signal })
+  const time = await this.config.fetch(`${this.config.connectionURL}/time`, { signal: this.abortController.signal })
   const requestTimeElapsed = performance.now()
   if (requestTimeElapsed - startTime > 8000) {
     throw new Error('Error fetching server time: request took too long')

--- a/shared/domains/chelonia/utils.js
+++ b/shared/domains/chelonia/utils.js
@@ -570,7 +570,7 @@ export function eventsAfter (contractID: string, sinceHeight: number, limit?: nu
   const fetchEventsStreamReader = async () => {
     requestLimit = Math.min(limit ?? MAX_EVENTS_AFTER, remainingEvents)
     lastUrl = `${this.config.connectionURL}/eventsAfter/${contractID}/${sinceHeight}${Number.isInteger(requestLimit) ? `/${requestLimit}` : ''}`
-    const eventsResponse = await fetch(lastUrl, { signal })
+    const eventsResponse = await this.config.fetch(lastUrl, { signal })
     if (!eventsResponse.ok) {
       const msg = `${eventsResponse.status}: ${eventsResponse.statusText}`
       if (eventsResponse.status === 410) throw new ChelErrorResourceGone(msg)


### PR DESCRIPTION
This is based on PR 'Offline cache' #2508, addressing issue #2503. The reason for this separate PR is that it might take a while to have #2508 ready, but these changes are generally useful.

These changes add a `fetch` option to Chelonia to override the global `fetch`. This is useful in many contexts, such as for debugging, for adding custom logic and other things. In PR #2508, this option is used for caching some API calls (since the network activity happens inside of the SW, the `fetch` event isn't used)