### PR TITLE
#2999 - Chatroom mention issues

### DIFF
--- a/frontend/assets/style/components/_forms.scss
+++ b/frontend/assets/style/components/_forms.scss
@@ -36,6 +36,11 @@ legend.legend {
     display: block;
     color: $text_1;
     margin-top: 0.5rem;
+
+    &.with-icon::before {
+      @include i.icon(info-circle);
+      margin-right: 0.25rem;
+    }
   }
 }
 

--- a/frontend/model/chatroom/utils.js
+++ b/frontend/model/chatroom/utils.js
@@ -11,6 +11,7 @@ export function makeChannelMention (str: string, withId: boolean = false): strin
 }
 
 export function getIdFromChannelMention (str: string): string {
+  console.log('!@# str', str)
   return str.includes(':chatID:')
     ? str.split(':chatID:')[1]
     : ''
@@ -31,9 +32,8 @@ export function swapMentionIDForDisplayname (
   const { reverseNamespaceLookups } = sbp('state/vuex/state')
   const possibleMentions = [
     ...Object.keys(reverseNamespaceLookups).map(u => makeMentionFromUserID(u).me).filter(v => !!v),
-    makeChannelMention('[^\\s]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
+    makeChannelMention('[a-zA-Z0-9]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
   ]
-
   const { escaped, forChat } = options
   const regEx = escaped
     ? new RegExp(`(?<=\\s|^)(${possibleMentions.join('|')})(?=[^\\w\\d]|$)`)

--- a/frontend/model/chatroom/utils.js
+++ b/frontend/model/chatroom/utils.js
@@ -11,7 +11,6 @@ export function makeChannelMention (str: string, withId: boolean = false): strin
 }
 
 export function getIdFromChannelMention (str: string): string {
-  console.log('!@# str', str)
   return str.includes(':chatID:')
     ? str.split(':chatID:')[1]
     : ''

--- a/frontend/model/contracts/group.js
+++ b/frontend/model/contracts/group.js
@@ -1137,11 +1137,13 @@ sbp('chelonia/defineContract', {
           attributes: chatRoomAttributesType
         })(data)
 
-        // Validation on the chatroom name (reference: https://github.com/okTurtles/group-income/issues/1987)
+        // Validation on the chatroom name - references:
+        // https://github.com/okTurtles/group-income/issues/1987
+        // https://github.com/okTurtles/group-income/issues/2999
         const chatroomName = data.attributes.name
         const nameValidationMap: {[string]: Function} = {
           [L('Chatroom name cannot contain white-space')]: (v: string): boolean => /\s/g.test(v),
-          [L('Chatroom name must be lower-case only')]: (v: string): boolean => /[A-Z]/g.test(v)
+          [L('Chatroom name can only contain lowercase letters, numbers, and hyphens(-)')]: (v: string): boolean => /[^a-z0-9-]/g.test(v)
         }
 
         for (const key in nameValidationMap) {

--- a/frontend/views/containers/chatroom/CreateNewChannelModal.vue
+++ b/frontend/views/containers/chatroom/CreateNewChannelModal.vue
@@ -253,8 +253,8 @@ export default ({
     'form.name' (newVal) {
       if (newVal.length) {
         this.form.name = newVal.replace(/\s/g, '-') // replace all whitespaces with '-'
-          .replace(/[^a-z0-9-]/g, '') // remove all non-alphanumeric characters except '-'
           .toLowerCase()
+          .replace(/[^a-z0-9-]/g, '') // remove all non-alphanumeric characters except '-'
       }
     }
   }

--- a/frontend/views/containers/chatroom/CreateNewChannelModal.vue
+++ b/frontend/views/containers/chatroom/CreateNewChannelModal.vue
@@ -24,6 +24,7 @@
           @blur='updateField("name")'
           v-error:name=''
         )
+        i18n.helper.with-icon(v-if='!$v.form.name.$error' tag='p') Channel name can only contain letters, numbers, and hyphens(-).
 
       label.field
         .c-desc-label-container
@@ -248,9 +249,11 @@ export default ({
     }
   },
   watch: {
-    'form.name' (newVal, oldVal) {
+    'form.name' (newVal) {
       if (newVal.length) {
-        this.form.name = newVal.replaceAll(/\s/g, '-').toLowerCase()
+        this.form.name = newVal.replace(/\s/g, '-') // replace all whitespaces with '-'
+          .replace(/[^a-zA-Z0-9-]/g, '') // remove all non-alphanumeric characters except '-'
+          .toLowerCase()
       }
     }
   }

--- a/frontend/views/containers/chatroom/CreateNewChannelModal.vue
+++ b/frontend/views/containers/chatroom/CreateNewChannelModal.vue
@@ -24,7 +24,7 @@
           @blur='updateField("name")'
           v-error:name=''
         )
-        i18n.helper.with-icon(v-if='!$v.form.name.$error' tag='p') Channel name can only contain letters, numbers, and hyphens(-).
+        i18n.helper.with-icon(v-if='!$v.form.name.$error' tag='p') Channel name can only contain lowercase letters, numbers, and hyphens(-).
 
       label.field
         .c-desc-label-container
@@ -197,6 +197,7 @@ export default ({
     async submit () {
       const { name, description } = this.form
       try {
+        this.$refs.formMsg.clean()
         await sbp('gi.app/group/addAndJoinChatRoom', {
           contractID: this.currentGroupId,
           data: {
@@ -252,7 +253,7 @@ export default ({
     'form.name' (newVal) {
       if (newVal.length) {
         this.form.name = newVal.replace(/\s/g, '-') // replace all whitespaces with '-'
-          .replace(/[^a-zA-Z0-9-]/g, '') // remove all non-alphanumeric characters except '-'
+          .replace(/[^a-z0-9-]/g, '') // remove all non-alphanumeric characters except '-'
           .toLowerCase()
       }
     }

--- a/frontend/views/containers/chatroom/PinnedMessages.vue
+++ b/frontend/views/containers/chatroom/PinnedMessages.vue
@@ -83,7 +83,7 @@ export default {
     possibleMentions () {
       return [
         ...Object.keys(this.ourContactProfilesById).map(u => makeMentionFromUserID(u).me).filter(v => !!v),
-        makeChannelMention('[^\\s]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
+        makeChannelMention('[a-zA-Z0-9]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
       ]
     },
     messageSentVariant () {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -717,8 +717,7 @@ export default ({
           // in this case the rest of the code is treated as code content too.
           msgSplitByCodeMarkdown[index - 1]?.text !== '```'
         ) {
-          const mentionConvertedText = convertAllMentions(entry.text)
-          entry.text = mentionConvertedText
+          entry.text = convertAllMentions(entry.text)
         }
       })
       msgToSend = combineMarkdownSegmentListIntoString(msgSplitByCodeMarkdown)

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -717,7 +717,8 @@ export default ({
           // in this case the rest of the code is treated as code content too.
           msgSplitByCodeMarkdown[index - 1]?.text !== '```'
         ) {
-          entry.text = convertAllMentions(entry.text)
+          const mentionConvertedText = convertAllMentions(entry.text)
+          entry.text = mentionConvertedText
         }
       })
       msgToSend = combineMarkdownSegmentListIntoString(msgSplitByCodeMarkdown)

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
@@ -77,7 +77,7 @@ export default ({
         // For example, if someone else leaves a group and then we join from
         // a different device, we might not sync their contract.
         ...Object.keys(this.$store.state.reverseNamespaceLookups).map(u => makeMentionFromUserID(u).me).filter(v => !!v),
-        makeChannelMention('[^\\s]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
+        makeChannelMention('[a-zA-Z0-9]+', true) // chat-mention as contractID has a format of `#:chatID:...`. So target them as a pattern instead of the exact strings.
       ]
     },
     showTrailingEllipsis () {


### PR DESCRIPTION
closes #2999 

Was able to reproduce it in `master` too.
The main cause was the RegExp for capturing chatroom contractID. it currently doesn't consider the fact that contractID never contains a special characters and punctuations etc. Fixed it.

<img width="410" src="https://github.com/user-attachments/assets/c4666c0d-784f-498b-8062-421aee81df9a" />

<img width="410" src="https://github.com/user-attachments/assets/962d19e6-b91c-44bd-abb8-26f38bef9698" />

<br><br>

While updating UI logic for this issue, added this helper text for channel name field as well. Hope it looks good and pls let me know if the wordings need to be changed:

<img width="580" src="https://github.com/user-attachments/assets/78603964-75d0-4f88-8369-d2fa591f0b53" />


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
