### PR TITLE
#3022 Fix blob URL and cache index memory leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ strings.exe
 /strings.mac
 /strings.linux
 /.tldr*
+/.agents/

--- a/frontend/model/database.js
+++ b/frontend/model/database.js
@@ -380,7 +380,7 @@ const filesCache = localforage.createInstance({
 const maxFileEntries = 100
 
 sbp('sbp/selectors/register', {
-  'gi.db/filesCache/save': function (cacheKey: string, blob: Blob): Promise<*> {
+  'gi.db/filesCache/save': async function (cacheKey: string, blob: Blob): Promise<*> {
     if (cacheKey.startsWith('__')) throw new Error('Invalid key')
     // We need to perform several operations in the DB, which includes
     // the operation requested (i.e., saving a file) and updating the `keys`
@@ -388,7 +388,7 @@ sbp('sbp/selectors/register', {
     // Because the `keys` entry is a point of contention among calls and we
     // can only perform a single storage operation at the same time, we use
     // a queue to ensure that all operations are done atomically.
-    return sbp('okTurtles.eventQueue/queueEvent', 'gi.db/files', async () => {
+    return await sbp('okTurtles.eventQueue/queueEvent', 'gi.db/files', async () => {
       const keys = await filesCache.getItem('keys') ?? []
       return filesCache.setItem(cacheKey, blob).then(async v => {
         console.log('successfully saved:', cacheKey)

--- a/frontend/model/database.js
+++ b/frontend/model/database.js
@@ -380,7 +380,7 @@ const filesCache = localforage.createInstance({
 const maxFileEntries = 100
 
 sbp('sbp/selectors/register', {
-  'gi.db/filesCache/save': async function (cacheKey: string, blob: Blob): Promise<*> {
+  'gi.db/filesCache/save': function (cacheKey: string, blob: Blob): Promise<*> {
     if (cacheKey.startsWith('__')) throw new Error('Invalid key')
     // We need to perform several operations in the DB, which includes
     // the operation requested (i.e., saving a file) and updating the `keys`

--- a/frontend/model/database.js
+++ b/frontend/model/database.js
@@ -375,20 +375,21 @@ const filesCache = localforage.createInstance({
   storeName: 'Files Cache'
 })
 
+// TODO: we should probably do this based on the total size (e.g. 1 movie means
+// the cache should have fewer items).
 const maxFileEntries = 100
 
 sbp('sbp/selectors/register', {
   'gi.db/filesCache/save': async function (cacheKey: string, blob: Blob): Promise<*> {
     if (cacheKey.startsWith('__')) throw new Error('Invalid key')
-    const keys = await filesCache.getItem('keys') ?? []
-
     // We need to perform several operations in the DB, which includes
     // the operation requested (i.e., saving a file) and updating the `keys`
     // entry for caching, as well as possibly deleting cached entries.
     // Because the `keys` entry is a point of contention among calls and we
     // can only perform a single storage operation at the same time, we use
     // a queue to ensure that all operations are done atomically.
-    return sbp('okTurtles.eventQueue/queueEvent', 'gi.db/files', () => {
+    return sbp('okTurtles.eventQueue/queueEvent', 'gi.db/files', async () => {
+      const keys = await filesCache.getItem('keys') ?? []
       return filesCache.setItem(cacheKey, blob).then(async v => {
         console.log('successfully saved:', cacheKey)
         const idx = keys.indexOf(cacheKey)

--- a/frontend/model/database.js
+++ b/frontend/model/database.js
@@ -465,6 +465,8 @@ sbp('sbp/selectors/register', {
       const keys = await filesCache.getItem('keys') ?? []
       const allTempKeys = keys.filter(k => k.startsWith('temporary/'))
       await filesCache.removeMany(allTempKeys)
+      const remainingKeys = keys.filter(k => !k.startsWith('temporary/'))
+      await filesCache.setItem('keys', remainingKeys)
     }).catch(e => {
       console.error('[gi.db/filesCache/temporary/clear] Error removing temporary keys', e)
     })

--- a/frontend/views/components/avatar-editor/AvatarEditorModal.vue
+++ b/frontend/views/components/avatar-editor/AvatarEditorModal.vue
@@ -153,6 +153,15 @@ export default ({
       this.form.slider = ZOOM_SLIDER_MIN // init the slider zoom value before re-rendering components
       this.ephemeral.canvasComponentKey = randomHexString(10)
     }
+  },
+  beforeDestroy () {
+    const initialUrl = this.$route.query.imageUrl
+    if (initialUrl) {
+      URL.revokeObjectURL(initialUrl)
+    }
+    if (this.ephemeral.replaceImageUrl) {
+      URL.revokeObjectURL(this.ephemeral.replaceImageUrl)
+    }
   }
 }: Object)
 </script>

--- a/frontend/views/components/avatar-editor/AvatarEditorModal.vue
+++ b/frontend/views/components/avatar-editor/AvatarEditorModal.vue
@@ -102,6 +102,7 @@ export default ({
         slider: ZOOM_SLIDER_MIN
       },
       ephemeral: {
+        initialImageUrl: '',
         replaceImageUrl: '',
         // 'canvasComponentKey' below is updated every time a new image is loaded and is used to destory/re-render the children components.
         canvasComponentKey: randomHexString(10)
@@ -154,10 +155,12 @@ export default ({
       this.ephemeral.canvasComponentKey = randomHexString(10)
     }
   },
+  created () {
+    this.ephemeral.initialImageUrl = this.$route.query.imageUrl
+  },
   beforeDestroy () {
-    const initialUrl = this.$route.query.imageUrl
-    if (initialUrl) {
-      URL.revokeObjectURL(initialUrl)
+    if (this.ephemeral.initialImageUrl) {
+      URL.revokeObjectURL(this.ephemeral.initialImageUrl)
     }
     if (this.ephemeral.replaceImageUrl) {
       URL.revokeObjectURL(this.ephemeral.replaceImageUrl)

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -83,6 +83,8 @@
           @click='onMediaPreviewCardClick(fileType(entry), entry.url)'
         )
 
+  // NOTE: should call stopPropagation here to keep showing the PinnedMessages dialog
+  //       when user tries to download attachment inside the dialog
   a.c-invisible-link(ref='downloadHelper' @click.stop='')
 </template>
 

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -133,7 +133,8 @@ export default {
       settledImgURLList: [],
       config: {
         CHATROOM_ATTACHMENT_TYPES: CHATROOM_ATTACHMENT_TYPES
-      }
+      },
+      staleDownloadObjectUrl: null
     }
   },
   computed: {
@@ -181,14 +182,7 @@ export default {
     }
   },
   beforeDestroy () {
-    if (this.hasMediaAttachments) {
-      sbp('okTurtles.events/off', DELETE_ATTACHMENT, this.deleteAttachment)
-
-      if (this.isForDownload) {
-        // make sure to revoke all media object URLs when the component is destroyed
-        this.revokeAllMediaObjectURLs()
-      }
-    }
+    this.clearResources()
   },
   methods: {
     initMediaObjectURLLists () {
@@ -316,10 +310,10 @@ export default {
         aTag.click()
 
         if (!objectURL) {
-          setTimeout(() => {
-            aTag.href = '#'
-            URL.revokeObjectURL(url)
-          }, 0)
+          if (this.staleDownloadObjectUrl) {
+            URL.revokeObjectURL(this.staleDownloadObjectUrl)
+          }
+          this.staleDownloadObjectUrl = url
         }
       } catch (err) {
         console.error('error caught while downloading a file: ', err)
@@ -406,6 +400,20 @@ export default {
     },
     getAttachmentId (attachment) {
       return attachment.downloadData?.manifestCid || attachment.name.replace(/\s+/g, '_')
+    },
+    clearResources () {
+      if (this.hasMediaAttachments) {
+        sbp('okTurtles.events/off', DELETE_ATTACHMENT, this.deleteAttachment)
+
+        if (this.isForDownload) {
+          // make sure to revoke all media object URLs when the component is destroyed
+          this.revokeAllMediaObjectURLs()
+        }
+      }
+
+      if (this.staleDownloadObjectUrl) {
+        URL.revokeObjectURL(this.staleDownloadObjectUrl)
+      }
     }
   },
   watch: {

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -134,7 +134,9 @@ export default {
       config: {
         CHATROOM_ATTACHMENT_TYPES: CHATROOM_ATTACHMENT_TYPES
       },
-      staleDownloadObjectUrl: null
+      ephemeral: {
+        staleDownloadObjectUrl: null
+      }
     }
   },
   computed: {
@@ -310,10 +312,10 @@ export default {
         aTag.click()
 
         if (!objectURL) {
-          if (this.staleDownloadObjectUrl) {
-            URL.revokeObjectURL(this.staleDownloadObjectUrl)
+          if (this.ephemeral.staleDownloadObjectUrl) {
+            URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
           }
-          this.staleDownloadObjectUrl = url
+          this.ephemeral.staleDownloadObjectUrl = url
         }
       } catch (err) {
         console.error('error caught while downloading a file: ', err)
@@ -411,8 +413,8 @@ export default {
         }
       }
 
-      if (this.staleDownloadObjectUrl) {
-        URL.revokeObjectURL(this.staleDownloadObjectUrl)
+      if (this.ephemeral.staleDownloadObjectUrl) {
+        URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
       }
     }
   },

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -83,7 +83,7 @@
           @click='onMediaPreviewCardClick(fileType(entry), entry.url)'
         )
 
-  a.c-invisible-link(ref='downloadHelper' @click.stop)
+  a.c-invisible-link(ref='downloadHelper' @click.stop='')
 </template>
 
 <script>

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -83,7 +83,7 @@
           @click='onMediaPreviewCardClick(fileType(entry), entry.url)'
         )
 
-  a.c-invisible-link(ref='downloadHelper')
+  a.c-invisible-link(ref='downloadHelper' @click.stop)
 </template>
 
 <script>
@@ -313,13 +313,14 @@ export default {
         aTag.setAttribute('href', url)
         aTag.setAttribute('download', attachment.name)
 
-        aTag.addEventListener('click', function (event) {
-          // NOTE: should call stopPropagation here to keep showing the PinnedMessages dialog
-          //       when user trys to download attachment inside the dialog
-          event.stopPropagation()
-        })
-
         aTag.click()
+
+        if (!objectURL) {
+          setTimeout(() => {
+            aTag.href = '#'
+            URL.revokeObjectURL(url)
+          }, 0)
+        }
       } catch (err) {
         console.error('error caught while downloading a file: ', err)
       }

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -34,7 +34,7 @@
         :variant='variant'
         :canDelete='canDelete'
         :mediaObjectURL='mediaObjectURLList.audio[entryIndex]'
-        @download='downloadAttachment(entry)'
+        @download='downloadAttachment(entry, mediaObjectURLList.audio[entryIndex])'
         @delete='deleteAttachment({ index: entryIndex, type: config.CHATROOM_ATTACHMENT_TYPES.AUDIO })'
       )
 
@@ -135,9 +135,6 @@ export default {
       settledImgURLList: [],
       config: {
         CHATROOM_ATTACHMENT_TYPES: CHATROOM_ATTACHMENT_TYPES
-      },
-      ephemeral: {
-        staleDownloadObjectUrl: null
       }
     }
   },
@@ -193,10 +190,6 @@ export default {
         // make sure to revoke all media object URLs when the component is destroyed
         this.revokeAllMediaObjectURLs()
       }
-    }
-
-    if (this.ephemeral.staleDownloadObjectUrl) {
-      URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
     }
   },
   methods: {
@@ -312,6 +305,14 @@ export default {
       }
     },
     async downloadAttachment (attachment, objectURL = null) {
+      // NOTE: objectURL argument here -
+      // objectURLs of some media attachments are generated immediately during component initialization.
+      // eg.1: Image attachments are downloaded and displayed immediately.
+      // eg.2: If user has downloaded/played some audio/videos before, their blobs are stored as temp caches in indexedDB so that
+      //       users don't have to download them again for the session. ObjectURLs of these temp caches are also generated immediately
+      //       during component initialization so they look just playable without presenting download button.
+      //
+      // In these cases, we can just use these pre-generated objectURLs for downloading.
       if (!attachment.downloadData) { return }
 
       // reference: https://blog.logrocket.com/programmatically-downloading-files-browser/
@@ -325,10 +326,9 @@ export default {
         aTag.click()
 
         if (!objectURL) {
-          if (this.ephemeral.staleDownloadObjectUrl) {
-            URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
-          }
-          this.ephemeral.staleDownloadObjectUrl = url
+          setTimeout(() => {
+            URL.revokeObjectURL(url)
+          }, 500)
         }
       } catch (err) {
         console.error('error caught while downloading a file: ', err)

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -184,7 +184,18 @@ export default {
     }
   },
   beforeDestroy () {
-    this.clearResources()
+    if (this.hasMediaAttachments) {
+      sbp('okTurtles.events/off', DELETE_ATTACHMENT, this.deleteAttachment)
+
+      if (this.isForDownload) {
+        // make sure to revoke all media object URLs when the component is destroyed
+        this.revokeAllMediaObjectURLs()
+      }
+    }
+
+    if (this.ephemeral.staleDownloadObjectUrl) {
+      URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
+    }
   },
   methods: {
     initMediaObjectURLLists () {
@@ -402,20 +413,6 @@ export default {
     },
     getAttachmentId (attachment) {
       return attachment.downloadData?.manifestCid || attachment.name.replace(/\s+/g, '_')
-    },
-    clearResources () {
-      if (this.hasMediaAttachments) {
-        sbp('okTurtles.events/off', DELETE_ATTACHMENT, this.deleteAttachment)
-
-        if (this.isForDownload) {
-          // make sure to revoke all media object URLs when the component is destroyed
-          this.revokeAllMediaObjectURLs()
-        }
-      }
-
-      if (this.ephemeral.staleDownloadObjectUrl) {
-        URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
-      }
     }
   },
   watch: {

--- a/frontend/views/containers/payments/ExportPaymentsModal.vue
+++ b/frontend/views/containers/payments/ExportPaymentsModal.vue
@@ -69,8 +69,7 @@ export default ({
       },
       ephemeral: {
         periodOpts: [],
-        downloadName: '',
-        staleDownloadObjectUrl: null
+        downloadName: ''
       }
     }
   },
@@ -157,10 +156,9 @@ export default ({
 
       this.$nextTick(() => {
         this.$refs.downloadHelper.click()
-        if (this.ephemeral.staleDownloadObjectUrl) {
-          URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
-        }
-        this.ephemeral.staleDownloadObjectUrl = downloadUrl
+        setTimeout(() => {
+          URL.revokeObjectURL(downloadUrl)
+        }, 500)
       })
     }
   },
@@ -169,11 +167,6 @@ export default ({
       this.ephemeral.periodOpts = uniq(this.data.map(entry => entry.period))
     } else {
       this.close()
-    }
-  },
-  beforeDestroy () {
-    if (this.ephemeral.staleDownloadObjectUrl) {
-      URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
     }
   }
 })

--- a/frontend/views/containers/payments/ExportPaymentsModal.vue
+++ b/frontend/views/containers/payments/ExportPaymentsModal.vue
@@ -70,7 +70,8 @@ export default ({
       ephemeral: {
         periodOpts: [],
         downloadUrl: '',
-        downloadName: ''
+        downloadName: '',
+        staleDownloadObjectUrl: ''
       }
     }
   },
@@ -157,6 +158,10 @@ export default ({
 
       this.$nextTick(() => {
         this.$refs.downloadHelper.click()
+        if (this.ephemeral.staleDownloadObjectUrl) {
+          URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
+        }
+        this.ephemeral.staleDownloadObjectUrl = downloadUrl
       })
     }
   },
@@ -165,6 +170,11 @@ export default ({
       this.ephemeral.periodOpts = uniq(this.data.map(entry => entry.period))
     } else {
       this.close()
+    }
+  },
+  beforeDestroy () {
+    if (this.ephemeral.staleDownloadObjectUrl) {
+      URL.revokeObjectURL(this.ephemeral.staleDownloadObjectUrl)
     }
   }
 })

--- a/frontend/views/containers/payments/ExportPaymentsModal.vue
+++ b/frontend/views/containers/payments/ExportPaymentsModal.vue
@@ -69,9 +69,8 @@ export default ({
       },
       ephemeral: {
         periodOpts: [],
-        downloadUrl: '',
         downloadName: '',
-        staleDownloadObjectUrl: ''
+        staleDownloadObjectUrl: null
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "sass-dist": "node-sass --output-style compressed -o ./dist/assets/css ./frontend/assets/style",
     "cy:open": "CYPRESS_BASE_URL=http://localhost:8000 cypress open",
     "test": "grunt test",
+    "eslint": "eslint \"**/*.{js,vue}\"",
     "eslintfix": "eslint \"**/*.{js,vue}\" --fix",
     "i18n": "node scripts/i18n.js",
     "flow": "flow",


### PR DESCRIPTION
These are changes by Opus 4.6 per the [review here](https://github.com/okTurtles/group-income/issues/3022#issuecomment-4013860288) in issue #3022 to address memory leaks.

Requesting @SebinSong to take over this one.

- ChatAttachmentPreview: replace anonymous addEventListener with @click.stop on the invisible download link, and revoke freshly-created blob URLs after the browser initiates the download (using setTimeout to let the click land first). Previously every download leaked both an event listener and a blob URL.

- AvatarEditorModal: add beforeDestroy hook that revokes the initial imageUrl (passed via $route.query) and the replacement blob URL stored in ephemeral.replaceImageUrl. Both were leaked when the modal closed.

- gi.db/filesCache/temporary/clear: after removeMany() deletes all temporary-prefixed entries, write the filtered keys array back to the 'keys' index. Without this the index grew monotonically and stale keys were never cleaned up.

Also adds an 'eslint' npm script and ignores the .agents/ directory.

Assisted by Claude Opus 4.6
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3042" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
