### PR TITLE
#2982 - Show the current period and empty periods in the dashboard UI

### DIFF
--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1397,7 +1397,7 @@ sbp('chelonia/defineContract', {
             initFetchPeriodPayments({ contractID, meta, periodTo: period, state, getters })
           })
 
-          // There can be two cases -
+          // There can be two cases:
           // 1) The period to update comes right after current period
           // 2) There are one or more empty periods (periods with no payments made) between current period and the period to update.
           // In case of 1), we add +1 to the payment-related group streaks.

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -69,11 +69,10 @@ function initGroupProfile (joinedDate: string, joinedHeight: number, reference: 
   }
 }
 
-function initPaymentPeriod ({ meta, getters }) {
-  const start = getters.periodStampGivenDate(meta.createdDate)
+function initPaymentPeriod ({ period, getters }) {
   return {
-    start,
-    end: plusOnePeriodLength(start, getters.groupSettings.distributionPeriodLength),
+    start: period,
+    end: plusOnePeriodLength(period, getters.groupSettings.distributionPeriodLength),
     // this saved so that it can be used when creating a new payment
     initialCurrency: getters.groupMincomeCurrency,
     // TODO: should we also save the first period's currency exchange rate..?
@@ -116,7 +115,7 @@ function clearOldPayments ({ contractID, state, getters }) {
 
 function initFetchPeriodPayments ({ contractID, meta, periodTo = '', state, getters }) {
   const period = periodTo || getters.periodStampGivenDate(meta.createdDate)
-  const periodPayments = fetchInitKV(state.paymentsByPeriod, period, initPaymentPeriod({ meta, getters }))
+  const periodPayments = fetchInitKV(state.paymentsByPeriod, period, initPaymentPeriod({ period, getters }))
   const previousPeriod = getters.periodBeforePeriod(period)
 
   // Update the '.end' field of the previous in-memory period, if any.

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1396,7 +1396,7 @@ sbp('chelonia/defineContract', {
             initFetchPeriodPayments({ contractID, meta, periodTo: period, state, getters })
           })
 
-          // There can be two cases -
+          // There can be two cases:
           // 1) The period to update comes right after current period
           // 2) There are one or more empty periods (periods with no payments made) between current period and the period to update.
           // In case of 1), we add +1 to the payment-related group streaks.

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1400,7 +1400,7 @@ sbp('chelonia/defineContract', {
           if (emptyPeriodsBetweenCurrentAndTo.length === 0) {
             updateGroupStreaks({ state, getters })
           } else {
-            // 'lastStreakPeriod', 'fullMonthlyPledges', 'fullMonthlySupport', 'onTimePayments' need to be reset when there are empty periods.
+            // 'lastStreakPeriod', 'fullMonthlyPledges', 'fullMonthlySupport' and 'onTimePayments' need to be reset when there are empty periods.
             state.streaks.lastStreakPeriod = null
             state.streaks.fullMonthlyPledges = 0
             state.streaks.fullMonthlySupport = 0

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1397,7 +1397,7 @@ sbp('chelonia/defineContract', {
             initFetchPeriodPayments({ contractID, meta, periodTo: period, state, getters })
           })
 
-          // There can be two cases:
+          // There can be two cases -
           // 1) The period to update comes right after current period
           // 2) There are one or more empty periods (periods with no payments made) between current period and the period to update.
           // In case of 1), we add +1 to the payment-related group streaks.

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1400,7 +1400,8 @@ sbp('chelonia/defineContract', {
           if (emptyPeriodsBetweenCurrentAndTo.length === 0) {
             updateGroupStreaks({ state, getters })
           } else {
-            // 'lastStreakPeriod', 'fullMonthlyPledges', 'fullMonthlySupport' and 'onTimePayments' need to be reset when there are empty periods.
+            // Below 4 group streaks ('lastStreakPeriod', 'fullMonthlyPledges', 'fullMonthlySupport' and 'onTimePayments') need to be reset
+            // when there are empty periods between current period and the period to update.
             state.streaks.lastStreakPeriod = null
             state.streaks.fullMonthlyPledges = 0
             state.streaks.fullMonthlySupport = 0
@@ -1419,6 +1420,10 @@ sbp('chelonia/defineContract', {
 
               for (const pledgerId of allPledgerIds) {
                 const currentValue = fetchInitKV(state.streaks.missedPayments, pledgerId, 0)
+                // Two cases here:
+                // (Ther term 'current period' means the distribution period the group setting 'currently has'. So it could be months ago if there are many empty periods.)
+                // 1) If the pledger has missed payments in the current period - their current missed-payments streaks so far + 1 (for the current period) + the number of empty periods.
+                // 2) If the pledger has completed  payments in the current period - No need to consider the member's missed payments streak so far. Just add the number of empty periods.
                 state.streaks.missedPayments[pledgerId] = missedInCurrentPeriod(pledgerId)
                   ? 1 + currentValue + emptyPeriodsBetweenCurrentAndTo.length
                   : emptyPeriodsBetweenCurrentAndTo.length

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1366,7 +1366,10 @@ sbp('chelonia/defineContract', {
         const current = state.settings?.distributionDate
         const currentPeriodPayments = getters.groupPeriodPayments[current] ? cloneDeep(getters.groupPeriodPayments[current]) : null
 
-        if (comparePeriodStamps(periodTo, current) > 0) {
+        if (!current && periodTo) {
+          updateGroupStreaks({ state, getters })
+          state.settings.distributionDate = periodTo
+        } else if (current && comparePeriodStamps(periodTo, current) > 0) {
           // There can be one or more distribution periods without any payments (empty-periods) between current 'distributionDate'
           // and the distribution period to update to. (eg. No one in the group hasn't logged in for a long time)
           // 'paymentsByPeriod' object in the group state and the payment-related group streaks need to be populated/updated accordingly for those empty periods in this case.
@@ -1413,9 +1416,11 @@ sbp('chelonia/defineContract', {
 
             if (groupHasReceivers && allPledgerIds.length > 0) {
               const missedInCurrentPeriod = (memberID) => {
+                // 'lastAdjustedDistribution' is null if no payments have been made in the period.
+                // If there has been payments made in the period, 'lastAdjustedDistribution' is an array of todo paymentitems that have not been completed yet.
                 return !currentPeriodPayments ||
-                  !currentPeriodPayments?.lastAdjustedDistribution ||
-                  currentPeriodPayments.lastAdjustedDistribution?.some(entry => entry.fromMemberID === memberID)
+                  !currentPeriodPayments.lastAdjustedDistribution ||
+                  currentPeriodPayments.lastAdjustedDistribution.some(entry => entry.fromMemberID === memberID)
               }
 
               for (const pledgerId of allPledgerIds) {

--- a/frontend/model/contracts/shared/getters/group.js
+++ b/frontend/model/contracts/shared/getters/group.js
@@ -114,6 +114,11 @@ export default ({
   groupProfiles (state, getters) {
     return getters.groupProfilesForGroup(getters.currentGroupState)
   },
+  groupPledgerProfiles (state, getters) {
+    return Object.fromEntries(Object.entries(getters.groupProfiles).filter(
+      ([memberID, profile]: [string, any]) => profile.incomeDetailsType === 'pledgeAmount' && profile.pledgeAmount > 0
+    ))
+  },
   groupCreatedDate (state, getters) {
     return getters.groupProfile(getters.currentGroupOwnerID).joinedDate
   },

--- a/frontend/model/contracts/shared/getters/group.js
+++ b/frontend/model/contracts/shared/getters/group.js
@@ -119,6 +119,11 @@ export default ({
       ([memberID, profile]: [string, any]) => profile.incomeDetailsType === 'pledgeAmount' && profile.pledgeAmount > 0
     ))
   },
+  groupReceiverProfiles (state, getters) {
+    return Object.fromEntries(Object.entries(getters.groupProfiles).filter(
+      ([memberID, profile]: [string, any]) => profile.incomeDetailsType === 'incomeAmount'
+    ))
+  },
   groupCreatedDate (state, getters) {
     return getters.groupProfile(getters.currentGroupOwnerID).joinedDate
   },

--- a/frontend/model/contracts/shared/getters/group.js
+++ b/frontend/model/contracts/shared/getters/group.js
@@ -250,7 +250,9 @@ export default ({
     return getters.groupMembersCount >= 3
   },
   groupDistributionStarted (state, getters) {
-    return (currentDate: string) => currentDate >= getters.groupSettings?.distributionDate
+    return (currentDate: string) => {
+      return new Date(currentDate) >= new Date(getters.groupSettings?.distributionDate)
+    }
   },
   groupProposalSettings (state, getters) {
     return (proposalType = PROPOSAL_GENERIC) => {

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -334,7 +334,7 @@ store.watch(
     if (distributionStarted) {
       const distributionDateInSettings = store.getters.groupSettings.distributionDate
 
-      if (newPeriod && (newPeriod !== distributionDateInSettings)) {
+      if (newPeriod && distributionDateInSettings && (newPeriod !== distributionDateInSettings)) {
         sbp('gi.actions/group/updateDistributionDate', { contractID: store.state.currentGroupId })
           .catch((e) => {
             console.error('getters.currentPaymentPeriod watcher Error calling updateDistributionDate', e)

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -333,8 +333,6 @@ store.watch(
 
     if (distributionStarted) {
       const distributionDateInSettings = store.getters.groupSettings.distributionDate
-      console.log('!@# distributionDateInSettings: ', distributionDateInSettings)
-      console.log('!@# getters.currentPaymentPeriod: ', newPeriod)
 
       if (newPeriod && (newPeriod !== distributionDateInSettings)) {
         sbp('gi.actions/group/updateDistributionDate', { contractID: store.state.currentGroupId })

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -342,8 +342,7 @@ store.watch(
           })
       }
     }
-  },
-  { immediate: true }
+  }
 )
 
 // save the state each time it's modified, but debounce it to avoid saving too frequently

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -333,9 +333,10 @@ store.watch(
 
     if (distributionStarted) {
       const distributionDateInSettings = store.getters.groupSettings.distributionDate
-      const isPeriodRolledOver = oldPeriod && newPeriod && (newPeriod !== distributionDateInSettings)
-      const isDistributionDateBehind = new Date(newPeriod) > new Date(distributionDateInSettings)
-      if (isPeriodRolledOver || isDistributionDateBehind) {
+      console.log('!@# distributionDateInSettings: ', distributionDateInSettings)
+      console.log('!@# getters.currentPaymentPeriod: ', newPeriod)
+
+      if (newPeriod && (newPeriod !== distributionDateInSettings)) {
         sbp('gi.actions/group/updateDistributionDate', { contractID: store.state.currentGroupId })
           .catch((e) => {
             console.error('getters.currentPaymentPeriod watcher Error calling updateDistributionDate', e)

--- a/frontend/model/state.js
+++ b/frontend/model/state.js
@@ -4,7 +4,7 @@
 // state) per: http://vuex.vuejs.org/en/intro.html
 
 import sbp from '@sbp/sbp'
-import { CHELONIA_RESET, CONTRACTS_MODIFIED, EVENT_HANDLED, CONTRACT_REGISTERED } from '@chelonia/lib/events'
+import { CHELONIA_RESET, CONTRACTS_MODIFIED, EVENT_HANDLED } from '@chelonia/lib/events'
 import { LOGOUT } from '~/frontend/utils/events.js'
 import { KV_LOAD_STATUS } from '~/frontend/utils/constants.js'
 import Vue from 'vue'
@@ -313,6 +313,39 @@ store.watch(function (state, getters) {
   reactiveDate.date = new Date()
 })
 
+store.watch(
+  (state, getters) => getters.currentPaymentPeriod,
+  (newPeriod, oldPeriod) => {
+    // This watcher is for automatically syncing 'currentPaymentPeriod' with 'groupSettings.distributionDate'.
+    // Before bringing this logic in, how the app updates the state related to group distribution period was,
+    // 'currentPaymentPeriod': gets auto-updated(t1) in response to the change of 'reactiveDate.date' when it passes into the new period.
+    // 'groupSettings.distributionDate': gets updated manually by calling 'updateCurrentDistribution' function(t2) in group.js
+    // This logic removes the inconsistency that exists between these two from the point of time t1 till t2.
+
+    // Note: if this code gets called when we're in the period before the 1st distribution
+    //       period, then the distributionDate will get updated to the previous distribution date
+    //       (incorrectly). That in turn will cause the Payments page to update and display TODOs
+    //       before it should.
+    // NOTE: `distributionStarted` allows distributionDate can be updated automatically ONLY after
+    //       the distribution is started. And it fixes the issue mentioned above.
+
+    const distributionStarted = store.getters.groupDistributionStarted(reactiveDate.date)
+
+    if (distributionStarted) {
+      const distributionDateInSettings = store.getters.groupSettings.distributionDate
+      const isPeriodRolledOver = oldPeriod && newPeriod && (newPeriod !== distributionDateInSettings)
+      const isDistributionDateBehind = new Date(newPeriod) > new Date(distributionDateInSettings)
+      if (isPeriodRolledOver || isDistributionDateBehind) {
+        sbp('gi.actions/group/updateDistributionDate', { contractID: store.state.currentGroupId })
+          .catch((e) => {
+            console.error('getters.currentPaymentPeriod watcher Error calling updateDistributionDate', e)
+          })
+      }
+    }
+  },
+  { immediate: true }
+)
+
 // save the state each time it's modified, but debounce it to avoid saving too frequently
 let logoutInProgress = false
 const debouncedSave = debounce(() => !logoutInProgress && sbp('state/vuex/save'), 500)
@@ -336,40 +369,5 @@ if (process.env.NODE_ENV === 'development') {
     store.commit('noop')
   }, 500))
 }
-
-sbp('okTurtles.events/on', CONTRACT_REGISTERED, async (contract) => {
-  const { contracts: { manifests } } = await sbp('chelonia/config')
-  // check to make sure we're only loading the getters for the version of the contract
-  // that this build of GI was compiled with
-  if (manifests[contract.name] === contract.manifest) {
-    if (contract.name === 'gi.contracts/group') {
-      store.watch(
-        (state, getters) => getters.currentPaymentPeriod,
-        (newPeriod, oldPeriod) => {
-          // This watcher is for automatically syncing 'currentPaymentPeriod' with 'groupSettings.distributionDate'.
-          // Before bringing this logic in, how the app updates the state related to group distribution period was,
-          // 'currentPaymentPeriod': gets auto-updated(t1) in response to the change of 'reactiveDate.date' when it passes into the new period.
-          // 'groupSettings.distributionDate': gets updated manually by calling 'updateCurrentDistribution' function(t2) in group.js
-          // This logic removes the inconsistency that exists between these two from the point of time t1 till t2.
-
-          // Note: if this code gets called when we're in the period before the 1st distribution
-          //       period, then the distributionDate will get updated to the previous distribution date
-          //       (incorrectly). That in turn will cause the Payments page to update and display TODOs
-          //       before it should.
-          // NOTE: `distributionStarted` allows distributionDate can be updated automatically ONLY after
-          //       the distribution is started. And it fixes the issue mentioned above.
-          const distributionDateInSettings = store.getters.groupSettings.distributionDate
-          const distributionStarted = store.getters.groupDistributionStarted(reactiveDate.date)
-          if (oldPeriod && newPeriod && distributionStarted && (newPeriod !== distributionDateInSettings)) {
-            sbp('gi.actions/group/updateDistributionDate', { contractID: store.state.currentGroupId })
-              .catch((e) => {
-                console.error('okTurtles.events/on CONTRACT_REGISTERED Error calling updateDistributionDate', e)
-              })
-          }
-        }
-      )
-    }
-  }
-})
 
 export default store

--- a/frontend/views/containers/contributions/SupportHistory.vue
+++ b/frontend/views/containers/contributions/SupportHistory.vue
@@ -24,6 +24,7 @@ import { L } from '@common/common.js'
 import PaymentsMixin from '@containers/payments/PaymentsMixin.js'
 import BarGraph from '@components/graphs/bar-graph/BarGraph.vue'
 import { MAX_HISTORY_PERIODS } from '@model/contracts/shared/constants.js'
+import { withGroupCurrency } from '@view-utils/misc.js'
 
 export default ({
   name: 'SupportHistory',
@@ -40,7 +41,6 @@ export default ({
   computed: {
     ...mapGetters([
       'currentPaymentPeriod',
-      'withGroupCurrency',
       'groupTotalPledgeAmount',
       'groupCreatedDate',
       'thisPeriodPaymentInfo'
@@ -50,6 +50,7 @@ export default ({
     this.updateHistory()
   },
   methods: {
+    withGroupCurrency,
     async updateHistory () {
       const allPeriods = await this.getAllSortedPeriodKeys()
       const periods = allPeriods.slice(-MAX_HISTORY_PERIODS)

--- a/frontend/views/containers/payments/PaymentsMixin.js
+++ b/frontend/views/containers/payments/PaymentsMixin.js
@@ -45,7 +45,7 @@ const PaymentsMixin: Object = {
         ...this.groupSortedPeriodKeys
       ].filter(period => {
         const dPeriod = new Date(period)
-        return dPeriod > new Date(groupCreatedDate) && dPeriod <= currentDate // show only started periods & filter out the 'waiting' period
+        return dPeriod > groupCreatedDate && dPeriod <= currentDate // show only started periods & filter out the 'waiting' period
       })
       // remove the waiting period from the list. it's useful for the contract but not in the UI
       if (periods.length === 1 && new Date(periods[0]) < distributionDate) {

--- a/test/cypress/integration/group-chat.spec.js
+++ b/test/cypress/integration/group-chat.spec.js
@@ -268,6 +268,9 @@ describe('Group Chat Basic Features (Create & Join & Leave & Close)', () => {
   it('user1 checks the visibilities, sort order and permissions', () => {
     switchUser(user1)
     cy.giRedirectToGroupChat()
+
+    cy.wait(3 * 1000) // eslint-disable-line cypress/no-unnecessary-waiting
+
     cy.log('Users can update details(name, description) of the channels they created.')
     const undetailedChannel = chatRooms.filter(c => c.name.startsWith('channel1') && !c.description)[0]
     const detailedChannel = chatRooms.filter(c => c.name.startsWith('channel1') && c.description)[0]
@@ -426,9 +429,9 @@ describe('Group Chat Basic Features (Create & Join & Leave & Close)', () => {
 
     cy.getByDT('groupMembers').find('ul>li').should('have.length', 2) // user1 & user2
 
-    // NOTE: this check is to wait until 2 INTERACTIVE mesages are created
+    // NOTE: this check is to wait until 2 additional notifications for the INTERACTIVE mesages are created
     //       one for creating proposal and another is for proposal approval
-    cy.getByDT('groupChatLink').get('.c-badge.is-compact[aria-label="2 new notifications"]').contains('2')
+    cy.getByDT('groupChatLink').get('.c-badge.is-compact[aria-label="3 new notifications"]').contains('3')
 
     cy.giRedirectToGroupChat()
 

--- a/test/cypress/integration/group-chat.spec.js
+++ b/test/cypress/integration/group-chat.spec.js
@@ -269,6 +269,8 @@ describe('Group Chat Basic Features (Create & Join & Leave & Close)', () => {
     switchUser(user1)
     cy.giRedirectToGroupChat()
 
+    // This is put here to fix a frequent heisenbug happening after cy.giSwitchChannel() below, which never happens when running test locally.
+    // The intention is to give it a bit of extra time for async operations to complete in relatively unstable environment like CI.
     cy.wait(3 * 1000) // eslint-disable-line cypress/no-unnecessary-waiting
 
     cy.log('Users can update details(name, description) of the channels they created.')


### PR DESCRIPTION
closes #2982 

Empty periods will be auto-populated in `paymentsByPeriod` property of the group state and will be shown in the dashboard bar graphs like below:

<img width="530"  src="https://github.com/user-attachments/assets/ae373844-8567-4fbd-8f49-2715c9ee519a" />
