### PR TITLE
#2761 - Add profile tooltips to display names in contribution page

### DIFF
--- a/frontend/model/getters.js
+++ b/frontend/model/getters.js
@@ -151,7 +151,7 @@ const getters: { [x: string]: (state: Object, getters: { [x: string]: any }) => 
           .filter(p => p.toMemberID === ourIdentityContractId)
           .reduce((acc, payment) => {
             who.push(getters.userDisplayNameFromID(payment.fromMemberID))
-            whoIds.push(payment.toMemberID)
+            whoIds.push(payment.fromMemberID)
 
             return acc + payment.amount
           }, 0)

--- a/frontend/model/getters.js
+++ b/frontend/model/getters.js
@@ -140,7 +140,7 @@ const getters: { [x: string]: (state: Object, getters: { [x: string]: any }) => 
             return acc + payment.amount
           }, 0)
 
-        return { who, whoIds, total, pledged: ourGroupProfile.pledgeAmount  }
+        return { who, whoIds, total, pledged: ourGroupProfile.pledgeAmount }
       })(),
       receivingMonetary: (() => {
         if (!doWeNeedIncome) { return null }

--- a/frontend/model/getters.js
+++ b/frontend/model/getters.js
@@ -130,27 +130,33 @@ const getters: { [x: string]: (state: Object, getters: { [x: string]: any }) => 
       givingMonetary: (() => {
         if (doWeNeedIncome) { return null }
         const who = []
+        const whoIds = []
         const total = distribution
           .filter(p => p.fromMemberID === ourIdentityContractId)
           .reduce((acc, payment) => {
             who.push(getters.userDisplayNameFromID(payment.toMemberID))
+            whoIds.push(payment.toMemberID)
+
             return acc + payment.amount
           }, 0)
 
-        return { who, total, pledged: ourGroupProfile.pledgeAmount }
+        return { who, whoIds, total, pledged: ourGroupProfile.pledgeAmount  }
       })(),
       receivingMonetary: (() => {
         if (!doWeNeedIncome) { return null }
         const needed = getters.groupSettings.mincomeAmount - ourGroupProfile.incomeAmount
         const who = []
+        const whoIds = []
         const total = distribution
           .filter(p => p.toMemberID === ourIdentityContractId)
           .reduce((acc, payment) => {
             who.push(getters.userDisplayNameFromID(payment.fromMemberID))
+            whoIds.push(payment.toMemberID)
+
             return acc + payment.amount
           }, 0)
 
-        return { who, total, needed }
+        return { who, whoIds, total, needed }
       })(),
       receivingNonMonetary: (() => {
         const listWho = Object.keys(groupProfiles)
@@ -161,9 +167,13 @@ const getters: { [x: string]: (state: Object, getters: { [x: string]: any }) => 
 
           userContributions.forEach((what) => {
             const contributionIndex = contr.findIndex(c => c.what === what)
-            contributionIndex >= 0
-              ? contr[contributionIndex].who.push(displayName)
-              : contr.push({ who: [displayName], what })
+
+            if (contributionIndex >= 0) {
+              contr[contributionIndex].who.push(displayName)
+              contr[contributionIndex].whoIds.push(memberID)
+            } else {
+              contr.push({ who: [displayName], whoIds: [memberID], what })
+            }
           })
           return contr
         }, [])

--- a/frontend/views/components/ProfileCard.vue
+++ b/frontend/views/components/ProfileCard.vue
@@ -11,93 +11,26 @@ tooltip(
   slot
 
   template(slot='tooltip')
-    .card.c-profile(
+    profile-card-content(
       v-if='profile'
-      role='dialog'
-      data-test='memberProfileCard'
-      :aria-label='L("{username} profile", { username })'
+      :contractID='contractID'
+      :deactivated='deactivated'
+      :on-post-cta-click='toggleTooltip'
+      @modal-close='toggleTooltip'
     )
-      .c-identity(:class='{notGroupMember: !isActiveGroupMember}')
-        avatar-user(:contractID='contractID' size='lg')
-        user-name(:contractID='contractID')
-
-      i18n.has-text-1(
-        tag='p'
-        v-if='!isActiveGroupMember'
-      ) No longer a member of the group
-
-      p.c-bio(v-if='profile.bio')
-        | {{profile.bio}}
-        i18n.c-bio-link.is-unstyled.link(
-          v-if='isSelf'
-          tag='button'
-          @click='openModal("UserSettingsModal")'
-          data-test='linkEditBio'
-        ) Edit bio
-
-      i18n.button.is-small.is-outlined.c-bio-button(
-        v-else-if='isSelf && hasIncomeDetails'
-        tag='button'
-        @click='openModal("UserSettingsModal")'
-        data-test='buttonEditBio'
-      ) Add a bio
-
-      div(v-if='hasIncomeDetails' data-test='profilePaymentMethods')
-        ul.c-payment-list
-          li.c-payment-item(v-for='(paymentMethod, name) in this.paymentMethods' data-test='profilePaymentMethod')
-            span.c-payment-type.has-text-0.has-text-bold {{paymentMethod.name}}
-            span.has-text-1 {{paymentMethod.value}}
-
-        i18n.link(
-          v-if='isSelf && receivingMonetary'
-          tag='button'
-          @click='openModal("incomeDetails")'
-          data-test='linkEditPayment'
-        ) Edit payment info
-
-      .c-add-payment(v-else-if='isSelf')
-        i18n.has-text-1(tag='p') Help other users send monthly contributions your way by adding your payment information.
-        i18n.button.c-add-payment-button(
-          tag='button'
-          @click='openModal("incomeDetails")'
-          data-test='buttonAddPayment'
-        ) Add payment information
-
-      .buttons(v-if='!isSelf')
-        button-submit.is-outlined.is-small(
-          type='button'
-          data-test='buttonSendMessage'
-          @click='sendMessage'
-        )
-          i18n Send message
-
-        i18n.button.is-outlined.is-small(
-          v-if='groupShouldPropose || isGroupCreator'
-          tag='button'
-          @click.stop='onRemoveMemberClick'
-          data-test='buttonRemoveMember'
-        ) Remove member
-
-      modal-close.c-close(
-        :aria-label='L("Close profile")'
-        @close='toggleTooltip'
-      )
 </template>
 
 <script>
-import sbp from '@sbp/sbp'
-import AvatarUser from '@components/AvatarUser.vue'
-import ButtonSubmit from '@components/ButtonSubmit.vue'
-import UserName from '@components/UserName.vue'
-import Tooltip from '@components/Tooltip.vue'
-import ModalClose from '@components/modal/ModalClose.vue'
-import DMMixin from '@containers/chatroom/DMMixin.js'
-import { OPEN_MODAL, REPLACE_MODAL } from '@utils/events.js'
 import { mapGetters } from 'vuex'
-import { PROFILE_STATUS } from '~/frontend/model/contracts/shared/constants.js'
+import Tooltip from '@components/Tooltip.vue'
+import ProfileCardContent from './ProfileCardContent.vue'
 
 export default ({
   name: 'ProfileCard',
+  components: {
+    Tooltip,
+    ProfileCardContent
+  },
   props: {
     contractID: String,
     direction: {
@@ -111,90 +44,17 @@ export default ({
     },
     isVisible: Boolean
   },
-  mixins: [
-    DMMixin
-  ],
-  components: {
-    AvatarUser,
-    ModalClose,
-    UserName,
-    Tooltip,
-    ButtonSubmit
-  },
   computed: {
     ...mapGetters([
-      'groupProfiles',
-      'currentGroupOwnerID',
-      'globalProfile',
-      'groupShouldPropose',
-      'ourContributionSummary',
-      'ourGroupDirectMessageFromUserIds',
-      'ourIdentityContractId'
+      'globalProfile'
     ]),
-    isSelf () {
-      return this.contractID === this.ourIdentityContractId
-    },
-    isGroupCreator () {
-      return this.ourIdentityContractId === this.currentGroupOwnerID
-    },
     profile () {
       return this.globalProfile(this.contractID)
-    },
-    username () {
-      return this.profile?.username || this.contractID
-    },
-    userGroupProfile () {
-      return this.groupProfiles[this.contractID]
-    },
-    isActiveGroupMember () {
-      return this.userGroupProfile?.status === PROFILE_STATUS.ACTIVE
-    },
-    paymentMethods () {
-      return this.userGroupProfile?.paymentMethods
-    },
-    hasIncomeDetails () {
-      return !!this.userGroupProfile?.incomeDetailsType
-    },
-    receivingMonetary () {
-      return !!this.ourContributionSummary.receivingMonetary
     }
   },
   methods: {
-    openModal (modal, props) {
-      if (this.deactivated) { return }
-      this.toggleTooltip()
-
-      sbp('okTurtles.events/emit', OPEN_MODAL, modal, props)
-    },
-    onRemoveMemberClick () {
-      if (this.deactivated) { return }
-      this.toggleTooltip()
-
-      sbp(
-        'okTurtles.events/emit',
-        this.$route.query?.modal === 'GroupMembersAllModal' ? REPLACE_MODAL : OPEN_MODAL,
-        'RemoveMember',
-        { memberID: this.contractID }
-      )
-    },
     toggleTooltip () {
       this.$refs.tooltip?.toggle()
-    },
-    async sendMessage () {
-      const chatRoomID = this.ourGroupDirectMessageFromUserIds(this.contractID)
-      if (!chatRoomID) {
-        const freshChatRoomID = await this.createDirectMessage(this.contractID)
-        if (freshChatRoomID) {
-          this.redirect(freshChatRoomID)
-        }
-      } else {
-        if (!this.ourGroupDirectMessages[chatRoomID].visible) {
-          this.setDMVisibility(chatRoomID, true)
-        } else {
-          this.redirect(chatRoomID)
-        }
-      }
-      this.toggleTooltip()
     }
   }
 }: Object)
@@ -203,110 +63,12 @@ export default ({
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";
 
-.card {
-  padding: 1rem 1.5rem 1.5rem 1.5rem;
-  color: $text_1;
-  max-width: 100vw;
-  width: 24.3rem;
-  box-shadow: 0 0.5rem 1.25rem rgba(54, 54, 54, 0.3);
-
-  &:last-child {
-    margin-bottom: 0;
-  }
-
-  @include phone {
-    box-shadow: none;
-    width: 100vw;
-    padding-bottom: 4rem;
-  }
-}
-
-.c-profile {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-}
-
-.is-active .c-profile {
-  animation: zoom 100ms both cubic-bezier(0.165, 0.84, 0.44, 1);
-  @include phone {
-    animation-name: enterFromBottom;
-  }
-}
-
-.c-identity {
-  display: flex;
-  align-items: center;
-  padding-bottom: 1.5rem;
-}
-
-.notGroupMember {
-  filter: saturate(0.3);
-}
-
-.c-bio-button {
-  width: 100%;
-  margin-bottom: 0.5rem;
-}
-
-.c-bio-link {
-  margin-left: 0.3rem;
-}
-
-.c-payment-list {
-  margin-top: 1rem;
-}
-
-.c-payment-item {
-  margin-bottom: 0.5rem;
-}
-
-.c-payment-type {
-  padding-right: 0.5rem;
-  user-select: none;
-}
-
-.c-add-payment-button {
-  margin-top: 1.5rem;
-  width: 100%;
-}
-
-.c-bio + .c-add-payment {
-  margin-top: 2rem;
-}
-
 .c-twrapper {
   display: flex;
   align-items: center;
 
   &:focus {
     outline: none;
-  }
-}
-
-.buttons {
-  margin-top: 1rem;
-
-  .is-outlined {
-    width: calc(50% - 0.5rem);
-  }
-}
-
-.c-close {
-  left: calc(100vw - 4rem);
-  top: 1.5rem;
-  @include tablet {
-    left: auto;
-    right: 1rem;
-
-    /* Hide it visually... */
-    opacity: 0;
-    pointer-events: none;
-
-    /* ...but keep it for keyboard users. */
-    &:focus {
-      opacity: 1;
-    }
   }
 }
 </style>

--- a/frontend/views/components/ProfileCard.vue
+++ b/frontend/views/components/ProfileCard.vue
@@ -5,6 +5,7 @@ tooltip(
   :manual='true'
   :opacity='1'
   :deactivated='deactivated'
+  :isVisible='isVisible'
   :aria-label='L("Show profile")'
 )
   slot
@@ -107,7 +108,8 @@ export default ({
     deactivated: {
       type: Boolean,
       default: false
-    }
+    },
+    isVisible: Boolean
   },
   mixins: [
     DMMixin

--- a/frontend/views/components/ProfileCardContent.vue
+++ b/frontend/views/components/ProfileCardContent.vue
@@ -208,6 +208,13 @@ export default {
   position: relative;
   display: flex;
   flex-direction: column;
+
+  .is-active & {
+    animation: zoom 100ms both cubic-bezier(0.165, 0.84, 0.44, 1);
+    @include phone {
+      animation-name: enterFromBottom;
+    }
+  }
 }
 
 .c-identity {

--- a/frontend/views/components/ProfileCardContent.vue
+++ b/frontend/views/components/ProfileCardContent.vue
@@ -1,0 +1,281 @@
+<template lang='pug'>
+.card.c-profile(
+  role='dialog'
+  data-test='memberProfileCard'
+  :aria-label='L("{username} profile", { username })'
+)
+  .c-identity(:class='{ "not-group-member": !isActiveGroupMember }')
+    avatar-user(:contractID='contractID' size='lg')
+    user-name(:contractID='contractID')
+
+  i18n.has-text-1(
+    tag='p'
+    v-if='!isActiveGroupMember'
+  ) No longer a member of the group
+
+  p.c-bio(v-if='profile.bio')
+    | {{profile.bio}}
+    i18n.c-bio-link.is-unstyled.link(
+      v-if='isSelf'
+      tag='button'
+      @click='openModal("UserSettingsModal")'
+      data-test='linkEditBio'
+    ) Edit bio
+
+  i18n.button.is-small.is-outlined.c-bio-button(
+    v-else-if='isSelf && hasIncomeDetails'
+    tag='button'
+    @click='openModal("UserSettingsModal")'
+    data-test='buttonEditBio'
+  ) Add a bio
+
+  div(v-if='hasIncomeDetails' data-test='profilePaymentMethods')
+    ul.c-payment-list
+      li.c-payment-item(v-for='(paymentMethod, name) in paymentMethods'
+        data-test='profilePaymentMethod')
+        span.c-payment-type.has-text-0.has-text-bold {{ paymentMethod.name }}
+        span.has-text-1 {{ paymentMethod.value }}
+
+    i18n.link(
+      v-if='isSelf && receivingMonetary'
+      tag='button'
+      @click='openModal("incomeDetails")'
+      data-test='linkEditPayment'
+    ) Edit payment info
+
+  .c-add-payment(v-else-if='isSelf')
+    i18n.has-text-1(tag='p') Help other users send monthly contributions your way by adding your payment information.
+    i18n.button.c-add-payment-button(
+      tag='button'
+      @click='openModal("incomeDetails")'
+      data-test='buttonAddPayment'
+    ) Add payment information
+
+  .buttons(v-if='!isSelf')
+    button-submit.is-outlined.is-small(
+      type='button'
+      data-test='buttonSendMessage'
+      @click='sendMessage'
+    )
+      i18n Send message
+
+    i18n.button.is-outlined.is-small(
+      v-if='groupShouldPropose || isGroupCreator'
+      tag='button'
+      @click.stop='onRemoveMemberClick'
+      data-test='buttonRemoveMember'
+    ) Remove member
+
+  modal-close.c-close(
+    :aria-label='L("Close profile")'
+    @close='$emit("modal-close")'
+  )
+</template>
+
+<script>
+import sbp from '@sbp/sbp'
+import AvatarUser from '@components/AvatarUser.vue'
+import ButtonSubmit from '@components/ButtonSubmit.vue'
+import UserName from '@components/UserName.vue'
+import Tooltip from '@components/Tooltip.vue'
+import ModalClose from '@components/modal/ModalClose.vue'
+import DMMixin from '@containers/chatroom/DMMixin.js'
+import { OPEN_MODAL, REPLACE_MODAL } from '@utils/events.js'
+import { mapGetters } from 'vuex'
+import { PROFILE_STATUS } from '~/frontend/model/contracts/shared/constants.js'
+
+export default {
+  name: 'ProfileCardContent',
+  mixins: [
+    DMMixin
+  ],
+  components: {
+    AvatarUser,
+    ModalClose,
+    UserName,
+    Tooltip,
+    ButtonSubmit
+  },
+  props: {
+    contractID: String,
+    onPostCtaClick: Function,
+    deactivated: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    ...mapGetters([
+      'groupProfiles',
+      'currentGroupOwnerID',
+      'globalProfile',
+      'groupShouldPropose',
+      'ourContributionSummary',
+      'ourGroupDirectMessageFromUserIds',
+      'ourIdentityContractId'
+    ]),
+    profile () {
+      return this.globalProfile(this.contractID)
+    },
+    userGroupProfile () {
+      return this.groupProfiles[this.contractID]
+    },
+    isSelf () {
+      return this.contractID === this.ourIdentityContractId
+    },
+    username () {
+      return this.profile?.username || this.contractID
+    },
+    isGroupCreator () {
+      return this.ourIdentityContractId === this.currentGroupOwnerID
+    },
+    isActiveGroupMember () {
+      return this.userGroupProfile?.status === PROFILE_STATUS.ACTIVE
+    },
+    paymentMethods () {
+      return this.userGroupProfile?.paymentMethods
+    },
+    hasIncomeDetails () {
+      return !!this.userGroupProfile?.incomeDetailsType
+    },
+    receivingMonetary () {
+      return !!this.ourContributionSummary.receivingMonetary
+    }
+  },
+  methods: {
+    openModal (modal, props) {
+      if (this.deactivated) { return }
+
+      sbp('okTurtles.events/emit', OPEN_MODAL, modal, props)
+      this.onPostCtaClick && this.onPostCtaClick()
+    },
+    onRemoveMemberClick () {
+      if (this.deactivated) { return }
+
+      sbp(
+        'okTurtles.events/emit',
+        this.$route.query?.modal === 'GroupMembersAllModal' ? REPLACE_MODAL : OPEN_MODAL,
+        'RemoveMember',
+        { memberID: this.contractID }
+      )
+
+      this.onPostCtaClick && this.onPostCtaClick()
+    },
+    async sendMessage () {
+      const chatRoomID = this.ourGroupDirectMessageFromUserIds(this.contractID)
+
+      if (!chatRoomID) {
+        const freshChatRoomID = await this.createDirectMessage(this.contractID)
+        if (freshChatRoomID) {
+          this.redirect(freshChatRoomID)
+        }
+      } else {
+        if (!this.ourGroupDirectMessages[chatRoomID].visible) {
+          this.setDMVisibility(chatRoomID, true)
+        } else {
+          this.redirect(chatRoomID)
+        }
+      }
+
+      this.onPostCtaClick && this.onPostCtaClick()
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+@import "@assets/style/_variables.scss";
+
+.card {
+  padding: 1rem 1.5rem 1.5rem 1.5rem;
+  color: $text_1;
+  max-width: 100vw;
+  width: 24.3rem;
+  box-shadow: 0 0.5rem 1.25rem rgba(54, 54, 54, 0.3);
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  @include phone {
+    box-shadow: none;
+    width: 100vw;
+    padding-bottom: 4rem;
+  }
+}
+
+.c-profile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.c-identity {
+  display: flex;
+  align-items: center;
+  padding-bottom: 1.5rem;
+}
+
+.not-group-member {
+  filter: saturate(0.3);
+}
+
+.c-bio-button {
+  width: 100%;
+  margin-bottom: 0.5rem;
+}
+
+.c-bio-link {
+  margin-left: 0.3rem;
+}
+
+.c-payment-list {
+  margin-top: 1rem;
+}
+
+.c-payment-item {
+  margin-bottom: 0.5rem;
+}
+
+.c-payment-type {
+  padding-right: 0.5rem;
+  user-select: none;
+}
+
+.c-add-payment-button {
+  margin-top: 1.5rem;
+  width: 100%;
+}
+
+.c-bio + .c-add-payment {
+  margin-top: 2rem;
+}
+
+.buttons {
+  margin-top: 1rem;
+
+  .is-outlined {
+    width: calc(50% - 0.5rem);
+  }
+}
+
+.c-close {
+  position: absolute;
+  left: calc(100vw - 4rem);
+  top: 1.5rem;
+
+  @include tablet {
+    left: auto;
+    right: 1rem;
+
+    /* Hide it visually... */
+    opacity: 0;
+    pointer-events: none;
+
+    /* ...but keep it for keyboard users. */
+    &:focus {
+      opacity: 1;
+    }
+  }
+}
+</style>

--- a/frontend/views/containers/contributions/ContributionItem.vue
+++ b/frontend/views/containers/contributions/ContributionItem.vue
@@ -263,6 +263,10 @@ export default ({
   z-index: 1;
   background-color: $background_0;
 
+  @include phone {
+    border-radius: 0.625rem 0.625rem 0 0;
+  }
+
   .is-dark-theme & {
     background-color: $general_1;
   }

--- a/frontend/views/containers/contributions/ContributionItem.vue
+++ b/frontend/views/containers/contributions/ContributionItem.vue
@@ -29,7 +29,7 @@
     @click='showProfileTooltip'
   )
 
-  .c-profile-card-container(
+  .c-profile-card-container.is-active(
     v-if='ephemeral.profileTooltip.show'
     v-on-clickaway='closeProfileTooltip'
   )
@@ -37,6 +37,11 @@
       @click.stop='closeProfileTooltip'
     )
 
+    // NOTE: Why not ProfileCard.vue here?
+    // In here, we need to display the profile card UI when one or more text 'segments' of the sentence are hovered/focused [1].
+    // ProfileCard.vue is currently implemented with Tooltip.vue component which requires the 'entire sentence' to be the trigger [2].
+    // So instead of further complicating the ProfileCard.vue with the logic for [1] above, we are implementing the logic here and only reusing the
+    // user card UI of ProfileCard.vue (which is ProfileCardContent.vue).
     profile-card-content.c-card(
       :contractID='ephemeral.profileTooltip.userId'
       :on-post-cta-click='closeProfileTooltip'
@@ -46,7 +51,6 @@
 
 <script>
 import { L } from '@common/common.js'
-import { mapGetters } from 'vuex'
 import ProfileCardContent from '@components/ProfileCardContent.vue'
 import { mixin as clickaway } from 'vue-clickaway'
 
@@ -89,7 +93,6 @@ export default ({
     }
   },
   computed: {
-    ...mapGetters(['ourIdentityContractId']),
     listOfName () {
       const html = {
         amount: `<span class="has-text-bold">${this.what}</span>`,

--- a/frontend/views/containers/contributions/ContributionItem.vue
+++ b/frontend/views/containers/contributions/ContributionItem.vue
@@ -23,9 +23,9 @@
         v-safe-html='contributionText'
       )
 
-  .c-contribution-list(
-    v-else=''
-    v-safe-html='contributionText'
+  .c-contribution-list.has-dynamic-tooltip(
+    v-else
+    v-safe-html:button='contributionText'
   )
 </template>
 
@@ -64,8 +64,8 @@ export default ({
       if (this.hasWhoElse) {
         const html = {
           service: `<span class="has-text-bold">${this.what}</span>`,
-          button_: '<button class="is-unstyled is-link-inherit link">',
           numMembers: this.otherContributor,
+          button_: '<button class="is-unstyled is-link-inherit link">',
           _button: '</button>'
         }
 
@@ -111,8 +111,14 @@ export default ({
 
     firstWho () {
       const who = this.who
-      if (!Array.isArray(who)) return who
-      return who.length === 2 ? L('{who0} and {who1}', { who0: who[0], who1: who[1] }) : who[0]
+      const btnHtml = {
+        button_: '<button class="is-unstyled is-link-inherit link">',
+        _button: '</button>'
+      }
+      if (!Array.isArray(who)) return L('{button_}{who}{_button}', { who, ...btnHtml })
+      return who.length === 2
+        ? L('{button_}{who0}{_button} and {button_}{who1}{_button}', { who0: who[0], who1: who[1], ...btnHtml })
+        : L('{button_}{who}{_button}', { who: who[0], ...btnHtml })
     },
 
     otherContributor () {
@@ -156,5 +162,9 @@ export default ({
   &:last-child {
     padding-bottom: 0.5rem;
   }
+}
+
+.c-contribution-list.has-dynamic-tooltip {
+  position: relative;
 }
 </style>

--- a/frontend/views/containers/contributions/ContributionItem.vue
+++ b/frontend/views/containers/contributions/ContributionItem.vue
@@ -5,7 +5,7 @@
   div(v-if='hasWhoElse')
     transition(name='replace-list')
       div(
-        v-if='isVisible'
+        v-if='ephemeral.isVisible'
         key='visible'
       )
         .c-contribution-list(v-safe-html='listOfName')
@@ -13,27 +13,47 @@
         i18n.is-unstyled.is-link-inherit.link(
           tag='button'
           type='button'
-          @click='isVisible = !isVisible'
+          @click='toggleVisibility'
         ) Hide
 
       div(
         v-else
         key='hidden'
-        @click='isVisible = !isVisible'
+        @click='toggleVisibility'
         v-safe-html='contributionText'
       )
 
-  .c-contribution-list.has-dynamic-tooltip(
+  .c-contribution-list(
     v-else
     v-safe-html:button='contributionText'
+    @click.stop='showProfileTooltip'
   )
+
+  .c-profile-card-container(
+    v-if='ephemeral.profileTooltip.show'
+    v-on-clickaway='closeProfileTooltip'
+  )
+    .c-profile-card-overlay
+
+    profile-card-content.c-card(
+      :contractID='ourIdentityContractId'
+      :on-post-cta-click='closeProfileTooltip'
+      @modal-close='closeProfileTooltip'
+    )
 </template>
 
 <script>
 import { L } from '@common/common.js'
+import { mapGetters } from 'vuex'
+import ProfileCardContent from '@components/ProfileCardContent.vue'
+import { mixin as clickaway } from 'vue-clickaway'
 
 export default ({
   name: 'ContributionItem',
+  components: {
+    ProfileCardContent
+  },
+  mixins: [clickaway],
   props: {
     who: [String, Array],
     what: String,
@@ -56,10 +76,46 @@ export default ({
   },
   data () {
     return {
-      isVisible: false
+      ephemeral: {
+        isVisible: false,
+        profileTooltip: {
+          show: false
+        }
+      }
     }
   },
   computed: {
+    ...mapGetters(['ourIdentityContractId']),
+    listOfName () {
+      const html = {
+        amount: `<span class="has-text-bold">${this.what}</span>`,
+        listName: this.who.map((name, index) => {
+          return `<p class="has-text-1 c-contribution-list-item">${name}</p>`
+        }).join('')
+      }
+      if (this.action === 'RECEIVING') {
+        return L('{amount} from {listName}', html)
+      } else {
+        return L('A total of {amount} to {listName}', html)
+      }
+    },
+    firstWho () {
+      const who = this.who
+      const btnHtml = {
+        button_: '<button class="is-unstyled is-link-inherit link user-name">',
+        _button: '</button>'
+      }
+      if (!Array.isArray(who)) return L('{button_}{who}{_button}', { who, ...btnHtml })
+      return who.length === 2
+        ? L('{button_}{who0}{_button} and {button_}{who1}{_button}', { who0: who[0], who1: who[1], ...btnHtml })
+        : L('{button_}{who}{_button}', { who: who[0], ...btnHtml })
+    },
+    otherContributor () {
+      return this.who.length // (-1 contributor + 1 array length)
+    },
+    hasWhoElse () {
+      return Array.isArray(this.who) && this.who.length > 2
+    },
     contributionText () {
       if (this.hasWhoElse) {
         const html = {
@@ -94,40 +150,6 @@ export default ({
         }
       }
     },
-
-    listOfName () {
-      const html = {
-        amount: `<span class="has-text-bold">${this.what}</span>`,
-        listName: this.who.map((name, index) => {
-          return `<p class="has-text-1 c-contribution-list-item">${name}</p>`
-        }).join('')
-      }
-      if (this.action === 'RECEIVING') {
-        return L('{amount} from {listName}', html)
-      } else {
-        return L('A total of {amount} to {listName}', html)
-      }
-    },
-
-    firstWho () {
-      const who = this.who
-      const btnHtml = {
-        button_: '<button class="is-unstyled is-link-inherit link">',
-        _button: '</button>'
-      }
-      if (!Array.isArray(who)) return L('{button_}{who}{_button}', { who, ...btnHtml })
-      return who.length === 2
-        ? L('{button_}{who0}{_button} and {button_}{who1}{_button}', { who0: who[0], who1: who[1], ...btnHtml })
-        : L('{button_}{who}{_button}', { who: who[0], ...btnHtml })
-    },
-
-    otherContributor () {
-      return this.who.length // (-1 contributor + 1 array length)
-    },
-
-    hasWhoElse () {
-      return Array.isArray(this.who) && this.who.length > 2
-    },
     iconClass () {
       const style = {
         'NON_MONETARY': {
@@ -141,6 +163,25 @@ export default ({
       }
       return `icon-${style[this.type].icon} icon-round has-background-${style[this.type].color} has-text-${style[this.type].color}`
     }
+  },
+  methods: {
+    toggleVisibility () {
+      console.log('!@# toggling visibility')
+      this.ephemeral.isVisible = !this.ephemeral.isVisible
+    },
+    showProfileTooltip (e) {
+      const el = e.target
+      if (el.matches('button.user-name')) {
+        const displayName = el.textContent.trim()
+        console.log('!@# displayName: ', displayName)
+        this.ephemeral.profileTooltip.show = true
+      }
+    },
+    closeProfileTooltip () {
+      if (this.ephemeral.profileTooltip.show) {
+        this.ephemeral.profileTooltip.show = false
+      }
+    }
   }
 }: Object)
 </script>
@@ -149,6 +190,7 @@ export default ({
 @import "@assets/style/_variables.scss";
 
 .c-contribution-item {
+  position: relative;
   display: flex;
   align-items: baseline;
   margin: 0.5rem 0;
@@ -164,7 +206,52 @@ export default ({
   }
 }
 
-.c-contribution-list.has-dynamic-tooltip {
+.c-profile-card-container {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: $zindex-tooltip;
+
+  @include phone {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+}
+
+.c-profile-card-overlay {
+  position: absolute;
+  display: none;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(10, 10, 10, 0.86);
+  z-index: 0;
+
+  @include phone {
+    display: block;
+  }
+}
+
+.c-card {
   position: relative;
+  z-index: 1;
+  background-color: $background_0;
+
+  .is-dark-theme & {
+    background-color: $general_1;
+  }
+
+  ::v-deep .c-close {
+    position: absolute;
+  }
 }
 </style>

--- a/frontend/views/pages/Contributions.vue
+++ b/frontend/views/pages/Contributions.vue
@@ -49,7 +49,7 @@ page(pageTestName='contributionsPage' pageTestHeaderName='contributionsTitle')
 
         ul.spacer(
           v-if='doesReceiveAny'
-          data-test='revceivingList'
+          data-test='receivingList'
         )
           contribution(
             v-if='doesReceiveMonetary'

--- a/frontend/views/pages/Contributions.vue
+++ b/frontend/views/pages/Contributions.vue
@@ -57,6 +57,7 @@ page(pageTestName='contributionsPage' pageTestHeaderName='contributionsTitle')
             contribution-item(
               :what='withCurrency(receivingMonetary.total)'
               :who='receivingMonetary.who'
+              :whoIds='receivingMonetary.whoIds'
               type='MONETARY'
             )
 
@@ -68,6 +69,7 @@ page(pageTestName='contributionsPage' pageTestHeaderName='contributionsTitle')
               contribution-item(
                 :what='contribution.what'
                 :who='contribution.who'
+                :whoIds='contribution.whoIds'
                 type='NON_MONETARY'
               )
 
@@ -104,6 +106,7 @@ page(pageTestName='contributionsPage' pageTestHeaderName='contributionsTitle')
             contribution-item(
               :what='withCurrency(givingMonetary.total)'
               :who='givingMonetary.who'
+              :whoIds='givingMonetary.whoIds'
               type='MONETARY'
               action='GIVING'
             )


### PR DESCRIPTION
closes #2761 

**[On desktop]**

https://github.com/user-attachments/assets/7311b113-84b8-4781-9812-b300cb06324d

**[On mobile]**

https://github.com/user-attachments/assets/e6b2a63f-88ee-4ea1-ad4d-be4291d2d3f7

---
In this case we need to display a user-profile tooltip for specific text segments in a sentence generated by `this.L(...)`. But the existing `ProfileCard.vue` component only allows us to show the tooltip by either hovering/focusing the whole text.
So I extracted `ProfileCardContent.vue` from `ProfileCard.vue` (for DRYing purpose) and implemented the required logic in `ContributionItem.vue`.

Thanks.