### PR TITLE
Chatroom member list shouldn't show members that have left

### DIFF
--- a/frontend/views/containers/chatroom/ChatMembersAllModal.vue
+++ b/frontend/views/containers/chatroom/ChatMembersAllModal.vue
@@ -167,6 +167,10 @@ export default ({
     ...mapState([
       'currentGroupId'
     ]),
+    chatroomActiveMembers () {
+      const activeMemberEntries = Object.entries(this.chatRoomMembers).filter(([, joinInfo]) => !joinInfo.hasLeft)
+      return Object.fromEntries(activeMemberEntries)
+    },
     filteredRecents () {
       return filterByKeyword(this.addedMembers, this.searchText, ['username', 'displayName'])
     },
@@ -222,7 +226,7 @@ export default ({
   methods: {
     initializeMembers () {
       if (this.isGroupDirectMessage()) {
-        this.addedMembers = Object.keys(this.chatRoomMembers)
+        this.addedMembers = Object.keys(this.chatroomActiveMembers)
           .map(contractID => {
             const profile = contractID === this.ourIdentityContractId ? this.globalProfile(contractID) : this.ourContactProfilesById[contractID]
             return {
@@ -246,7 +250,8 @@ export default ({
             }
           })
       } else {
-        this.addedMembers = this.chatRoomMembersInOrder.map(member => ({ ...member, departedDate: null }))
+        this.addedMembers = this.chatRoomMembersInOrder.filter(member => !!this.chatroomActiveMembers[member.contractID])
+          .map(member => ({ ...member, departedDate: null }))
         this.canAddMembers = this.groupMembersSorted
           .filter(member => !this.addedMembers.find(mb => mb.contractID === member.contractID) && !member.invitedBy)
           .map(member => ({


### PR DESCRIPTION
closes #2893 

Can see the removed member is properly moved to the section below.

<img width="480" alt="image" src="https://github.com/user-attachments/assets/5dbd7564-1e72-4fc6-a1fe-5a7ac9a05b33" />
