### PR TITLE
#2931 - `group-chat-direct-message.spec.js` heisenbug fix

### DIFF
--- a/test/cypress/integration/group-chat-direct-message.spec.js
+++ b/test/cypress/integration/group-chat-direct-message.spec.js
@@ -199,6 +199,9 @@ describe('Create/Join direct messages and orders of direct message channels', ()
 
     openDMByMembers([user3])
 
+    // This is a fix for a heisenbug: https://github.com/okTurtles/group-income/issues/2931
+    cy.wait(4 * 1000) // eslint-disable-line cypress/no-unnecessary-waiting
+
     cy.getByDT('channelName').within(() => {
       cy.getByDT('menuTrigger').click()
     })


### PR DESCRIPTION
closes #2931 

I've been using a draft PR #2960 for attempting bugfixes and the fix in this PR has passed in the 10 consecutive test runs there (The failed tests in below screenshot are another heisen-bug, not this one):

<img width="80%" src="https://github.com/user-attachments/assets/b68ceb1e-d2a1-4eec-998b-ec7b2f456506" />

actually in 12 test runs if we include the latest 2 runs in #2964 too.

So decided that it is a reliable fix.
