### PR TITLE
Replace unnecessary reactive calls with regular operations

### DIFF
--- a/shared/domains/chelonia/utils.js
+++ b/shared/domains/chelonia/utils.js
@@ -331,20 +331,20 @@ export const keyAdditionProcessor = function (msg: SPMessage, hash: string, keys
     // Is this a an invite key? If so, run logic for invite keys and invitation
     // accounting
     if (key.name.startsWith('#inviteKey-')) {
-      if (!state._vm.invites) this.config.reactiveSet(state._vm, 'invites', Object.create(null))
+      if (!state._vm.invites) state._vm.invites = Object.create(null)
       const inviteSecret = decryptedKey || (
         has(this.transientSecretKeys, key.id)
           ? serializeKey(this.transientSecretKeys[key.id], true)
           : undefined
       )
-      this.config.reactiveSet(state._vm.invites, key.id, {
+      state._vm.invites[key.id] = {
         status: INVITE_STATUS.VALID,
         initialQuantity: key.meta.quantity,
         quantity: key.meta.quantity,
         expires: key.meta.expires,
         inviteSecret,
         responses: []
-      })
+      }
     }
 
     // Is this KEY operation the result of requesting keys for another contract?


### PR DESCRIPTION
Rationale:

Processing messages is always done on copies of the state, and the results are then applied to the root state after all operations have run. Since, it's not really necessary to incur into the overhead of using `reactiveSet` / `reactiveDel`.