### PR TITLE
#2770 - Display chatroom name in bold when it has unread messages

### DIFF
--- a/frontend/model/chatroom/getters.js
+++ b/frontend/model/chatroom/getters.js
@@ -164,15 +164,16 @@ const getters: { [x: string]: (state: Object, getters: { [x: string]: any }, roo
   },
   chatRoomsInDetail (state, getters, rootState) {
     const chatRoomsInDetail = merge({}, getters.groupChatRooms)
+    const myIdendityId = rootState.loggedIn.identityContractID
     for (const contractID in chatRoomsInDetail) {
       const chatRoom = rootState[contractID]
-      if (chatRoom && chatRoom.attributes &&
-        chatRoom.members[rootState.loggedIn.identityContractID]) {
+      if (chatRoom && chatRoom.attributes && chatRoom.members[myIdendityId]) {
         chatRoomsInDetail[contractID] = {
           ...chatRoom.attributes,
           id: contractID,
           unreadMessagesCount: getters.chatRoomUnreadMessages(contractID).length,
-          joined: true
+          joined: true,
+          isCreator: myIdendityId === chatRoom.attributes.creatorID
         }
       } else {
         const { name, privacyLevel } = chatRoomsInDetail[contractID]

--- a/frontend/model/chatroom/getters.js
+++ b/frontend/model/chatroom/getters.js
@@ -172,8 +172,7 @@ const getters: { [x: string]: (state: Object, getters: { [x: string]: any }, roo
           ...chatRoom.attributes,
           id: contractID,
           unreadMessagesCount: getters.chatRoomUnreadMessages(contractID).length,
-          joined: true,
-          isCreator: myIdendityId === chatRoom.attributes.creatorID
+          joined: true
         }
       } else {
         const { name, privacyLevel } = chatRoomsInDetail[contractID]

--- a/frontend/setupChelonia.js
+++ b/frontend/setupChelonia.js
@@ -176,8 +176,7 @@ const setupChelonia = async (): Promise<*> => {
           'chelonia/contract/hasKeysToPerformOperation',
           'gi.actions/identity/kv/initChatRoomUnreadMessages', 'gi.actions/identity/kv/deleteChatRoomUnreadMessages',
           'gi.actions/identity/kv/setChatRoomReadUntil',
-          'gi.actions/identity/kv/addChatRoomUnreadMessage', 'gi.actions/identity/kv/removeChatRoomUnreadMessage',
-          'gi.actions/identity/kv/markAsUnread'
+          'gi.actions/identity/kv/addChatRoomUnreadMessage', 'gi.actions/identity/kv/removeChatRoomUnreadMessage'
         ],
         allowedDomains: ['okTurtles.data', 'okTurtles.events', 'okTurtles.eventQueue', 'gi.db', 'gi.contracts'],
         preferSlim: true,

--- a/frontend/setupChelonia.js
+++ b/frontend/setupChelonia.js
@@ -176,7 +176,8 @@ const setupChelonia = async (): Promise<*> => {
           'chelonia/contract/hasKeysToPerformOperation',
           'gi.actions/identity/kv/initChatRoomUnreadMessages', 'gi.actions/identity/kv/deleteChatRoomUnreadMessages',
           'gi.actions/identity/kv/setChatRoomReadUntil',
-          'gi.actions/identity/kv/addChatRoomUnreadMessage', 'gi.actions/identity/kv/removeChatRoomUnreadMessage'
+          'gi.actions/identity/kv/addChatRoomUnreadMessage', 'gi.actions/identity/kv/removeChatRoomUnreadMessage',
+          'gi.actions/identity/kv/markAsUnread'
         ],
         allowedDomains: ['okTurtles.data', 'okTurtles.events', 'okTurtles.eventQueue', 'gi.db', 'gi.contracts'],
         preferSlim: true,

--- a/frontend/views/containers/chatroom/ConversationsList.vue
+++ b/frontend/views/containers/chatroom/ConversationsList.vue
@@ -72,16 +72,18 @@ export default ({
       'ourUnreadMessages'
     ]),
     hasNotReadTheLatestMessage () {
-      const entries = Object.keys(this.groupChatRooms).map(chatId => {
+      // This computed props check if the chatrooms in the list have any messages that are not seen by the user yet.
+      const entries = Object.keys(this.list.channels).map(chatId => {
         const chatroomLatestState = this.$store.state.contracts[chatId]
         if (!chatroomLatestState || chatroomLatestState.type !== 'gi.contracts/chatroom') { return null }
 
         const latestMsgInfo = { msgHash: chatroomLatestState.HEAD, height: chatroomLatestState.height }
         const chatReadUntilInfo = this.ourUnreadMessages?.[chatId]?.readUntil
-        console.log('!@# here: ', latestMsgInfo, chatReadUntilInfo)
+
         if (!chatReadUntilInfo) {
-          // User has not entered the chatroom since creating it.
-          // TODO: add check for 'isCreator' flag here.
+          // NOTE: If a user creates a new channel but leaves before any message is sent/received in there,
+          // it's 'readUntil' data is undefined. In this case, we can determine whether the latest message is not seen yet by checking if
+          // its height value is >= 3. (3 is the height value of the second message in every chatroom)
           return [chatId, latestMsgInfo.height >= 3]
         } else {
           return [chatId, latestMsgInfo.height > chatReadUntilInfo.createdHeight]

--- a/frontend/views/containers/chatroom/ConversationsList.vue
+++ b/frontend/views/containers/chatroom/ConversationsList.vue
@@ -74,19 +74,19 @@ export default ({
     hasNotReadTheLatestMessage () {
       // This computed props check if the chatrooms in the list have any messages that are not seen by the user yet.
       const entries = Object.keys(this.list.channels).map(chatId => {
-        const chatroomLatestState = this.$store.state.contracts[chatId]
-        if (!chatroomLatestState || chatroomLatestState.type !== 'gi.contracts/chatroom') { return null }
+        const chatroomState = this.$store.state.contracts[chatId]
+        if (!chatroomState || typeof chatroomState?.height !== 'number') { return null }
 
-        const latestMsgInfo = { msgHash: chatroomLatestState.HEAD, height: chatroomLatestState.height }
+        const latestMsgHeight = chatroomState.height
         const chatReadUntilInfo = this.ourUnreadMessages?.[chatId]?.readUntil
 
         if (!chatReadUntilInfo) {
           // NOTE: If a user creates a new channel but leaves before any message is sent/received in there,
           // it's 'readUntil' data is undefined. In this case, we can determine whether the latest message is not seen yet by checking if
           // its height value is >= 3. (3 is the height value of the second message in every chatroom)
-          return [chatId, latestMsgInfo.height >= 3]
+          return [chatId, latestMsgHeight >= 3]
         } else {
-          return [chatId, latestMsgInfo.height > chatReadUntilInfo.createdHeight]
+          return [chatId, latestMsgHeight > chatReadUntilInfo.createdHeight]
         }
       }).filter(Boolean)
 


### PR DESCRIPTION
closes #2770 

**[Video]**
As you can see, when a group member(`user-1`) sends new messages in the chat, the chatroom names in another user's (`user-2`) browser is displayed as bold. This also works when the `user-2` above is offline.

https://github.com/user-attachments/assets/fa589243-84a3-4751-a9e2-07ad5630024a

