### PR TITLE
Re-sync on PUB event

### DIFF
--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -599,6 +599,9 @@ export default (sbp('sbp/selectors/register', {
         // 'new' subscriptions as well as every time the connection is reset
         'subscription-succeeded': (event) => {
           const { channelID } = event.detail
+          // The check below is needed because we could have unsubscribed since
+          // requesting a subscription from the server. In that case, we don't
+          // need to call `sync`.
           if (this.subscriptionSet.has(channelID)) {
             // For new subscriptions, some messages could have been lost
             // between the time the subscription was requested and it was
@@ -608,7 +611,7 @@ export default (sbp('sbp/selectors/register', {
               console.warn(`[chelonia] Syncing contract ${channelID} failed: ${err.message}`)
             })
           }
-          options.handlers?.['subscription-succeeded']?.()
+          options.handlers?.['subscription-succeeded']?.(event)
         }
       },
       // Map message handlers to transparently handle encryption and signatures

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -591,25 +591,24 @@ export default (sbp('sbp/selectors/register', {
       sbp('chelonia/private/stopClockSync')
     }
     sbp('chelonia/private/startClockSync')
-    const resyncOnOnline = () => {
-      // Some messages could have been lost between the time the subscription
-      // was requested and it was actually set up. In these cases, force sync
-      // contracts to get them updated.
-      sbp('chelonia/private/out/sync', Array.from(this.subscriptionSet), { force: true }).catch(err => {
-        console.warn(`[chelonia] Syncing contracts failed: ${err.message}`)
-      })
-    }
     this.pubsub = createClient(pubsubURL, {
       ...this.config.connectionOptions,
       handlers: {
         ...options.handlers,
-        online () {
-          resyncOnOnline()
-          options.handlers?.['online']?.()
-        },
-        'reconnection-succeeded' () {
-          resyncOnOnline()
-          options.handlers?.['reconnection-succeeded']?.()
+        // Every time we get a REQUEST_TYPE.SUB response, which happens for
+        // 'new' subscriptions as well as every time the connection is reset
+        'subscription-succeeded': (event) => {
+          const { channelID } = event.detail
+          if (this.subscriptionSet.has(channelID)) {
+            // For new subscriptions, some messages could have been lost
+            // between the time the subscription was requested and it was
+            // actually set up. In these cases, force sync contracts to get them
+            // updated.
+            sbp('chelonia/private/out/sync', channelID, { force: true }).catch(err => {
+              console.warn(`[chelonia] Syncing contract ${channelID} failed: ${err.message}`)
+            })
+          }
+          options.handlers?.['subscription-succeeded']?.()
         }
       },
       // Map message handlers to transparently handle encryption and signatures


### PR DESCRIPTION
Fix #2769. Verify that #2666 isn't a regression.

To test (on master and then this):

Use Chrome or a Chromium-based browser. Create a group with two users. Create a new network throttling setting with high latency (e.g., 5s) and use this for both u1 (the one creating the chatroom and adding u2) and for u2. u1 only needs to be throttled for the part where u2 is added to the chatroom.