### PR TITLE
Close DB on exit

### DIFF
--- a/backend/DatabaseBackend.js
+++ b/backend/DatabaseBackend.js
@@ -4,9 +4,10 @@ export interface IDatabaseBackend {
   readData (key: string): Promise<Buffer | string | void>;
   writeData (key: string, value: Buffer | string): Promise<void>;
   deleteData (key: string): Promise<void>;
+  close (): Promise<void> | void;
 }
 
-const requiredMethodNames = ['init', 'clear', 'readData', 'writeData', 'deleteData']
+const requiredMethodNames = ['init', 'clear', 'readData', 'writeData', 'deleteData', 'close']
 
 export default class DatabaseBackend {
   constructor () {

--- a/backend/database-fs.js
+++ b/backend/database-fs.js
@@ -108,4 +108,6 @@ export default class FsBackend extends DatabaseBackend implements IDatabaseBacke
       throw e
     })
   }
+
+  close () {}
 }

--- a/backend/database-router.js
+++ b/backend/database-router.js
@@ -107,14 +107,18 @@ export default class RouterBackend extends DatabaseBackend implements IDatabaseB
   async clear (): Promise<void> {
     for (const backend of new Set(Object.values(this.backends))) {
       // $FlowFixMe[incompatible-use]
-      await backend.clear()
+      await backend.clear().catch(e => {
+        console.error(e, 'Error clearing DB')
+      })
     }
   }
 
   async close () {
     for (const backend of new Set(Object.values(this.backends))) {
       // $FlowFixMe[incompatible-use]
-      await backend.close()
+      await backend.close().catch(e => {
+        console.error(e, 'Error closing DB')
+      })
     }
   }
 }

--- a/backend/database-router.js
+++ b/backend/database-router.js
@@ -113,6 +113,7 @@ export default class RouterBackend extends DatabaseBackend implements IDatabaseB
 
   async close () {
     for (const backend of new Set(Object.values(this.backends))) {
+      // $FlowFixMe[incompatible-use]
       await backend.close()
     }
   }

--- a/backend/database-router.js
+++ b/backend/database-router.js
@@ -106,19 +106,27 @@ export default class RouterBackend extends DatabaseBackend implements IDatabaseB
 
   async clear (): Promise<void> {
     for (const backend of new Set(Object.values(this.backends))) {
-      // $FlowFixMe[incompatible-use]
-      await backend.clear().catch(e => {
-        console.error(e, 'Error clearing DB')
-      })
+      try {
+        // $FlowFixMe[incompatible-use]
+        await backend.clear()
+      } catch (e) {
+        // $FlowFixMe[incompatible-use]
+        const prefix = Object.entries(this.backends).find(([, b]) => b === backend)[0]
+        console.error(e, `Error clearing DB for prefix ${prefix}`)
+      }
     }
   }
 
   async close () {
     for (const backend of new Set(Object.values(this.backends))) {
-      // $FlowFixMe[incompatible-use]
-      await backend.close().catch(e => {
-        console.error(e, 'Error closing DB')
-      })
+      try {
+        // $FlowFixMe[incompatible-use]
+        await backend.close()
+      } catch (e) {
+        // $FlowFixMe[incompatible-use]
+        const prefix = Object.entries(this.backends).find(([, b]) => b === backend)[0]
+        console.error(e, `Error closing DB for prefix ${prefix}`)
+      }
     }
   }
 }

--- a/backend/database-router.js
+++ b/backend/database-router.js
@@ -110,4 +110,10 @@ export default class RouterBackend extends DatabaseBackend implements IDatabaseB
       await backend.clear()
     }
   }
+
+  async close () {
+    for (const backend of new Set(Object.values(this.backends))) {
+      await backend.close()
+    }
+  }
 }

--- a/backend/database-sqlite.js
+++ b/backend/database-sqlite.js
@@ -36,7 +36,6 @@ export default class SqliteBackend extends DatabaseBackend implements IDatabaseB
       throw new Error(`The ${filename} SQLite database is already open.`)
     }
     this.db = new Database(join(dataFolder, filename))
-    process.on('exit', () => this.db.close())
     this.run('CREATE TABLE IF NOT EXISTS Data(key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)')
     console.info(`Connected to the ${filename} SQLite database.`)
     this.readStatement = this.db.prepare('SELECT value FROM Data WHERE key = ?')
@@ -63,5 +62,9 @@ export default class SqliteBackend extends DatabaseBackend implements IDatabaseB
 
   async deleteData (key: string) {
     await this.deleteStatement.run(key)
+  }
+
+  close () {
+    this.db.close()
   }
 }

--- a/backend/database-sqlite.js
+++ b/backend/database-sqlite.js
@@ -36,6 +36,7 @@ export default class SqliteBackend extends DatabaseBackend implements IDatabaseB
       throw new Error(`The ${filename} SQLite database is already open.`)
     }
     this.db = new Database(join(dataFolder, filename))
+    process.on('exit', () => this.db.close())
     this.run('CREATE TABLE IF NOT EXISTS Data(key TEXT NOT NULL PRIMARY KEY, value TEXT NOT NULL)')
     console.info(`Connected to the ${filename} SQLite database.`)
     this.readStatement = this.db.prepare('SELECT value FROM Data WHERE key = ?')

--- a/backend/database.js
+++ b/backend/database.js
@@ -237,6 +237,9 @@ export const initDB = async ({ skipDbPreloading }: { skipDbPreloading?: boolean 
     // Destructuring is safe because these methods have been bound using rebindMethods().
     const { init, readData, writeData, deleteData, close } = new Ctor(options[persistence])
     await init()
+    process.on('exit', () => {
+      close().catch(e => console.error(e, 'Error closing DB'))
+    })
 
     // https://github.com/isaacs/node-lru-cache#usage
     const cache = new LRU({
@@ -301,9 +304,6 @@ export const initDB = async ({ skipDbPreloading }: { skipDbPreloading?: boolean 
     })
     sbp('sbp/selectors/lock', ['chelonia.db/get', 'chelonia.db/set', 'chelonia.db/delete'])
   }
-  process.on('exit', () => {
-    close.catch(e => console.error(e, 'Error closing DB'))
-  })
   if (skipDbPreloading) return
   // TODO: Update this to only run when persistence is disabled when `chel deploy` can target SQLite.
   if (persistence !== 'fs' || options.fs.dirname !== dbRootPath) {

--- a/backend/events.js
+++ b/backend/events.js
@@ -1,1 +1,2 @@
+export const SERVER_EXITING = 'server-exiting'
 export const SERVER_RUNNING = 'server-running'

--- a/backend/index.js
+++ b/backend/index.js
@@ -3,7 +3,7 @@
 import sbp from '@sbp/sbp'
 import '@sbp/okturtles.data'
 import '@sbp/okturtles.events'
-import { SERVER_RUNNING } from './events.js'
+import { SERVER_EXITING, SERVER_RUNNING } from './events.js'
 import { PUBSUB_INSTANCE } from './instance-keys.js'
 import chalk from 'chalk'
 import './logger.js'
@@ -39,34 +39,28 @@ module.exports = (new Promise((resolve, reject) => {
   require('./server.js')
 }): Promise<void>)
 
-const shutdownFn = function (message) {
+sbp('okTurtles.events/once', SERVER_EXITING, () => {
   sbp('okTurtles.data/apply', PUBSUB_INSTANCE, function (pubsub) {
-    console.info('message received in child, shutting down...', message)
-    pubsub.on('close', async function () {
-      try {
-        await sbp('backend/server/stop')
-        console.info('Hapi server down')
-        // await db.stop()
-        // console.info('database stopped')
-        process.send({}) // tell grunt we've successfully shutdown the server
-        process.nextTick(() => process.exit(0)) // triple-check we quit :P
-      } catch (err) {
-        console.error(err, 'Error during shutdown')
-        process.exit(1)
-      }
+    sbp('okTurtles.eventQueue/queueEvent', SERVER_EXITING, () => {
+      return new Promise((resolve) => {
+        pubsub.on('close', async function () {
+          try {
+            await sbp('backend/server/stop')
+            console.info('Hapi server down')
+          } catch (err) {
+            console.error(err, 'Error during shutdown')
+          } finally {
+            resolve()
+          }
+        })
+        pubsub.close()
+        // Since `ws` v8.0, `WebSocketServer.close()` no longer closes remaining connections.
+        // See https://github.com/websockets/ws/commit/df7de574a07115e2321fdb5fc9b2d0fea55d27e8
+        pubsub.clients.forEach(client => client.terminate())
+      })
     })
-    pubsub.close()
-    // Since `ws` v8.0, `WebSocketServer.close()` no longer closes remaining connections.
-    // See https://github.com/websockets/ws/commit/df7de574a07115e2321fdb5fc9b2d0fea55d27e8
-    pubsub.clients.forEach(client => client.terminate())
   })
-}
-
-// sent by nodemon
-process.on('SIGUSR2', shutdownFn)
-
-// when spawned via grunt, listen for message to cleanly shutdown and relinquish port
-process.on('message', shutdownFn)
+})
 
 process.on('uncaughtException', (err) => {
   console.error(err, '[server] Unhandled exception')
@@ -78,5 +72,43 @@ process.on('unhandledRejection', (reason, p) => {
   process.exit(1)
 })
 
+const exit = (code: number) => {
+  // Make sure `process.exit` is called after all existing SERVER_EXITING
+  // handlers. This is because once `process.exit` is called, all handlers
+  // must be synchronous.
+  sbp('okTurtles.events/once', SERVER_EXITING, () => {
+    // In case there are asynchronous events, wait for them to finish
+    sbp('okTurtles.eventQueue/queueEvent', SERVER_EXITING, () => {
+      process.send({}) // tell grunt we've successfully shutdown the server
+      process.nextTick(() => process.exit(code)) // triple-check we quit :P
+    })
+  })
+  sbp('okTurtles.events/emit', SERVER_EXITING)
+}
+
+const handleSignal = (signal: string, code: number) => {
+  process.on(signal, () => {
+    console.error(`Exiting upon receiving ${signal} (${code})`)
+    // Exit codes follow the 128 + signal code convention.
+    // See <https://tldp.org/LDP/abs/html/exitcodes.html>
+    exit(128 + code)
+  })
+}
+
+// Codes from <signal.h>
+[
+  ['SIGHUP', 1],
+  ['SIGINT', 2],
+  ['SIGQUIT', 3],
+  ['SIGTERM', 15],
+  ['SIGUSR1', 10],
+  ['SIGUSR2', 11]
+].forEach(([signal, code]) => handleSignal(signal, code))
+
 // TODO: should we use Bluebird to handle swallowed errors
 // http://jamesknelson.com/are-es6-promises-swallowing-your-errors/
+// when spawned via grunt, listen for message to cleanly shutdown and relinquish port
+process.on('message', (message) => {
+  console.info('message received in child, shutting down...', message)
+  exit(0)
+})

--- a/backend/index.js
+++ b/backend/index.js
@@ -96,7 +96,7 @@ const handleSignal = (signal: string, code: number) => {
 }
 
 // Codes from <signal.h>
-[
+;[
   ['SIGHUP', 1],
   ['SIGINT', 2],
   ['SIGQUIT', 3],

--- a/backend/server.js
+++ b/backend/server.js
@@ -684,3 +684,20 @@ sbp('okTurtles.data/set', PUBSUB_INSTANCE, createServer(hapi.listener, {
     // Repeat every 1 hour
   }, 1 * 60 * 60 * 1000)
 })()
+
+const handleSignal = (signal: string, code: number) => {
+  process.on(signal, () => {
+    console.error(`Exiting upon receiving ${signal} (${code})`)
+    process.exit(128 + code)
+  })
+}
+
+// Codes from <signal.h>
+[
+  ['SIGHUP', 1],
+  ['SIGINT', 2],
+  ['SIGQUIT', 3],
+  ['SIGTERM', 15],
+  ['SIGUSR1', 10],
+  ['SIGUSR2', 11]
+].forEach(([signal, code]) => handleSignal(signal, code))

--- a/backend/server.js
+++ b/backend/server.js
@@ -668,22 +668,3 @@ sbp('okTurtles.data/set', PUBSUB_INSTANCE, createServer(hapi.listener, {
     // Repeat every 1 hour
   }, 1 * 60 * 60 * 1000)
 })()
-
-const handleSignal = (signal: string, code: number) => {
-  process.on(signal, () => {
-    console.error(`Exiting upon receiving ${signal} (${code})`)
-    // Exit codes follow the 128 + signal code convention.
-    // See <https://tldp.org/LDP/abs/html/exitcodes.html>
-    process.exit(128 + code)
-  })
-}
-
-// Codes from <signal.h>
-[
-  ['SIGHUP', 1],
-  ['SIGINT', 2],
-  ['SIGQUIT', 3],
-  ['SIGTERM', 15],
-  ['SIGUSR1', 10],
-  ['SIGUSR2', 11]
-].forEach(([signal, code]) => handleSignal(signal, code))

--- a/backend/server.js
+++ b/backend/server.js
@@ -106,22 +106,6 @@ const creditsWorker = process.env.CHELONIA_ARCHIVE_MODE || !CREDITS_WORKER_TASK_
   ? undefined
   : createWorker(join(__dirname, 'creditsWorker.js'))
 
-// Node.js version 18 and lower don't have global.crypto defined
-// by default
-if (
-  !('crypto' in global) &&
-  typeof require === 'function'
-) {
-  const { webcrypto } = require('crypto')
-  if (webcrypto) {
-    Object.defineProperty(global, 'crypto', {
-      'enumerable': true,
-      'configurable': true,
-      'get': () => webcrypto
-    })
-  }
-}
-
 const { CONTRACTS_VERSION, GI_VERSION } = process.env
 
 const hapi = new Hapi.Server({

--- a/backend/server.js
+++ b/backend/server.js
@@ -688,6 +688,8 @@ sbp('okTurtles.data/set', PUBSUB_INSTANCE, createServer(hapi.listener, {
 const handleSignal = (signal: string, code: number) => {
   process.on(signal, () => {
     console.error(`Exiting upon receiving ${signal} (${code})`)
+    // Exit codes follow the 128 + signal code convention.
+    // See <https://tldp.org/LDP/abs/html/exitcodes.html>
     process.exit(128 + code)
   })
 }


### PR DESCRIPTION
Closes #2884 

This closes the DB when the process is terminated. However, it likely isn't sufficient alone to solve the issue, as it seems like the process running in production is being forcefully terminated by Docker, due to `bash` not passing through signals to subprocesses.

To fully address this issue, the way the Docker container is built and used should be modified too. The most immediate course of action is using `exec` to invoke the final command in `entrypoint.sh`. This will unfortunately result in some duplication, since the `run` subroutine can't be called with `exec`. A more comprehensive approach is removing `entrypoint.sh` and the need for it entirely, but that's a separate issue.

This PR also adds logging when the process receives a signal that causes it to terminate, which should be helpful for debugging and also to verify if changes made to `entrypoint.sh` (as discussed) actually successfully pass down termination signals.