### PR TITLE
#2823 - Fix the overflowing proposal issue

### DIFF
--- a/frontend/views/containers/proposals/ProposalItem.vue
+++ b/frontend/views/containers/proposals/ProposalItem.vue
@@ -14,7 +14,7 @@ li.c-item-wrapper(data-test='proposalItem' :data-proposal-hash='proposalHash')
         )
 
       .c-main-content
-        p.has-text-bold(data-test='typeDescription')
+        p.c-proposal-title.has-text-bold(data-test='typeDescription')
           | {{typeDescription}}
           tooltip.c-tip(
             v-if='isToRemoveMe && proposal.status === statuses.STATUS_OPEN'
@@ -54,6 +54,7 @@ li.c-item-wrapper(data-test='proposalItem' :data-proposal-hash='proposalHash')
           i18n.has-text-danger(
             v-if='isExpiredInvitationLink'
           ) Expired
+
       proposal-vote-options(
         v-if='proposal.status === statuses.STATUS_OPEN'
         :proposalHash='proposalHash'
@@ -450,5 +451,10 @@ export default ({
   &-text {
     display: inline;
   }
+}
+
+.c-proposal-title,
+.c-reason {
+  word-break: break-word;
 }
 </style>


### PR DESCRIPTION
closes #2823 

<img src='https://github.com/user-attachments/assets/c54c33a0-c069-4059-9ce3-bf7b4f31605c' width='530'>

As you can see from below, once the issue is fixed the 'Read more' button seems to work as expected too.


https://github.com/user-attachments/assets/a262ea39-ce38-4c07-9918-0343a0165638