### PR TITLE
#2951 - Same file cannot be attached in a row

### DIFF
--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -797,6 +797,7 @@ export default ({
       list.sort((a, b) => priority[getFileType(a.mimeType)] - priority[getFileType(b.mimeType)])
 
       this.ephemeral.attachments = list
+      this.$refs.fileAttachmentInputEl.value = '' // clear the input value
     },
     clearAllAttachments () {
       this.ephemeral.staleObjectURLs.push(this.ephemeral.attachments.map(({ url }) => url))


### PR DESCRIPTION
closes #2951 

I was able to reproduce the issue in `master`:

https://github.com/user-attachments/assets/20c04f0c-390f-409e-9ebe-30e9580ec9b8

---
The cause of the issue was that the file data the `<input type='file' />` tag holded was not cleared after they were loaded. So when the same file was loaded right after that, the browser just ignored/did not fire the `change` event. After making a fix for it:

https://github.com/user-attachments/assets/8ff24482-c253-4fd8-b3fa-8e13dc16775c

Can load the same file in a row.