### PR TITLE
ModalTemplate.vue: Invalid prop: type check failed for prop "a11yTitle"

### DIFF
--- a/frontend/views/components/modal/ModalTemplate.vue
+++ b/frontend/views/components/modal/ModalTemplate.vue
@@ -3,7 +3,7 @@
     data-test='modal'
     role='dialog'
     tabindex='-1'
-    :aria-label='a11yTitle'
+    :aria-label='a11yTitle || L("Modal Title Missing")'
     v-focus=''
   )
     transition(name='fade' appear)

--- a/strings/english.json
+++ b/strings/english.json
@@ -513,6 +513,7 @@
   "Mincome goal streak of: {streak} months": "Mincome goal streak of: {streak} months",
   "Mincome must be greater than 0": "Mincome must be greater than 0",
   "Minimum Income": "Minimum Income",
+  "Modal Title Missing": "Modal Title Missing",
   "Modal example": "Modal example",
   "Modal title": "Modal title",
   "Moderator": "Moderator",

--- a/strings/english.strings
+++ b/strings/english.strings
@@ -1542,6 +1542,9 @@
 /* views/containers/dashboard/GroupMincome.vue */
 "Minimum Income" = "Minimum Income";
 
+/* views/components/modal/ModalTemplate.vue */
+"Modal Title Missing" = "Modal Title Missing";
+
 /* views/containers/design-system/DSModalNested.vue */
 "Modal example" = "Modal example";
 

--- a/strings/french.json
+++ b/strings/french.json
@@ -14,6 +14,7 @@
   "{minutes}m": "{minutes}m",
   "New message": "New message",
   "The mincome has changed to {amount}.": "The mincome has changed to {amount}.",
+  "Modal Title Missing": "Modal Title Missing",
   "Are you sure you want to remove this pinned message?": "Are you sure you want to remove this pinned message?",
   "Error while deleting a message": "Error while deleting a message",
   "Failed to initialize chatroom": "Failed to initialize chatroom",

--- a/strings/french.strings
+++ b/strings/french.strings
@@ -45,6 +45,9 @@
 /* MISSING TRANSLATION - model/notifications/templates.js */
 "The mincome has changed to {amount}." = "The mincome has changed to {amount}.";
 
+/* MISSING TRANSLATION - views/components/modal/ModalTemplate.vue */
+"Modal Title Missing" = "Modal Title Missing";
+
 /* MISSING TRANSLATION - views/containers/chatroom/ChatMain.vue */
 "Are you sure you want to remove this pinned message?" = "Are you sure you want to remove this pinned message?";
 


### PR DESCRIPTION
Note: I searched and couldn't find the actual place the title was missing from, so added a default.

Note: this might close #2766 too