### PR TITLE
#2929 - Broken `SendArea.vue`

### DIFF
--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -992,6 +992,7 @@ export default ({
   background-color: var(--background_0);
   border: 1px solid var(--general_0);
   border-radius: 0.25rem;
+  min-width: 0;
 
   &-textarea,
   &-mask {


### PR DESCRIPTION
closes #2929 

can see it behave as it used to work:

<img width="320" src="https://github.com/user-attachments/assets/163675a3-8c3e-4e4d-b5f6-f69c66fead2a" />

