### PR TITLE
Worker error handling

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -3,7 +3,7 @@
 import Hapi from '@hapi/hapi'
 import sbp from '@sbp/sbp'
 import chalk from 'chalk'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { Worker } from 'node:worker_threads'
 import { SPMessage } from '~/shared/domains/chelonia/SPMessage.js'
 import '~/shared/domains/chelonia/chelonia.js'
@@ -38,21 +38,26 @@ const createWorker = (path: string): {
   const launchWorker = () => {
     worker = new Worker(path)
     return new Promise((resolve, reject) => {
-      worker.on('message', (msg) => {
+      const msgHandler = (msg) => {
         if (msg === 'ready') {
           worker.off('error', reject)
           worker.on('error', (e) => {
-            console.error(e, 'Error on worker', path)
-            ready = launchWorker()
-            ready.catch(e => {
-              console.error(e, 'Error on worker relaunch', path)
+            console.error(e, `Running worker ${basename(path)} terminated. Attempting relaunch...`)
+            worker.off('message', msgHandler)
+            // This won't result in an infinite loop because of exiting and
+            // because this handler is only executed after the 'ready' event
+            // Relaunch can happen multiple times, so long as the worker doesn't
+            // immediately fail.
+            ready = launchWorker().catch(e => {
+              console.error(e, `Error on worker ${basename(path)} relaunch`)
               process.exit(1)
             })
           })
           resolve()
         }
-      })
-      worker.on('error', reject)
+      }
+      worker.on('message', msgHandler)
+      worker.once('error', reject)
     })
   }
   ready = launchWorker()
@@ -60,17 +65,24 @@ const createWorker = (path: string): {
   const rpcSbp = (...args: any) => {
     return ready.then(() => new Promise((resolve, reject) => {
       const mc = new MessageChannel()
-      mc.port2.onmessage = (event) => {
+      const cleanup = ((worker) => () => {
         worker.off('error', reject)
+        mc.port2.onmessage = null
+        mc.port2.onmessageerror = null
+      })(worker)
+      mc.port2.onmessage = (event) => {
+        cleanup()
         const [success, result] = ((event.data: any): [boolean, any])
         if (success) return resolve(result)
         reject(result)
       }
       mc.port2.onmessageerror = () => {
-        worker.off('error', reject)
+        cleanup()
         reject(Error('Message error'))
       }
       worker.postMessage([mc.port1, ...args], [mc.port1])
+      // If the worker itself breaks during an SBP call, we want to make sure
+      // this promise immediately rejects
       worker.once('error', reject)
     }))
   }

--- a/shared/domains/chelonia/SPMessage.js
+++ b/shared/domains/chelonia/SPMessage.js
@@ -290,7 +290,7 @@ export class SPMessage {
     if (!state?._vm?.authorizedKeys && head.op === SPMessage.OP_CONTRACT) {
       const value = rawSignedIncomingData(parsedValue)
       const authorizedKeys = Object.fromEntries(value.valueOf()?.keys.map(wk => {
-        const k = unwrapMaybeEncryptedData(wk.valueOf())
+        const k = unwrapMaybeEncryptedData(wk)
         if (!k) return null
         return [k.data.id, k.data]
       }).filter(Boolean))


### PR DESCRIPTION
I've noticed that we didn't do much error handling with workers. This had the following consequences:

1. We won't know about crashes or their cause
2. Wokers crashing resulted in the application hanging when trying to send a worker task

This logic implements error reporting and automatic relaunch.