### PR TITLE
Fix size calculations

### DIFF
--- a/backend/ownerSizeTotalWorker.js
+++ b/backend/ownerSizeTotalWorker.js
@@ -149,10 +149,27 @@ sbp('sbp/selectors/register', {
 
     // Map to store: ultimateOwnerID -> [totalDelta, Set<originalResourceIDs>]
     const ultimateOwners = new Map()
+    const orphansSet = new Set()
     // Phase 1: Find the ultimate owner for each resource and aggregate deltas.
     await Promise.all(deltaEntries.map(async ([contractID, delta]) => {
       // --- Potentially Slow Owner Lookup Loop ---
-      const ownerID = cachedUltimateOwnerMap.get(contractID) || await lookupUltimateOwner(contractID)
+      const cachedOwnerID = cachedUltimateOwnerMap.get(contractID)
+      const ownerID = cachedOwnerID || await lookupUltimateOwner(contractID)
+      // If the delta update is for an orphaned resource, it likely was
+      // deleted and needs special handling
+      if (!cachedOwnerID && ownerID === contractID) {
+        // Verify that the resource no longer exists
+        if (!(await sbp('chelonia.db/get', contractID))) {
+          // If so, add it back to `updatedSizeMap`, so that it gets processed
+          // later, when resource deletion manually sets `cachedOwnerID`
+          const current = updatedSizeMap.get(contractID) ?? 0
+          updatedSizeMap.set(contractID, current + delta)
+          // Deleted resources can't be processed from scratch, so add them to
+          // a set to later remove them from the temporary index.
+          orphansSet.add(contractID)
+          return
+        }
+      }
       cachedUltimateOwnerMap.delete(contractID)
       // Aggregate delta for the ultimate owner.
       const [val, ownedResourcesSet] = ultimateOwners.get(ownerID) || [0, new Set(ownerID)]
@@ -168,6 +185,7 @@ sbp('sbp/selectors/register', {
       // Remove the processed resource IDs from the persistent temporary index
       await removeFromTempIndex(Array.from(contributingResources))
     }))
+    await removeFromTempIndex(Array.from(orphansSet))
 
     // Reschedule the task for the next interval
     setTimeout(sbp, TASK_TIME_INTERVAL, 'backend/server/computeSizeTaskDeltas')

--- a/backend/routes.js
+++ b/backend/routes.js
@@ -278,7 +278,7 @@ route.POST('/event', {
         }
       }
       // Store size information
-      await sbp('backend/server/updateSize', deserializedHEAD.contractID, Buffer.byteLength(request.payload))
+      await sbp('backend/server/updateSize', deserializedHEAD.contractID, Buffer.byteLength(request.payload), deserializedHEAD.isFirstMessage && !credentials?.billableContractID ? deserializedHEAD.contractID : undefined)
     } catch (err) {
       console.error(err, chalk.bold.yellow(err.name))
       if (err.name === 'ChelErrorDBBadPreviousHEAD' || err.name === 'ChelErrorAlreadyProcessed') {

--- a/backend/server.js
+++ b/backend/server.js
@@ -306,11 +306,11 @@ sbp('sbp/selectors/register', {
     }
   },
   'backend/server/registerBillableEntity': appendToIndexFactory('_private_billable_entities'),
-  'backend/server/updateSize': function (resourceID: string, size: number) {
+  'backend/server/updateSize': function (resourceID: string, size: number, ultimateOwnerID: ?string) {
     const sizeKey = `_private_size_${resourceID}`
     return updateSize(resourceID, sizeKey, size).then(() => {
       // Because this is relevant key for size accounting, call updateSizeSideEffects
-      return ownerSizeTotalWorker?.rpcSbp('worker/updateSizeSideEffects', { resourceID, size })
+      return ownerSizeTotalWorker?.rpcSbp('worker/updateSizeSideEffects', { resourceID, size, ultimateOwnerID })
     })
   },
   'backend/server/updateContractFilesTotalSize': function (resourceID: string, size: number) {
@@ -374,7 +374,7 @@ sbp('sbp/selectors/register', {
 
     return sbp('chelonia/queueInvocation', cid, async () => {
       const owner = await sbp('chelonia.db/get', `_private_owner_${cid}`)
-      if (owner && !ultimateOwnerID) ultimateOwnerID = await lookupUltimateOwner(owner)
+      if (!ultimateOwnerID) ultimateOwnerID = await lookupUltimateOwner(cid)
       const rawManifest = await sbp('chelonia.db/get', cid)
       const size = await sbp('chelonia.db/get', `_private_size_${cid}`)
       // If running in a persistent queue, already deleted contract should not


### PR DESCRIPTION
Fix #2865 

The issue was a race condition that's best explained with an example.

Imagine there's an identity contract `alice` that owns a `group` group contract and then the `alice` contract gets deleted shortly after being created (which would also delete the `group` contract due to cascading).

Because delta updates are batched, there'll be size deltas for `alice` and `group` both for creation (positive size) and deletion (negative size).

Normally, the `group` events will be processed by adjusting the size of `alice`. However, since `group` has been deleted, the delta code will not find an owner and will set the size on `group` directly, mistaking it for an ultimate owner. Then, when `group` is deleted, the ultimate owner is set to `alice` (this information was passed on for correct attribution and was correct). Hence, there's a size discrepancy due to the initial confusion.

This PR addresses this by explicitly giving hints on contract creation to the worker about which contracts are ultimate owners, and by using this information to detect 'orphaned' contracts, i.e., deleted contracts for which we can't find an owner. In these cases, delta processing is deferred until a later execution time during which the actual ultimate owner is known (since this is given at contract deletion time).

This issue was introduced in #2852 precisely because of sending a delta to the ultimate owner, which due to the mismatch, would result in a negative size. However, I think #2852 only made this more likely to happen rather than introduce the issue, since the part where things went wrong (i.e., wrongly attributing the positive size to the wrong contract) was already present.