### PR TITLE
#3044 - Chat emoji size bug

### DIFF
--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -28,6 +28,7 @@
   }
 
   &.has-only-emojis {
+    // If the message only contains emojis, make the text-size larger.
     font-size: 2.25em;
   }
 

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -27,6 +27,10 @@
     }
   }
 
+  &.has-only-emojis {
+    font-size: 2.25em;
+  }
+
   // inline code styles
   code {
     display: inline-block;

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -30,6 +30,10 @@
   &.has-only-emojis {
     // If the message only contains emojis, make the text-size larger.
     font-size: 2.25em;
+
+    .chat-emoji {
+      font-size: inherit;
+    }
   }
 
   // inline code styles

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -213,10 +213,6 @@
   .chat-emoji {
     font-size: 1.2em;
   }
-
-  .chat-emoji-only {
-    font-size: 2.25em;
-  }
 }
 
 // hover styles

--- a/frontend/utils/constants.js
+++ b/frontend/utils/constants.js
@@ -12,6 +12,7 @@ export const CHAT_ATTACHMENT_SIZE_LIMIT = 30 * MEGABYTE // in byte.
 export const IMAGE_ATTACHMENT_MAX_SIZE = 400 * KILOBYTE // 400KB
 export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_DESKTOP = 500 * 1.25 // in px
 export const CHAT_LONG_MESSAGE_HEIGHT_THRESHOLD_MOBILE = 500 * 1.5 // The value of mobile is more tolerant considering smaller screen size.
+export const EMOJI_REGEX: any = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu
 
 export const TextObjectType = {
   Text: 'TEXT',

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
@@ -40,7 +40,7 @@ import {
   CHATROOM_REPLYING_MESSAGE_LIMITS_IN_CHARS
 } from '@model/contracts/shared/constants.js'
 import { makeMentionFromUserID, makeChannelMention, getIdFromChannelMention } from '@model/chatroom/utils.js'
-import { TextObjectType } from '@utils/constants.js'
+import { TextObjectType, EMOJI_REGEX } from '@utils/constants.js'
 import { L } from '@common/common.js'
 
 export default ({
@@ -97,9 +97,8 @@ export default ({
     generateTextObjectsFromText (text) {
       const containsMentionChar = str => new RegExp(`[${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR}]`, 'g').test(str)
       const wrapEmojis = str => {
-        const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu
         // We should be able to style the emojis in message-text (reference issue: https://github.com/okTurtles/group-income/issues/2464)
-        return str.replace(emojiRegex, '<span class="chat-emoji">$1</span>')
+        return str.replace(EMOJI_REGEX, '<span class="chat-emoji">$1</span>')
       }
 
       if (!text) {

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageText.vue
@@ -95,22 +95,15 @@ export default ({
       return o.type === TextObjectType.ChannelMention
     },
     generateTextObjectsFromText (text) {
-      const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu
-      const isOnlyEmojis = text.replace(emojiRegex, '').trim().length === 0
-
       const containsMentionChar = str => new RegExp(`[${CHATROOM_MEMBER_MENTION_SPECIAL_CHAR}${CHATROOM_CHANNEL_MENTION_SPECIAL_CHAR}]`, 'g').test(str)
       const wrapEmojis = str => {
+        const emojiRegex = /(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu
         // We should be able to style the emojis in message-text (reference issue: https://github.com/okTurtles/group-income/issues/2464)
         return str.replace(emojiRegex, '<span class="chat-emoji">$1</span>')
       }
 
       if (!text) {
         return []
-      } else if (isOnlyEmojis) {
-        return [{
-          type: TextObjectType.Text,
-          text: `<span class="chat-emoji-only">${text}</span>`
-        }]
       } else if (!containsMentionChar(text)) {
         return [{
           type: TextObjectType.Text,

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageWithMarkdown.js
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageWithMarkdown.js
@@ -5,6 +5,7 @@ import { validateURL, logExceptNavigationDuplicated } from '@view-utils/misc.js'
 import { OPEN_TOUCH_LINK_HELPER } from '@utils/events.js'
 import { htmlStringToDomObjectTree } from './chat-mentions-utils.js'
 import RenderMessageText from './RenderMessageText.vue'
+import { EMOJI_REGEX } from '@utils/constants.js'
 
 // reference (Vue render function): https://v2.vuejs.org/v2/guide/render-function
 const RenderMessageWithMarkdown: any = {
@@ -20,7 +21,7 @@ const RenderMessageWithMarkdown: any = {
   },
   render: function (createElement: any): any {
     const { text, edited = false, isReplyingMessage = false } = this.$props
-    const isOnlyEmojis = text.replace(/(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu, '').trim().length === 0
+    const isOnlyEmojis = text.replace(EMOJI_REGEX, '').trim().length === 0
     const domTree = htmlStringToDomObjectTree(renderMarkdown(text))
 
     // Turns a dom tree object structure into the equivalent recursive createElement(...) call structure.

--- a/frontend/views/containers/chatroom/chat-mentions/RenderMessageWithMarkdown.js
+++ b/frontend/views/containers/chatroom/chat-mentions/RenderMessageWithMarkdown.js
@@ -20,6 +20,7 @@ const RenderMessageWithMarkdown: any = {
   },
   render: function (createElement: any): any {
     const { text, edited = false, isReplyingMessage = false } = this.$props
+    const isOnlyEmojis = text.replace(/(\p{Emoji_Presentation}|\p{Emoji}\uFE0F|[\u2615-\u27BF]|\u200D)/gu, '').trim().length === 0
     const domTree = htmlStringToDomObjectTree(renderMarkdown(text))
 
     // Turns a dom tree object structure into the equivalent recursive createElement(...) call structure.
@@ -89,7 +90,8 @@ const RenderMessageWithMarkdown: any = {
       {
         class: {
           'c-replying': isReplyingMessage,
-          'custom-markdown-content': true
+          'custom-markdown-content': true,
+          'has-only-emojis': isOnlyEmojis
         },
         attrs: { ...(this.$attrs || {}) },
         on: { ...(this.$listeners || {}) }


### PR DESCRIPTION
closes #3044 

<img width="430" src="https://github.com/user-attachments/assets/e09bfb85-5612-4032-b285-c54524b6d360" />

As mentioned [here](https://github.com/okTurtles/group-income/issues/3044#issuecomment-4019906252), the issue happens when the emoji directly follows markdown syntaxes. Fixed it.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3046" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
