### PR TITLE
Fix badge count

### DIFF
--- a/test/cypress/integration/group-chat-message.spec.js
+++ b/test/cypress/integration/group-chat-message.spec.js
@@ -227,7 +227,7 @@ describe('Send/edit/remove/reply/pin/unpin messages & add/remove reactions insid
 
   it('user1 sees a mention and three reactions, and he sends two mentions and one reaction too', () => {
     switchUser(user1)
-    cy.getByDT('groupChatLink').get('.c-badge.is-compact[aria-label="1 new notifications"]').contains('1')
+    cy.getByDT('groupChatLink').get('.c-badge.is-compact[aria-label="3 new notifications"]').contains('3')
     cy.giRedirectToGroupChat()
     cy.giSendMessage(me, `Hi ${makeMentionFromUsername(user2).me}. Anytime!`)
     cy.giSendMessage(me, `Hi ${makeMentionFromUsername(user2).all}. No matter what, I will always be by your side.`)


### PR DESCRIPTION
Addresses issue of tests sometimes not passing. Badge is displayed for 'all messages' (as per default notification settings), rendering the previous count inaccurate (which just considered mentions).

Closes #3052.

Relevant code:

```js
  chatNotificationSettings (state) {
    return Object.assign({
      publicDefault: {
        messageNotification: MESSAGE_NOTIFY_SETTINGS.ALL_MESSAGES,
        messageSound: MESSAGE_NOTIFY_SETTINGS.DIRECT_MESSAGES
      },
      // ...
    }, state.chatNotificationSettings || {})
  },
```

```
  const chatNotificationSettings = rootGetters.chatNotificationSettings[contractID] || (privacyLevelPrivate
    ? rootGetters.chatNotificationSettings.privateDefault
    : rootGetters.chatNotificationSettings.publicDefault
  )
  const { messageNotification, messageSound } = chatNotificationSettings
  // messageNotification === MESSAGE_NOTIFY_SETTINGS.ALL_MESSAGE will be true
  const shouldNotifyMessage = messageNotification === MESSAGE_NOTIFY_SETTINGS.ALL_MESSAGES ||
  (messageNotification === MESSAGE_NOTIFY_SETTINGS.DIRECT_MESSAGES && isDMOrMention)
  const shouldSoundMessage = messageSound === MESSAGE_NOTIFY_SETTINGS.ALL_MESSAGES ||
    (messageSound === MESSAGE_NOTIFY_SETTINGS.DIRECT_MESSAGES && isDMOrMention)
  const shouldAddToUnreadMessages = isDMOrMention ||
    (shouldNotifyMessage || shouldSoundMessage) ||
    [MESSAGE_TYPES.INTERACTIVE, MESSAGE_TYPES.POLL].includes(messageType)

  await sbp('chelonia/contract/retain', contractID, { ephemeral: true })
  try {
    if (shouldAddToUnreadMessages) {
      sbp('gi.actions/identity/kv/addChatRoomUnreadMessage', { contractID, messageHash, createdHeight: height }).catch(e => {
        console.error('[messageReceivePostEffect] Error calling addChatRoomUnreadMessage', e)
      })
    }

```
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
