### PR TITLE
Backport libchelonia changes

### DIFF
--- a/shared/domains/chelonia/SPMessage.js
+++ b/shared/domains/chelonia/SPMessage.js
@@ -291,9 +291,9 @@ export class SPMessage {
       const value = rawSignedIncomingData(parsedValue)
       const authorizedKeys = Object.fromEntries(value.valueOf()?.keys.map(wk => {
         const k = unwrapMaybeEncryptedData(wk.valueOf())
-        if (!k.data) return null
+        if (!k) return null
         return [k.data.id, k.data]
-      })).filter(Boolean)
+      }).filter(Boolean))
       state = {
         _vm: {
           type: head.type,

--- a/shared/domains/chelonia/chelonia.js
+++ b/shared/domains/chelonia/chelonia.js
@@ -630,7 +630,7 @@ export default (sbp('sbp/selectors/register', {
                     return
                   }
                   sbp('chelonia/queueInvocation', msg.channelID, () => {
-                    (v: Function)(parseEncryptedOrUnencryptedMessage.call(this, {
+                    (v: Function).call(this.pubsub, parseEncryptedOrUnencryptedMessage.call(this, {
                       contractID: msg.channelID,
                       serializedData: msg.data
                     }))
@@ -1480,8 +1480,8 @@ export default (sbp('sbp/selectors/register', {
       const originatingState = originatingContract.state(originatingContractID)
 
       const havePendingKeyRequest = Object.values(originatingState._vm.authorizedKeys).findIndex((k) => {
-      // $FlowFixMe
-        return k._notAfterHeight == null && k.meta?.keyRequest?.contractID === contractID && state?._volatile?.pendingKeyRequests?.includes(k.name)
+        // $FlowFixMe
+        return k._notAfterHeight == null && k.meta?.keyRequest?.contractID === contractID && state?._volatile?.pendingKeyRequests?.some(pkr => pkr.name === k.name)
       }) !== -1
 
       // If there's a pending key request for this contract, return

--- a/shared/domains/chelonia/encryptedData.js
+++ b/shared/domains/chelonia/encryptedData.js
@@ -350,6 +350,7 @@ export const isRawEncryptedData = (data: any): boolean => {
 }
 
 export const unwrapMaybeEncryptedData = (data: any): { encryptionKeyId: string | null, data: any } | void => {
+  if (data == null) return
   if (isEncryptedData(data)) {
     // If not running on a browser, we don't decrypt data to avoid filling the
     // logs with unable to decrypt messages.

--- a/shared/domains/chelonia/files.js
+++ b/shared/domains/chelonia/files.js
@@ -167,8 +167,9 @@ export const aes256gcmHandlers: any = {
     // IKM stands for Input Keying Material, and is a random value used to
     // derive the encryption used in the chunks. See RFC 8188 for how the
     // actual encryption key gets derived from the IKM.
-    let IKM = manifestOptions['cipher-params']?.IKM
-    const recordSize = manifestOptions['cipher-params']?.rs ?? 1 << 16
+    const params = manifestOptions['cipher-params']
+    let IKM = params?.IKM
+    const recordSize = params?.rs ?? 1 << 16
     if (!IKM) {
       IKM = new Uint8Array(33)
       self.crypto.getRandomValues(IKM)

--- a/shared/domains/chelonia/utils.js
+++ b/shared/domains/chelonia/utils.js
@@ -13,7 +13,7 @@ import { CONTRACT_IS_PENDING_KEY_REQUESTS } from './events.js'
 import type { SignedData } from './signedData.js'
 import { isSignedData } from './signedData.js'
 
-const MAX_EVENTS_AFTER = Number.parseInt(process.env.MAX_EVENTS_AFTER, 10) || Infinity
+const MAX_EVENTS_AFTER = Number.parseInt(process.env.MAX_EVENTS_AFTER || '', 10) || Infinity
 
 export const findKeyIdByName = (state: Object, name: string): ?string => state._vm?.authorizedKeys && ((Object.values((state._vm.authorizedKeys: any)): any): SPKey[]).find((k) => k.name === name && k._notAfterHeight == null)?.id
 
@@ -274,7 +274,7 @@ export const keyAdditionProcessor = function (msg: SPMessage, hash: string, keys
 
   const storeSecretKey = (key, decryptedKey) => {
     const decryptedDeserializedKey = deserializeKey(decryptedKey)
-    const transient = !!key.meta.private.transient
+    const transient = !!key.meta?.private?.transient
     sbp('chelonia/storeSecretKeys', new Secret([{
       key: decryptedDeserializedKey,
       // We always set this to true because this could be done from
@@ -357,7 +357,7 @@ export const keyAdditionProcessor = function (msg: SPMessage, hash: string, keys
       // when a corresponding OP_KEY_SHARE is received, which could trigger subscribing to this previously unsubscribed to contract
       if (data && internalSideEffectStack) {
         const keyRequestContractID = data.data
-        const reference = key.meta.keyRequest.reference && unwrapMaybeEncryptedData(key.meta.keyRequest.reference)
+        const reference = unwrapMaybeEncryptedData(key.meta.keyRequest.reference)
 
         // Since now we'll make changes to keyRequestContractID, we need to
         // do this while no other operations are running for that

--- a/shared/functions.js
+++ b/shared/functions.js
@@ -53,7 +53,7 @@ if (typeof globalThis === 'object' && !has(globalThis, 'Buffer')) {
 export async function createCIDfromStream (data: string | Uint8Array | ReadableStream, multicode: number = multicodes.RAW): Promise<string> {
   const uint8array = typeof data === 'string' ? new TextEncoder().encode(data) : data
   const digest = await blake2b256stream.digest(uint8array)
-  return CID.create(1, multicode, digest).toString(base58btc.encoder)
+  return CID.create(1, multicode, digest).toString(base58btc)
 }
 
 // TODO: implement a streaming hashing function for large files.
@@ -61,7 +61,7 @@ export async function createCIDfromStream (data: string | Uint8Array | ReadableS
 export function createCID (data: string | Uint8Array, multicode: number = multicodes.RAW): string {
   const uint8array = typeof data === 'string' ? new TextEncoder().encode(data) : data
   const digest = blake2b256.digest(uint8array)
-  return CID.create(1, multicode, digest).toString(base58btc.encoder)
+  return CID.create(1, multicode, digest).toString(base58btc)
 }
 
 export function blake32Hash (data: string | Uint8Array): string {


### PR DESCRIPTION
This PR includes several logic changes backported from the work on a standalone `libchelonia`. Logic changes are defined, for the purposes of this PR, as changes to the structure of the code after removing all type information.

Some of the changes are cosmetic, but a few are bugfixes.

1. Removed handling of `foreignContractID` for `OP_CONTRACT` keys. This isn't necessarily a bugfix (I don't think the previous code was wrong), but it's an unused feature that I can't think of a good use case for. Probably I added this to solve a specific problem that was later addressed in a different way. Since the code itself isn't wrong, just weird, I commented it out.
2. `OP_CONTRACT` needs some special bootstrapping for its `authorizedKeys` state (since the state is initially empty). `OP_CONTRACT` is defined as allowing for encrypted keys (same as `OP_KEY_ADD`), but the way things are implemented won't in fact accept nor handle encrypted keys. This hasn't broken anything for a few reasons: we're not currently using these encrypted keys, and the code is (currently) written in such a way that encrypted keys will end up being ignored.
3. Call to `.valueOf()` in `SPMessage.prototype.description`. This allows for more complete logs for unencrypted actions that have an inner signature. This isn't as much of a bugfix as it is an enhancement, and it hasn't broken anything because we aren't using unencrypted actions much.
4. Also a bugfix in `SPMessage.prototype.description`. `.type` should be `.action`. `.type` doesn't exist. This hasn't broken anything because of the same reasons as the previous bugfix.
5. `pendingKeyRequests?.includes(k.name)` to `pendingKeyRequests?.some(pkr => pkr.name === k.name)` in `'chelonia/out/keyRequest'`. This is a bugfix, since `pkr` is an object and not a string. This is used for `havePendingKeyRequest`, which is used to return early (avoiding unnecessary duplicate key requests). This likely hasn't resulted in observable issues since it'd just result in unnecessary, duplicate key requests.