### PR TITLE
Initial fix. Closes #2898.

### DIFF
--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1069,7 +1069,7 @@ export default (sbp('sbp/selectors/register', {
   // This function is called from 'state/vuex/postUpgradeVerification'
   // Group (foreign) CSKs that were encrypted with a CEK will be removed and
   // re-added being encrypted with the PEK. This allows other group members
-  // to see which foreign keys exist in our identity contract, which eliminates
+  // to see which foreign group CSK keys exist in our identity contract, which eliminates
   // the need for 'guessing' and resolves the issue of created DM chatrooms
   // not showing up
     const state = sbp('chelonia/rootState')

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1150,7 +1150,7 @@ export default (sbp('sbp/selectors/register', {
 
         const updatedGroupFKTuple = verifyUpdates()
         if (updatedGroupFKTuple) {
-          groupFKTuple = updatedGroupFKTuple
+          groupFKTuple = (updatedGroupFKTuple: [string, string, string][])
         }
 
         if (groupFKTuple.length === 0) return

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1150,7 +1150,7 @@ export default (sbp('sbp/selectors/register', {
 
         const updatedGroupFKTuple = verifyUpdates()
         if (updatedGroupFKTuple) {
-          groupFKTuple = (updatedGroupFKTuple: [string, string, string][])
+          groupFKTuple = ((updatedGroupFKTuple: any): [string, string, string][])
         }
 
         if (groupFKTuple.length === 0) return

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -626,7 +626,7 @@ export default (sbp('sbp/selectors/register', {
         contractID: groupID,
         contractName: rootState.contracts[groupID].type,
         data: encryptedOutgoingData(groupID, CEKid, {
-          contractID: groupID,
+          contractID,
           // $FlowFixMe
           keys: Object.values(newKeys).map(([, newKey, newId]: [any, Key, string]) => ({
             id: newId,

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1108,7 +1108,7 @@ export default (sbp('sbp/selectors/register', {
         // Then, add it back, using the PEK for encryption
         [
           'chelonia/out/keyAdd', {
-            skipDuplicateKeyCheck: true,
+            skipExistingKeyCheck: true,
             data: groupFKTuple.map(([groupID, oldKeyId, newKeyId]) => {
               const oldKey = state[contractID]._vm.authorizedKeys[oldKeyId]
               const foreignContractState = state[groupID]

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1116,7 +1116,10 @@ export default (sbp('sbp/selectors/register', {
               return null
             }
             // Check that the key we're replacing is valid
-            if (!state[contractID]._vm.authorizedKeys[oldKeyId]) return false
+            if (!state[contractID]._vm.authorizedKeys[oldKeyId]) {
+              modified = true
+              return null
+            }
             // The old key ID may have been rotated right before this function was
             // called
             if (state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1084,133 +1084,146 @@ export default (sbp('sbp/selectors/register', {
   ...encryptedAction('gi.actions/identity/saveFileDeleteToken', L('Failed to save delete tokens for the attachments.')),
   ...encryptedAction('gi.actions/identity/removeFileDeleteToken', L('Failed to remove delete tokens for the attachments.')),
   ...encryptedAction('gi.actions/identity/setGroupAttributes', L('Failed to set group attributes.')),
-  'gi.actions/identity/upgradeGroupForeignCSKs': (contractID: string, groupFKTuple: [string, string, string][], maxAttemptCount = 5) => {
-    if (maxAttemptCount < 1) {
-      console.error('[gi.actions/identity/upgradeGroupForeignCSK] Max attempts exceeded', contractID, groupFKTuple)
-    }
-    // See issue #2898
-    // This function is called from 'state/vuex/postUpgradeVerification'
-    // Group (foreign) CSKs that were encrypted with a CEK will be removed and
-    // re-added being encrypted with the PEK. This allows other group members
-    // to see which foreign group CSK keys exist in our identity contract, which eliminates
-    // the need for 'guessing' and resolves the issue of created DM chatrooms
-    // not showing up
-    const state = sbp('chelonia/rootState')
-    const CEKid = sbp('chelonia/contract/currentKeyIdByName', contractID, 'cek')
-    const PEKid = sbp('chelonia/contract/currentKeyIdByName', contractID, 'pek')
+  'gi.actions/identity/upgradeGroupForeignCSKs': async (contractID: string, groupFKTuple: [string, string, string][], maxAttemptCount = 5) => {
+    for (; maxAttemptCount > 0; --maxAttemptCount) {
+      try {
+        if (maxAttemptCount < 1) {
+          console.error('[gi.actions/identity/upgradeGroupForeignCSK] Max attempts exceeded', contractID, groupFKTuple)
+        }
+        // See issue #2898
+        // This function is called from 'state/vuex/postUpgradeVerification'
+        // Group (foreign) CSKs that were encrypted with a CEK will be removed and
+        // re-added being encrypted with the PEK. This allows other group members
+        // to see which foreign group CSK keys exist in our identity contract, which eliminates
+        // the need for 'guessing' and resolves the issue of created DM chatrooms
+        // not showing up
+        const state = sbp('chelonia/rootState')
+        const CEKid = sbp('chelonia/contract/currentKeyIdByName', contractID, 'cek')
+        const PEKid = sbp('chelonia/contract/currentKeyIdByName', contractID, 'pek')
 
-    // Sanity check to avoid unnecessary updates
-    groupFKTuple = groupFKTuple.filter((tuple) => {
-      let [groupID, oldKeyId, newKeyId] = tuple
-      // Check that we're group members
-      if (!state[contractID].groups[groupID] || state[contractID].groups[groupID].hasLeft) return false
-      // Check that the key we're replacing is valid
-      if (!state[contractID]._vm.authorizedKeys[oldKeyId]) return false
-      if (state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {
-        // The old key ID may have been rotated right before this function was
-        // called
-        tuple[1] = sbp('chelonia/contract/currentKeyIdByName', contractID, state[contractID]._vm.authorizedKeys[oldKeyId])
-        if (!tuple[1]) return false
-        oldKeyId = tuple[1]
-      }
-      // Check that the encryption key used originally was the CEK
-      if (!state[contractID]._vm.authorizedKeys[oldKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[oldKeyId]._private]?.name !== 'cek') return false
-
-      const updatedGroupCskId = sbp('chelonia/contract/currentKeyIdByName', groupID, 'csk')
-      if (newKeyId !== updatedGroupCskId) {
-        tuple[2] = updatedGroupCskId
-        newKeyId = updatedGroupCskId
-      }
-      // If the key ID is the same (should be in most cases if keys are being
-      // automatically rotated), proceed. We want it encrypted with the PEK
-      if (updatedGroupCskId === oldKeyId) return true
-      // If automatic key roation didn't work for some reason, we still want to
-      // remove the old key and add the new one using CEK encryption
-      if (!state[contractID]._vm.authorizedKeys[newKeyId]) return true
-      // If we already have the new key _and_ it is already encrypted with the
-      // PEK, then there's nothing to do.
-      if (!state[contractID]._vm.authorizedKeys[newKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[newKeyId]._private]?.name === 'pek') return false
-
-      return true
-    })
-
-    if (groupFKTuple.length === 0) return
-
-    // Note: We don't use OP_KEY_UPDATE
-    // OP_KEY_UPDATE works on _existing_ keys. The goal of this change
-    // is for others to be able to read the group CSKs in our contracts, and,
-    // for them, the initial OP_KEY_ADD is not visible. Hence, OP_KEY_DEL + OP_KEY_ADD
-    return sbp('chelonia/out/atomic', {
-      contractID,
-      contractName: 'gi.contracts/identity',
-      signingKeyId: sbp('chelonia/contract/suitableSigningKey', contractID, [SPMessage.OP_KEY_ADD], ['sig']),
-      beforeRequest: (newEntry) => {
-        // There still is a possibility that keys in the contract have changed
-        // while we're in the process of writing to it. We want to be careful
-        // with this operation and only send correct updates, or else the state
-        // will be broken.
-        // It's currently not possible to change an SPMessage after it's
-        // constructed, so if we detect any information that shouldn't be there,
-        // we call this action again (to produce a corrected messge) and abort
-        // the current call.
-        const canProceed = groupFKTuple.every(([groupID, oldKeyId, newKeyId]) => {
+        // Sanity check to avoid unnecessary updates
+        groupFKTuple = groupFKTuple.filter((tuple) => {
+          let [groupID, oldKeyId, newKeyId] = tuple
           // Check that we're group members
           if (!state[contractID].groups[groupID] || state[contractID].groups[groupID].hasLeft) return false
           // Check that the key we're replacing is valid
-          if (!state[contractID]._vm.authorizedKeys[oldKeyId] && state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {
-            return false
+          if (!state[contractID]._vm.authorizedKeys[oldKeyId]) return false
+          if (state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {
+            // The old key ID may have been rotated right before this function was
+            // called
+            tuple[1] = sbp('chelonia/contract/currentKeyIdByName', contractID, state[contractID]._vm.authorizedKeys[oldKeyId])
+            if (!tuple[1]) return false
+            oldKeyId = tuple[1]
           }
           // Check that the encryption key used originally was the CEK
           if (!state[contractID]._vm.authorizedKeys[oldKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[oldKeyId]._private]?.name !== 'cek') return false
 
-          // Check that the group CSK hasn't been rotated
           const updatedGroupCskId = sbp('chelonia/contract/currentKeyIdByName', groupID, 'csk')
-          if (newKeyId !== updatedGroupCskId) return false
-
-          // Check that newKeyId hasn't been added yet
-          if (state[contractID]._vm.authorizedKeys[newKeyId] && newKeyId !== oldKeyId) return false
+          if (newKeyId !== updatedGroupCskId) {
+            tuple[2] = updatedGroupCskId
+            newKeyId = updatedGroupCskId
+          }
+          // If the key ID is the same (should be in most cases if keys are being
+          // automatically rotated), proceed. We want it encrypted with the PEK
+          if (updatedGroupCskId === oldKeyId) return true
+          // If automatic key roation didn't work for some reason, we still want to
+          // remove the old key and add the new one using CEK encryption
+          if (!state[contractID]._vm.authorizedKeys[newKeyId]) return true
+          // If we already have the new key _and_ it is already encrypted with the
+          // PEK, then there's nothing to do.
+          if (!state[contractID]._vm.authorizedKeys[newKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[newKeyId]._private]?.name === 'pek') return false
 
           return true
         })
-        if (!canProceed) {
-          setTimeout(() => {
-            sbp('gi.actions/identity/upgradeGroupForeignCSKs', contractID, groupFKTuple, maxAttemptCount - 1).catch((e) => {
-              console.error('[gi.actions/identity/upgradeGroupForeignCSKs] Error', contractID, groupFKTuple, e)
-            })
-          }, 200)
-          throw new Error('gi.actions/identity/upgradeGroupForeignCSKs: Unable to proceed as data changed.')
-        }
-      },
-      data: [
-        // First, delete keys that were encrypted using the CEK
-        [
-          'chelonia/out/keyDel', {
-            data: groupFKTuple.map(([, oldKeyId]) => encryptedOutgoingData(contractID, CEKid, oldKeyId))
-          }
-        ],
-        // Then, add it back, using the PEK for encryption
-        [
-          'chelonia/out/keyAdd', {
-            skipExistingKeyCheck: true,
-            data: groupFKTuple.map(([groupID, oldKeyId, newKeyId]) => {
-              const oldKey = state[contractID]._vm.authorizedKeys[oldKeyId]
-              const foreignContractState = state[groupID]
-              return encryptedOutgoingData(contractID, PEKid, {
-                foreignKey: `shelter:${encodeURIComponent(groupID)}?keyName=${encodeURIComponent(foreignContractState._vm.authorizedKeys[newKeyId].name)}`,
-                id: newKeyId,
-                data: foreignContractState._vm.authorizedKeys[newKeyId].data,
-                permissions: oldKey.permissions,
-                allowedActions: oldKey.allowedActions,
-                purpose: oldKey.purpose,
-                ringLevel: oldKey.ringLevel,
-                // Intentionally using the old name in the new key to preserve
-                // continuity
-                name: oldKey.name
+
+        console.error('@@@@@upgradeGroupForeignCSKs', groupFKTuple)
+        if (groupFKTuple.length === 0) return
+
+        // Note: We don't use OP_KEY_UPDATE
+        // OP_KEY_UPDATE works on _existing_ keys. The goal of this change
+        // is for others to be able to read the group CSKs in our contracts, and,
+        // for them, the initial OP_KEY_ADD is not visible. Hence, OP_KEY_DEL + OP_KEY_ADD
+        return await sbp('chelonia/out/atomic', {
+          contractID,
+          contractName: 'gi.contracts/identity',
+          signingKeyId: sbp('chelonia/contract/suitableSigningKey', contractID, [SPMessage.OP_KEY_ADD], ['sig']),
+          publishOptions: {
+            rawRecreate: true
+          },
+          hooks: {
+            beforeRequest: (newEntry) => {
+              // There still is a possibility that keys in the contract have changed
+              // while we're in the process of writing to it. We want to be careful
+              // with this operation and only send correct updates, or else the state
+              // will be broken.
+              // It's currently not possible to change an SPMessage after it's
+              // constructed, so if we detect any information that shouldn't be there,
+              // we call this action again (to produce a corrected messge) and abort
+              // the current call.
+              const canProceed = groupFKTuple.every(([groupID, oldKeyId, newKeyId]) => {
+                // Check that we're group members
+                if (!state[contractID].groups[groupID] || state[contractID].groups[groupID].hasLeft) return false
+                // Check that the key we're replacing is valid
+                if (!state[contractID]._vm.authorizedKeys[oldKeyId] && state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {
+                  return false
+                }
+                // Check that the encryption key used originally was the CEK
+                if (!state[contractID]._vm.authorizedKeys[oldKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[oldKeyId]._private]?.name !== 'cek') return false
+
+                // Check that the group CSK hasn't been rotated
+                const updatedGroupCskId = sbp('chelonia/contract/currentKeyIdByName', groupID, 'csk')
+                if (newKeyId !== updatedGroupCskId) return false
+
+                // Check that newKeyId hasn't been added yet
+                if (state[contractID]._vm.authorizedKeys[newKeyId] && newKeyId !== oldKeyId) return false
+
+                return true
               })
-            })
-          }
-        ]
-      ]
-    })
+              if (!canProceed) {
+                setTimeout(() => {
+                  sbp('gi.actions/identity/upgradeGroupForeignCSKs', contractID, groupFKTuple, maxAttemptCount - 1).catch((e) => {
+                    console.error('[gi.actions/identity/upgradeGroupForeignCSKs] Error', contractID, groupFKTuple, e)
+                  })
+                }, 200)
+                throw new Error('gi.actions/identity/upgradeGroupForeignCSKs: Unable to proceed as data changed.')
+              }
+              console.error('@@@@@@ upgradeGroupForeignCSKs raw', newEntry)
+            }
+          },
+          data: [
+            // First, delete keys that were encrypted using the CEK
+            [
+              'chelonia/out/keyDel', {
+                data: groupFKTuple.map(([, oldKeyId]) => encryptedOutgoingData(contractID, CEKid, oldKeyId))
+              }
+            ],
+            // Then, add it back, using the PEK for encryption
+            [
+              'chelonia/out/keyAdd', {
+                skipExistingKeyCheck: true,
+                data: groupFKTuple.map(([groupID, oldKeyId, newKeyId]) => {
+                  const oldKey = state[contractID]._vm.authorizedKeys[oldKeyId]
+                  const foreignContractState = state[groupID]
+                  return encryptedOutgoingData(contractID, PEKid, {
+                    foreignKey: `shelter:${encodeURIComponent(groupID)}?keyName=${encodeURIComponent(foreignContractState._vm.authorizedKeys[newKeyId].name)}`,
+                    id: newKeyId,
+                    data: foreignContractState._vm.authorizedKeys[newKeyId].data,
+                    permissions: oldKey.permissions,
+                    allowedActions: oldKey.allowedActions,
+                    purpose: oldKey.purpose,
+                    ringLevel: oldKey.ringLevel,
+                    // Intentionally using the old name in the new key to preserve
+                    // continuity
+                    name: oldKey.name
+                  })
+                })
+              }
+            ]
+          ]
+        })
+      } catch (e) {
+        console.warn('[gi.actions/identity/upgradeGroupForeignCSKs] Error on attempted send', contractID, groupFKTuple, maxAttemptCount)
+      }
+    }
   }
 }): string[])

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -1085,58 +1085,74 @@ export default (sbp('sbp/selectors/register', {
   ...encryptedAction('gi.actions/identity/removeFileDeleteToken', L('Failed to remove delete tokens for the attachments.')),
   ...encryptedAction('gi.actions/identity/setGroupAttributes', L('Failed to set group attributes.')),
   'gi.actions/identity/upgradeGroupForeignCSKs': async (contractID: string, groupFKTuple: [string, string, string][], maxAttemptCount = 5) => {
+    // See issue #2898
+    // This function is called from 'state/vuex/postUpgradeVerification'
+    // Group (foreign) CSKs that were encrypted with a CEK will be removed and
+    // re-added being encrypted with the PEK. This allows other group members
+    // to see which foreign group CSK keys exist in our identity contract, which eliminates
+    // the need for 'guessing' and resolves the issue of created DM chatrooms
+    // not showing up
     for (; maxAttemptCount > 0; --maxAttemptCount) {
       try {
         if (maxAttemptCount < 1) {
           console.error('[gi.actions/identity/upgradeGroupForeignCSK] Max attempts exceeded', contractID, groupFKTuple)
         }
-        // See issue #2898
-        // This function is called from 'state/vuex/postUpgradeVerification'
-        // Group (foreign) CSKs that were encrypted with a CEK will be removed and
-        // re-added being encrypted with the PEK. This allows other group members
-        // to see which foreign group CSK keys exist in our identity contract, which eliminates
-        // the need for 'guessing' and resolves the issue of created DM chatrooms
-        // not showing up
         const state = sbp('chelonia/rootState')
         const CEKid = sbp('chelonia/contract/currentKeyIdByName', contractID, 'cek')
         const PEKid = sbp('chelonia/contract/currentKeyIdByName', contractID, 'pek')
 
-        // Sanity check to avoid unnecessary updates
-        groupFKTuple = groupFKTuple.filter((tuple) => {
-          let [groupID, oldKeyId, newKeyId] = tuple
-          // Check that we're group members
-          if (!state[contractID].groups[groupID] || state[contractID].groups[groupID].hasLeft) return false
-          // Check that the key we're replacing is valid
-          if (!state[contractID]._vm.authorizedKeys[oldKeyId]) return false
-          if (state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {
+        await Promise.all(groupFKTuple.map(([groupID]) =>
+          sbp('chelonia/contract/wait', groupID)
+        ))
+
+        const verifyUpdates = () => {
+          let modified = false
+
+          const updatedGroupFKTuple = groupFKTuple.map((tuple) => {
+            let [groupID, oldKeyId, newKeyId] = tuple
+            // Check that we're group members
+            if (!state[contractID].groups[groupID] || state[contractID].groups[groupID].hasLeft) {
+              modified = true
+              return null
+            }
+            // Check that the key we're replacing is valid
+            if (!state[contractID]._vm.authorizedKeys[oldKeyId]) return false
             // The old key ID may have been rotated right before this function was
             // called
-            tuple[1] = sbp('chelonia/contract/currentKeyIdByName', contractID, state[contractID]._vm.authorizedKeys[oldKeyId])
-            if (!tuple[1]) return false
-            oldKeyId = tuple[1]
-          }
-          // Check that the encryption key used originally was the CEK
-          if (!state[contractID]._vm.authorizedKeys[oldKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[oldKeyId]._private]?.name !== 'cek') return false
+            if (state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {
+              oldKeyId = sbp('chelonia/contract/currentKeyIdByName', contractID, state[contractID]._vm.authorizedKeys[oldKeyId])
+            }
+            // Check that the encryption key used originally was the CEK
+            if (!state[contractID]._vm.authorizedKeys[oldKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[oldKeyId]._private]?.name !== 'cek') {
+              modified = true
+              return null
+            }
 
-          const updatedGroupCskId = sbp('chelonia/contract/currentKeyIdByName', groupID, 'csk')
-          if (newKeyId !== updatedGroupCskId) {
-            tuple[2] = updatedGroupCskId
-            newKeyId = updatedGroupCskId
-          }
-          // If the key ID is the same (should be in most cases if keys are being
-          // automatically rotated), proceed. We want it encrypted with the PEK
-          if (updatedGroupCskId === oldKeyId) return true
-          // If automatic key roation didn't work for some reason, we still want to
-          // remove the old key and add the new one using CEK encryption
-          if (!state[contractID]._vm.authorizedKeys[newKeyId]) return true
-          // If we already have the new key _and_ it is already encrypted with the
-          // PEK, then there's nothing to do.
-          if (!state[contractID]._vm.authorizedKeys[newKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[newKeyId]._private]?.name === 'pek') return false
+            // Update the group CSK to the latest
+            const updatedGroupCskId = sbp('chelonia/contract/currentKeyIdByName', groupID, 'csk')
+            if (newKeyId !== updatedGroupCskId) {
+              modified = true
+              newKeyId = updatedGroupCskId
+            }
 
-          return true
-        })
+            // If we already have the new key _and_ it is already encrypted with the
+            // PEK, then there's nothing to do.
+            if (!state[contractID]._vm.authorizedKeys[newKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[newKeyId]._private]?.name === 'pek') {
+              modified = true
+              return null
+            }
 
-        console.error('@@@@@upgradeGroupForeignCSKs', groupFKTuple)
+            return [groupID, oldKeyId, newKeyId]
+          }).filter(Boolean)
+
+          return modified ? updatedGroupFKTuple : null
+        }
+
+        const updatedGroupFKTuple = verifyUpdates()
+        if (updatedGroupFKTuple) {
+          groupFKTuple = updatedGroupFKTuple
+        }
+
         if (groupFKTuple.length === 0) return
 
         // Note: We don't use OP_KEY_UPDATE
@@ -1148,7 +1164,7 @@ export default (sbp('sbp/selectors/register', {
           contractName: 'gi.contracts/identity',
           signingKeyId: sbp('chelonia/contract/suitableSigningKey', contractID, [SPMessage.OP_KEY_ADD], ['sig']),
           publishOptions: {
-            rawRecreate: true
+            disableAutoDedup: true
           },
           hooks: {
             beforeRequest: (newEntry) => {
@@ -1160,34 +1176,15 @@ export default (sbp('sbp/selectors/register', {
               // constructed, so if we detect any information that shouldn't be there,
               // we call this action again (to produce a corrected messge) and abort
               // the current call.
-              const canProceed = groupFKTuple.every(([groupID, oldKeyId, newKeyId]) => {
-                // Check that we're group members
-                if (!state[contractID].groups[groupID] || state[contractID].groups[groupID].hasLeft) return false
-                // Check that the key we're replacing is valid
-                if (!state[contractID]._vm.authorizedKeys[oldKeyId] && state[contractID]._vm.authorizedKeys[oldKeyId]._notAfterHeight != null) {
-                  return false
-                }
-                // Check that the encryption key used originally was the CEK
-                if (!state[contractID]._vm.authorizedKeys[oldKeyId]._private || state[contractID]._vm.authorizedKeys[state[contractID]._vm.authorizedKeys[oldKeyId]._private]?.name !== 'cek') return false
-
-                // Check that the group CSK hasn't been rotated
-                const updatedGroupCskId = sbp('chelonia/contract/currentKeyIdByName', groupID, 'csk')
-                if (newKeyId !== updatedGroupCskId) return false
-
-                // Check that newKeyId hasn't been added yet
-                if (state[contractID]._vm.authorizedKeys[newKeyId] && newKeyId !== oldKeyId) return false
-
-                return true
-              })
-              if (!canProceed) {
+              const updatedGroupFKTuple = verifyUpdates()
+              if (updatedGroupFKTuple) {
                 setTimeout(() => {
-                  sbp('gi.actions/identity/upgradeGroupForeignCSKs', contractID, groupFKTuple, maxAttemptCount - 1).catch((e) => {
+                  sbp('gi.actions/identity/upgradeGroupForeignCSKs', contractID, updatedGroupFKTuple, maxAttemptCount - 1).catch((e) => {
                     console.error('[gi.actions/identity/upgradeGroupForeignCSKs] Error', contractID, groupFKTuple, e)
                   })
                 }, 200)
                 throw new Error('gi.actions/identity/upgradeGroupForeignCSKs: Unable to proceed as data changed.')
               }
-              console.error('@@@@@@ upgradeGroupForeignCSKs raw', newEntry)
             }
           },
           data: [

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -756,7 +756,17 @@ export default (sbp('sbp/selectors/register', {
         // For now, we assume that we're messaging someone with whom we
         // share a group
         signingKeyId: await sbp('chelonia/contract/suitableSigningKey', partnerIDs[index], [SPMessage.OP_ACTION_ENCRYPTED], ['sig'], undefined, ['gi.contracts/identity/joinDirectMessage']),
+        // See issue #2898. This works as follows:
+        // If using a new version of the app which uses the PEK to encrypt the
+        // foreign group CSK so that it's visible to members, suitableSigningKey
+        // will return a key ID.
+        // If using an older version of the app, in which the foreign group CSK
+        // isn't visible, suitableSigningKey will return undefined.
+        // innerSigningKeyId takes precedence over innerSigningContractID, and
+        // an inner signing key will be used as a fallback
+        // (from innerSigningContractID) if innerSigningKeyId is undefined
         innerSigningKeyId: await sbp('chelonia/contract/suitableSigningKey', partnerIDs[index], [SPMessage.OP_ACTION_ENCRYPTED + '#inner'], ['sig'], undefined, ['gi.contracts/identity/joinDirectMessage#inner']),
+        innerSigningContractID: currentGroupId,
         hooks
       })
     }

--- a/frontend/controller/actions/identity.js
+++ b/frontend/controller/actions/identity.js
@@ -581,7 +581,7 @@ export default (sbp('sbp/selectors/register', {
   },
   'gi.actions/identity/addJoinDirectMessageKey': async (contractID, foreignContractID, keyName) => {
     const keyId = await sbp('chelonia/contract/currentKeyIdByName', foreignContractID, keyName)
-    const CEKid = await sbp('chelonia/contract/currentKeyIdByName', contractID, 'cek')
+    const PEKid = await sbp('chelonia/contract/currentKeyIdByName', contractID, 'pek')
     const foreignContractState = sbp('chelonia/contract/state', foreignContractID)
 
     const existingForeignKeys = await sbp('chelonia/contract/foreignKeysByContractID', contractID, foreignContractID)
@@ -593,7 +593,7 @@ export default (sbp('sbp/selectors/register', {
     return await sbp('chelonia/out/keyAdd', {
       contractID,
       contractName: 'gi.contracts/identity',
-      data: [encryptedOutgoingData(contractID, CEKid, {
+      data: [encryptedOutgoingData(contractID, PEKid, {
         foreignKey: `shelter:${encodeURIComponent(foreignContractID)}?keyName=${encodeURIComponent(keyName)}`,
         id: keyId,
         data: foreignContractState._vm.authorizedKeys[keyId].data,
@@ -753,10 +753,10 @@ export default (sbp('sbp/selectors/register', {
           // having any groups in common
           contractID: message.contractID()
         },
-        // For now, we assume that we're messaging someone which whom we
+        // For now, we assume that we're messaging someone with whom we
         // share a group
         signingKeyId: await sbp('chelonia/contract/suitableSigningKey', partnerIDs[index], [SPMessage.OP_ACTION_ENCRYPTED], ['sig'], undefined, ['gi.contracts/identity/joinDirectMessage']),
-        innerSigningContractID: currentGroupId,
+        innerSigningKeyId: await sbp('chelonia/contract/suitableSigningKey', partnerIDs[index], [SPMessage.OP_ACTION_ENCRYPTED + '#inner'], ['sig'], undefined, ['gi.contracts/identity/joinDirectMessage#inner']),
         hooks
       })
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "group-income",
-  "version": "2.0.2",
+  "version": "2.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "group-income",
-      "version": "2.0.2",
+      "version": "2.0.4",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apeleghq/rfc8188": "1.0.7",
@@ -22,7 +22,7 @@
         "@babel/runtime": "7.23.8",
         "@chelonia/cli": "3.0.0",
         "@chelonia/crypto": "1.0.1",
-        "@chelonia/lib": "1.2.0",
+        "@chelonia/lib": "1.2.3",
         "@chelonia/multiformats": "1.0.0",
         "@chelonia/serdes": "1.0.0",
         "@hapi/boom": "9.1.0",
@@ -1938,9 +1938,9 @@
       }
     },
     "node_modules/@chelonia/lib": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@chelonia/lib/-/lib-1.2.0.tgz",
-      "integrity": "sha512-Wt8L0Qvq8wpkh7iTbBm9sKQnDQAciNS50u69KOeR/Qg6MDjvqKPpHEx2TJRdfPGPg3Z7qyUj9Cf+5VPi1zKxSQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@chelonia/lib/-/lib-1.2.3.tgz",
+      "integrity": "sha512-ScP44xPYnIsbth2ZyFoaBaR1yZ1G9NDfNH2zJMgWpYrZvjNZumptxVlBUn2R6obl6BCNtt686q/bBx13m9AeAQ==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apeleghq/multipart-parser": "1.0.18",
@@ -1951,7 +1951,8 @@
         "@sbp/okturtles.eventqueue": "1.2.1",
         "@sbp/okturtles.events": "1.0.1",
         "scrypt-async": "2.0.1",
-        "turtledash": "1.0.2"
+        "turtledash": "1.0.2",
+        "tweetnacl": "1.0.3"
       },
       "peerDependencies": {
         "@sbp/sbp": "2.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/runtime": "7.23.8",
         "@chelonia/cli": "3.0.0",
         "@chelonia/crypto": "1.0.1",
-        "@chelonia/lib": "1.2.3",
+        "@chelonia/lib": "file:../libcheloniajs/chelonia-lib-1.2.4.tgz",
         "@chelonia/multiformats": "1.0.0",
         "@chelonia/serdes": "1.0.0",
         "@hapi/boom": "9.1.0",
@@ -1938,9 +1938,9 @@
       }
     },
     "node_modules/@chelonia/lib": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@chelonia/lib/-/lib-1.2.3.tgz",
-      "integrity": "sha512-ScP44xPYnIsbth2ZyFoaBaR1yZ1G9NDfNH2zJMgWpYrZvjNZumptxVlBUn2R6obl6BCNtt686q/bBx13m9AeAQ==",
+      "version": "1.2.4",
+      "resolved": "file:../libcheloniajs/chelonia-lib-1.2.4.tgz",
+      "integrity": "sha512-5jrvcdloBlDMCOkrnwGK4qGYEWi8SOKdN+aJkJXvR6uuJ4RVTHQHpraa39cXMa2QZlivqTziDYVRAAyUBRkA0Q==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apeleghq/multipart-parser": "1.0.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1940,7 +1940,7 @@
     "node_modules/@chelonia/lib": {
       "version": "1.2.4",
       "resolved": "file:../libcheloniajs/chelonia-lib-1.2.4.tgz",
-      "integrity": "sha512-5jrvcdloBlDMCOkrnwGK4qGYEWi8SOKdN+aJkJXvR6uuJ4RVTHQHpraa39cXMa2QZlivqTziDYVRAAyUBRkA0Q==",
+      "integrity": "sha512-WvglV81t+DFAjFFszP5XvXE7j1BaYIAXcyhKun3BFyrRU+DGHJ6uyzWXrmVoMkra2LLBoK7m1Sfk/+QWPv+pzA==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apeleghq/multipart-parser": "1.0.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@babel/runtime": "7.23.8",
         "@chelonia/cli": "3.0.0",
         "@chelonia/crypto": "1.0.1",
-        "@chelonia/lib": "file:../libcheloniajs/chelonia-lib-1.2.4.tgz",
+        "@chelonia/lib": "1.2.4",
         "@chelonia/multiformats": "1.0.0",
         "@chelonia/serdes": "1.0.0",
         "@hapi/boom": "9.1.0",
@@ -1939,8 +1939,8 @@
     },
     "node_modules/@chelonia/lib": {
       "version": "1.2.4",
-      "resolved": "file:../libcheloniajs/chelonia-lib-1.2.4.tgz",
-      "integrity": "sha512-WvglV81t+DFAjFFszP5XvXE7j1BaYIAXcyhKun3BFyrRU+DGHJ6uyzWXrmVoMkra2LLBoK7m1Sfk/+QWPv+pzA==",
+      "resolved": "https://registry.npmjs.org/@chelonia/lib/-/lib-1.2.4.tgz",
+      "integrity": "sha512-lRf5q0Qoj8vAyesGRtGTxBWH/+3O07EfI1dB4CHU+FjCwM+2qaYuh+YIdHFfnpVG95lqSywF5uEqxTpn+Ii0QA==",
       "license": "AGPL-3.0",
       "dependencies": {
         "@apeleghq/multipart-parser": "1.0.18",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@babel/runtime": "7.23.8",
     "@chelonia/cli": "3.0.0",
     "@chelonia/crypto": "1.0.1",
-    "@chelonia/lib": "1.2.0",
+    "@chelonia/lib": "1.2.3",
     "@chelonia/multiformats": "1.0.0",
     "@chelonia/serdes": "1.0.0",
     "@hapi/boom": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@babel/runtime": "7.23.8",
     "@chelonia/cli": "3.0.0",
     "@chelonia/crypto": "1.0.1",
-    "@chelonia/lib": "file:../libcheloniajs/chelonia-lib-1.2.4.tgz",
+    "@chelonia/lib": "1.2.4",
     "@chelonia/multiformats": "1.0.0",
     "@chelonia/serdes": "1.0.0",
     "@hapi/boom": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "@babel/runtime": "7.23.8",
     "@chelonia/cli": "3.0.0",
     "@chelonia/crypto": "1.0.1",
-    "@chelonia/lib": "1.2.3",
+    "@chelonia/lib": "file:../libcheloniajs/chelonia-lib-1.2.4.tgz",
     "@chelonia/multiformats": "1.0.0",
     "@chelonia/serdes": "1.0.0",
     "@hapi/boom": "9.1.0",


### PR DESCRIPTION
Closes #2898

TODO:

- ~~Verify this actually works (it seems to from a quick test)~~
- ~~Verify that in case of a key rotation while sending a message, the message gets re-attempted with the correct, new key. (Example: message gets sent with `csk1`, but fails due to a conflict and in the meantime `csk1` was updated to `csk2`, the new attempt should use `csk2`)~~
- ~~Make this backwards compatible (meaning that old contracts should still work _and_ to add a post upgrade hook to encrypt CSKs with PEKs)~~
- ~~For some reason the `_private` key attribute (which contains a key ID for the (outer) key that should be used (i.e., is pinned) for encrypting that particular key) contains a key ID. Double that this key ID properly gets updated as encryption keys are rotated. Example: `k1` has `id(ek1)` as `_private`. Then, this attribute should get updated to `id(ek2)` if `ek1` is rotated and replaced with `ek2`.~~