### PR TITLE
#2827 - Fix overflowing username in chat

### DIFF
--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -24,8 +24,8 @@
       slot(name='header')
         .c-who(v-if='!isEditing' :class='{ "sr-only": isSameSender }')
           profile-card(:contractID='from' direction='top-left')
-            span.is-title-4 {{ who }}
-          span.has-text-1 {{ humanDate(datetime, { hour: 'numeric', minute: 'numeric' }) }}
+            span.c-username.is-title-4 {{ who }}
+          span.c-datetime.has-text-1 {{ humanDate(datetime, { hour: 'numeric', minute: 'numeric' }) }}
 
       slot(name='body')
         render-message-text.c-replying(
@@ -502,11 +502,27 @@ export default ({
 }
 
 .c-body {
-  max-width: calc(100% - 2.5rem);
+  max-width: calc(100% - 2.75rem);
 }
 
 .c-who {
   display: flex;
+  width: 100%;
+
+  ::v-deep .c-twrapper {
+    width: auto;
+    overflow: hidden;
+  }
+
+  .c-username {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .c-datetime {
+    flex-shrink: 0;
+  }
 
   span {
     padding-right: 0.25rem;

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -24,7 +24,7 @@
       slot(name='header')
         .c-who(v-if='!isEditing' :class='{ "sr-only": isSameSender }')
           profile-card(:contractID='from' direction='top-left')
-            span.c-username.is-title-4 {{ who }}
+            span.c-username.is-title-4(:title='who') {{ who }}
           span.c-datetime.has-text-1 {{ humanDate(datetime, { hour: 'numeric', minute: 'numeric' }) }}
 
       slot(name='body')


### PR DESCRIPTION
closes #2827 

**[Fix screenshot]**

<img src='https://github.com/user-attachments/assets/18293642-4a98-4c20-a319-0ba8ffa45007' width='380'>

<br><br>

But let me know if we want it to show the whole username in multiple lines instead like below.

<img width="380" alt="another overflow fix" src="https://github.com/user-attachments/assets/a363df78-2a8f-4b9d-b87e-28b0e04d3449" />
