### PR TITLE
#3038 Chat UX improvements

### DIFF
--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -213,6 +213,10 @@
   .chat-emoji {
     font-size: 1.2em;
   }
+
+  .chat-emoji-only {
+    font-size: 2.25em;
+  }
 }
 
 // hover styles

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -471,7 +471,7 @@ export default ({
         })
     },
     isActive () {
-      return this.hasAttachments || this.ephemeral.textWithLines.trim()
+      return this.hasAttachments || this.ephemeral.textWithLines.trim().length > 0
     },
     textareaStyles () {
       return {
@@ -1406,7 +1406,6 @@ export default ({
 .c-send-button {
   color: $white;
   background: $general_0;
-  background: grey;
   margin-right: 0.5rem;
   margin-bottom: 0.5rem;
   height: 2rem;

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -471,7 +471,7 @@ export default ({
         })
     },
     isActive () {
-      return this.hasAttachments || this.ephemeral.textWithLines
+      return this.hasAttachments || this.ephemeral.textWithLines.trim()
     },
     textareaStyles () {
       return {

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
@@ -98,8 +98,12 @@ export default ({
       const containsMentionChar = str => new RegExp(`[${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR}]`, 'g').test(text)
       const wrapEmojis = str => {
         const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu
+        const isOnlyEmojis = str.replace(emojiRegex, '').trim().length === 0
+
         // We should be able to style the emojis in message-text (reference issue: https://github.com/okTurtles/group-income/issues/2464)
-        return str.replace(emojiRegex, '<span class="chat-emoji">$1</span>')
+        return isOnlyEmojis
+          ? `<span class="chat-emoji-only">${str}</span>`
+          : str.replace(emojiRegex, '<span class="chat-emoji">$1</span>')
       }
 
       if (!text) { return [] }

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
@@ -95,19 +95,23 @@ export default ({
       return o.type === TextObjectType.ChannelMention
     },
     generateTextObjectsFromText (text) {
-      const containsMentionChar = str => new RegExp(`[${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR}]`, 'g').test(text)
-      const wrapEmojis = str => {
-        const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu
-        const isOnlyEmojis = str.replace(emojiRegex, '').trim().length === 0
+      const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu
+      const isOnlyEmojis = text.replace(emojiRegex, '').trim().length === 0
 
+      const containsMentionChar = str => new RegExp(`[${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR}]`, 'g').test(str)
+      const wrapEmojis = str => {
         // We should be able to style the emojis in message-text (reference issue: https://github.com/okTurtles/group-income/issues/2464)
-        return isOnlyEmojis
-          ? `<span class="chat-emoji-only">${str}</span>`
-          : str.replace(emojiRegex, '<span class="chat-emoji">$1</span>')
+        return str.replace(emojiRegex, '<span class="chat-emoji">$1</span>')
       }
 
-      if (!text) { return [] }
-      if (!containsMentionChar(text)) {
+      if (!text) {
+        return []
+      } else if (isOnlyEmojis) {
+        return [{
+          type: TextObjectType.Text,
+          text: `<span class="chat-emoji-only">${text}</span>`
+        }]
+      } else if (!containsMentionChar(text)) {
         return [{
           type: TextObjectType.Text,
           text: wrapEmojis(text)


### PR DESCRIPTION
closes #3038 

<img width="287" src="https://github.com/user-attachments/assets/37c9fbc4-6abb-4a7c-94a4-031f7bf6e9c2" />

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3039" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
