### PR TITLE
Chat menu icon update

### DIFF
--- a/frontend/views/components/Page.vue
+++ b/frontend/views/components/Page.vue
@@ -87,7 +87,7 @@ export default ({
     toggleProps () {
       return {
         element: this.isGroupChatPage ? 'chat' : 'sidebar',
-        ariaExpanded: this.ephemeral.isActive
+        'aria-expanded': this.ephemeral.isActive
       }
     }
   },

--- a/frontend/views/components/Page.vue
+++ b/frontend/views/components/Page.vue
@@ -12,7 +12,13 @@ div(:data-test='pageTestName + "-page"' :class='$scopedSlots.sidebar ? "p-with-s
       span
         slot(name='title')
 
-    toggle(v-if='$scopedSlots.sidebar' @toggle='toggleMenu' element='sidebar' :aria-expanded='ephemeral.isActive' :show-badge='true')
+    toggle(
+      v-if='$scopedSlots.sidebar'
+      @toggle='toggleMenu'
+      v-bind='toggleProps'
+      :show-badge='true'
+    )
+
     slot(name='description')
 
   main.p-main(:class='mainClass')
@@ -23,7 +29,10 @@ div(:data-test='pageTestName + "-page"' :class='$scopedSlots.sidebar ? "p-with-s
     :class='{ "is-active": ephemeral.isActive }'
   )
     i18n.sr-only(tag='h2') Page details
-    toggle(@toggle='toggleMenu' element='sidebar' :aria-expanded='ephemeral.isActive')
+    toggle(
+      @toggle='toggleMenu'
+      v-bind='toggleProps'
+    )
     .p-sidebar-inner(:inert='isInert')
       slot(name='sidebar' :toggle='toggleMenuIfTouch')
 </template>
@@ -71,6 +80,15 @@ export default ({
   computed: {
     isInert () {
       return !this.ephemeral.isActive && this.ephemeral.isTouch
+    },
+    isGroupChatPage () {
+      return ['GroupChat', 'GroupChatConversation'].includes(this.$route.name)
+    },
+    toggleProps () {
+      return {
+        element: this.isGroupChatPage ? 'chat' : 'sidebar',
+        ariaExpanded: this.ephemeral.isActive
+      }
     }
   },
   methods: {
@@ -104,6 +122,12 @@ export default ({
             this.findAndScrollToAnchor(to.hash.slice(1))
           }, 100)
         }
+      }
+    },
+    'isGroupChatPage': {
+      immediate: true,
+      handler (isGroupChatPage) {
+        console.log('!@# isGroupChatPage', isGroupChatPage)
       }
     }
   }
@@ -202,7 +226,8 @@ $pagePaddingDesktop: 5.5rem;
     }
   }
 
-  .c-toggle.sidebar {
+  .c-toggle.sidebar,
+  .c-toggle.chat {
     right: 0;
 
     @include desktop {

--- a/frontend/views/components/Page.vue
+++ b/frontend/views/components/Page.vue
@@ -123,12 +123,6 @@ export default ({
           }, 100)
         }
       }
-    },
-    'isGroupChatPage': {
-      immediate: true,
-      handler (isGroupChatPage) {
-        console.log('!@# isGroupChatPage', isGroupChatPage)
-      }
     }
   }
 }: Object)

--- a/frontend/views/components/Toggle.vue
+++ b/frontend/views/components/Toggle.vue
@@ -4,19 +4,16 @@ button.c-toggle.is-unstyled(
   @click='$emit("toggle")'
   :aria-label='L("Toggle navigation")'
 )
-  i.icon-bars(v-if='element === "navigation"')
+  i(:class='iconClasses')
     slot
-  i.icon-info(v-else-if='element === "sidebar"' :class='{"c-toggle-bg": hasChatNotification}')
-    slot
-    badge(v-if='hasChatNotification') {{ currentGroupUnreadMessagesCount }}
-
+    badge(v-if='showChatNotification') {{ currentGroupUnreadMessagesCount }}
 </template>
 
 <script>
 import Badge from './Badge.vue'
 import { mapState, mapGetters } from 'vuex'
 
-export default ({
+export default {
   name: 'Toggle',
   components: {
     Badge
@@ -24,7 +21,7 @@ export default ({
   props: {
     element: {
       type: String,
-      validator: (value) => ['navigation', 'sidebar'].includes(value),
+      validator: (value) => ['navigation', 'sidebar', 'chat'].includes(value),
       required: true
     },
     showBadge: {
@@ -40,13 +37,27 @@ export default ({
     currentGroupUnreadMessagesCount () {
       return !this.currentGroupId ? 0 : this.groupUnreadMessages(this.currentGroupId)
     },
-    hasChatNotification () {
-      return ['GroupChat', 'GroupChatConversation'].includes(this.$route.name) && this.showBadge && this.currentGroupUnreadMessagesCount
+    showChatNotification () {
+      return this.element === 'chat' &&
+        this.showBadge &&
+        this.currentGroupUnreadMessagesCount
+    },
+    iconClasses () {
+      const nameMap = {
+        navigation: 'bars',
+        sidebar: 'info',
+        chat: 'comment'
+      }
+
+      return [
+        `icon-${nameMap[this.element] || 'info'} c-toggle-icon`,
+        { 'c-toggle-bg': this.showChatNotification }
+      ]
     }
   }
-}: Object)
-
+}
 </script>
+
 <style lang="scss" scoped>
 @import "@assets/style/_variables.scss";
 @import "@assets/style/_mixins.scss";
@@ -69,15 +80,13 @@ $iconSize: 2.75rem;
   // Similar to `.button.is-icon` but adapted to a "corner" button.
   &:hover,
   &:focus {
-    .icon-bars,
-    .icon-info {
+    .c-toggle-icon {
       background-color: $general_1;
     }
   }
 
   &:focus {
-    .icon-bars,
-    .icon-info {
+    .c-toggle-icon {
       box-shadow: 0 0 0 2px $primary_1;
     }
   }
@@ -90,8 +99,7 @@ $iconSize: 2.75rem;
     text-align: left;
   }
 
-  .icon-bars,
-  .icon-info {
+  .c-toggle-icon {
     position: relative; // Allow the badge to be anchored to the icon rather than to the button.
     border-radius: 50%;
     width: $iconSize;
@@ -112,8 +120,7 @@ $iconSize: 2.75rem;
     top: 0;
     transition: height 1ms 1ms, width 1ms 1ms, background $speed * 0.5;
 
-    .icon-info,
-    .icon-bars {
+    .c-toggle-icon {
       transition: opacity 1ms 1ms;
       opacity: 0;
     }

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -1016,7 +1016,7 @@ export default ({
           this.$refs.conversation.scrollToItem(index)
 
           // Sometimes, scrollToItem() above doesn't necessarily lead to 'scroll' event (eg. target message is the latest message but the scroll position is already at the bottom)
-          // and in that case, some scroll-position related states (chatroomReadUntilMessageHash, chatroomScrollPosotion) doesn't get updated which leads to a bug
+          // and in that case, some scroll-position related states (currentChatRoomReadUntil etc.) doesn't get updated which leads to a bug
           // where unread-message count doesn't get reset even after the user reads the latest message. (https://github.com/okTurtles/group-income/issues/2962)
           // So triggering 'onChatScroll()' here manually once to ensure these states are updated.
           this.onChatScroll()

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -201,7 +201,7 @@ const onChatScroll = function (ev) {
 
   if (curScrollTop < 5) {
     this.onScrollStart()
-  } else if (curScrollTop + 5 > scrollTopMax) {
+  } else if (curScrollTop + 5 > curScrollTopMax) {
     this.onScrollEnd()
   }
 
@@ -1014,6 +1014,12 @@ export default ({
           })
         } else {
           this.$refs.conversation.scrollToItem(index)
+
+          // Sometimes, scrollToItem() above doesn't necessarily lead to 'scroll' event (eg. target message is the latest message but the scroll position is already at the bottom)
+          // and in that case, some scroll-position related states (chatroomReadUntilMessageHash, chatroomScrollPosotion) doesn't get updated which leads to a bug
+          // where unread-message count doesn't get reset even after the user reads the latest message. (https://github.com/okTurtles/group-income/issues/2962)
+          // So triggering 'onChatScroll()' here manually once to ensure these states are updated.
+          this.onChatScroll()
         }
       }
 

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -1016,7 +1016,7 @@ export default ({
           this.$refs.conversation.scrollToItem(index)
 
           // Sometimes, scrollToItem() above doesn't necessarily lead to 'scroll' event (eg. target message is the latest message but the scroll position is already at the bottom)
-          // and in that case, some scroll-position related states (currentChatRoomReadUntil etc.) doesn't get updated which leads to a bug
+          // and in that case, some scroll-position related states (currentChatRoomReadUntil, currentChatRoomScrollPosition, etc.) doesn't get updated which leads to a bug
           // where unread-message count doesn't get reset even after the user reads the latest message. (https://github.com/okTurtles/group-income/issues/2962)
           // So triggering 'onChatScroll()' here manually once to ensure these states are updated.
           this.onChatScroll()

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -201,7 +201,7 @@ const onChatScroll = function (ev) {
 
   if (curScrollTop < 5) {
     this.onScrollStart()
-  } else if (curScrollTop + 5 > curScrollTopMax) {
+  } else if (curScrollTop + 5 > scrollTopMax) {
     this.onScrollEnd()
   }
 

--- a/test/cypress/integration/group-chat.spec.js
+++ b/test/cypress/integration/group-chat.spec.js
@@ -431,9 +431,9 @@ describe('Group Chat Basic Features (Create & Join & Leave & Close)', () => {
 
     cy.getByDT('groupMembers').find('ul>li').should('have.length', 2) // user1 & user2
 
-    // NOTE: this check is to wait until 2 additional notifications for the INTERACTIVE mesages are created
+    // NOTE: this check is to wait until 2 notifications for the INTERACTIVE mesages are created
     //       one for creating proposal and another is for proposal approval
-    cy.getByDT('groupChatLink').get('.c-badge.is-compact[aria-label="3 new notifications"]').contains('3')
+    cy.getByDT('groupChatLink').get('.c-badge.is-compact[aria-label="2 new notifications"]').contains('2')
 
     cy.giRedirectToGroupChat()
 


### PR DESCRIPTION
closes #3019 
closes #2962 

Updated the icon:

<img width="380" src="https://github.com/user-attachments/assets/93197fe9-44e1-4da8-8ce0-6e3653c2a035" />


While working on #3019, I kept encountering #2962 too:

https://github.com/user-attachments/assets/f287b595-1efe-44cf-843c-c94e125b4082

So made updates to fix it as well while at it.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3020">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
