### PR TITLE
#3026 - Two text overflow issues

### DIFF
--- a/frontend/assets/style/components/_cards.scss
+++ b/frontend/assets/style/components/_cards.scss
@@ -108,6 +108,7 @@ $card-shadow: 0 0 20px rgba(219, 219, 219, 0.6);
     width: 100%;
     padding: 0.75rem 1rem 1rem;
     user-select: text;
+    white-space: initial;
 
     @include tablet {
       padding: 0.875rem 1.25rem 1.25rem;

--- a/frontend/views/containers/chatroom/DeleteChannelModal.vue
+++ b/frontend/views/containers/chatroom/DeleteChannelModal.vue
@@ -19,7 +19,7 @@
           :args='LTags("strong")'
         ) This action {strong_}cannot be undone{_strong}.
 
-      label.checkbox(data-test='deleteChannelConfirmation')
+      label.checkbox.c-consent-checkbox(data-test='deleteChannelConfirmation')
         input.input(type='checkbox' name='confirmation' v-model='form.confirmation')
         i18n(:args='{ name: chatRoomAttributes.name, ...LTags("strong") }') Yes, I want to {strong_}delete {name} permanently{_strong}.
 
@@ -112,6 +112,15 @@ export default ({
   .c-list-item {
     list-style: initial;
     margin: 0.5rem 1rem;
+  }
+}
+
+.c-consent-checkbox {
+  width: 100%;
+
+  > :last-child {
+    white-space: initial;
+    word-break: break-all;
   }
 }
 </style>


### PR DESCRIPTION
closes #3026 

[ Fixes ]

<img width="520" src="https://github.com/user-attachments/assets/4d924b02-fe65-4846-9ac1-282388c24b80" />

<img width="520" src="https://github.com/user-attachments/assets/2ce584c0-dd42-407a-a55d-060a8015f927" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3029" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
