### PR TITLE
#2949 - `.gif` losing animations

### DIFF
--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -776,7 +776,7 @@ export default ({
 
           // Determine if the image needs lossy-compression before upload.
           attachment.needsImageCompression = fileSize > IMAGE_ATTACHMENT_MAX_SIZE &&
-            // Do not compress GIF images so they don't lose animation.
+            // Skip the compression for GIF images so they don't lose animation.
             file.type !== 'image/gif'
         }
 

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -775,7 +775,9 @@ export default ({
           img.src = fileUrl
 
           // Determine if the image needs lossy-compression before upload.
-          attachment.needsImageCompression = fileSize > IMAGE_ATTACHMENT_MAX_SIZE
+          attachment.needsImageCompression = fileSize > IMAGE_ATTACHMENT_MAX_SIZE &&
+            // Do not compress GIF images so they don't lose animation.
+            file.type !== 'image/gif'
         }
 
         list.push(attachment)

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -580,4 +580,8 @@ export default {
   flex-direction: column;
   flex-wrap: nowrap;
 }
+
+.c-image-card-container {
+  align-items: flex-end;
+}
 </style>


### PR DESCRIPTION
closes #2949 

The cause of the issue was the image compression logic done in #2411 . The compression logic is applied if an image size is larger than `400KB` and during this process the `gif` is converted to a static image. Fixed by skipping this logic for `gif` files.

https://github.com/user-attachments/assets/26b2d3f5-b84f-47e9-937a-debbbfc3d6e8

cc. @dotmacro 
