### PR TITLE
#2859 - Make sure 'is typing' indicator disappears when leaving the chatroom

### DIFF
--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -907,7 +907,8 @@ export default ({
     },
     emitUserTypingEvent () {
       sbp('gi.actions/chatroom/user-typing-event', {
-        contractID: this.currentChatRoomId
+        contractID: this.currentChatRoomId,
+        innerSigningContractID: this.ourIdentityContractId
       }).catch(e => {
         console.error('Error emitting user typing event', e)
       })
@@ -918,7 +919,8 @@ export default ({
     },
     emitUserStopTypingEvent () {
       sbp('gi.actions/chatroom/user-stop-typing-event', {
-        contractID: this.currentChatRoomId
+        contractID: this.currentChatRoomId,
+        innerSigningContractID: this.ourIdentityContractId
       }).catch(e => {
         console.error('Error emitting user stopped typing event', e)
       })

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -380,6 +380,11 @@ export default ({
           this.focusOnTextArea()
         })
       }
+    },
+    currentChatRoomId () {
+      if (this.ephemeral.typingUsers.length) {
+        this.ephemeral.typingUsers = []
+      }
     }
   },
   created () {


### PR DESCRIPTION
closes #2859 

https://github.com/user-attachments/assets/87343a65-3ff5-4212-849b-7625c87e72d6

