### PR TITLE
#3006 - option for browser-sync port override

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -3,6 +3,6 @@
 [transfer]
     fsckObjects = true
 [fetch]
-    fsckoOjects = true
+    fsckObjects = true
 [receive]
     fsckObjects = true

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,10 @@ if (!process.env.DB_PATH) {
   Object.assign(process.env, { DB_PATH: dbPath })
 }
 
+const isValidPort = (port) => {
+  return !Number.isNaN(port) && port >= 1024 && port <= 65535
+}
+
 module.exports = (grunt) => {
   require('load-grunt-tasks')(grunt)
 
@@ -91,7 +95,7 @@ module.exports = (grunt) => {
   ;(function defineApiEnvars () {
     const API_PORT = Number.parseInt(grunt.option('port') ?? process.env.API_PORT ?? '8000', 10)
 
-    if (Number.isNaN(API_PORT) || API_PORT < 1024 || API_PORT > 65535) {
+    if (!isValidPort(API_PORT)) {
       throw new RangeError(`Invalid API_PORT value: ${API_PORT}.`)
     }
     process.env.API_PORT = String(API_PORT)
@@ -624,6 +628,13 @@ module.exports = (grunt) => {
 
     // BrowserSync setup.
     const browserSync = require('browser-sync').create('esbuild')
+
+    // If there is port override, use it.
+    const portOverride = grunt.option('browsersync-port') || process.env.BROWSER_SYNC_PORT
+    if (portOverride && isValidPort(portOverride)) {
+      browserSyncOptions.port = Number(portOverride)
+    }
+
     browserSync.init(browserSyncOptions)
 
     ;[


### PR DESCRIPTION
closes #3006 

@taoeffect FYI, `grunt-cli` apparently doesn't recognise `grunt dev --browsersync-port 3001`
but it does for `grunt dev --browsersync-port=3001` (using **'='**) like it says in [this doc](https://gruntjs.com/api/grunt.option):

> An example would be a flag to target whether your build is for development or staging. On the command line: grunt deploy --target=staging would cause grunt.option('target') to return "staging".


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3018">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
