### PR TITLE
#3068 - Two bugs related to `Replying to: ...` UI

### DIFF
--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -1931,6 +1931,7 @@ export default ({
         this.ephemeral.loadingDown = undefined
         this.ephemeral.loadingUp = undefined
 
+        this.stopReplying()
         this.cleanupFailedMessagesAttachments()
         sbp('chelonia/queueInvocation', toChatRoomId, () => initAfterSynced(toChatRoomId))
       }

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -15,6 +15,7 @@
   )
     .c-mentions(
       v-if='ephemeral.mention.options.length'
+      :class='{ "is-above-replying-message": !!replyingMessage }'
       ref='mentionWrapper'
     )
       template(v-if='ephemeral.mention.type === "member"')
@@ -1369,6 +1370,11 @@ export default ({
   overflow-y: auto;
   overflow-x: hidden;
   max-height: 12.25rem;
+
+  &.is-above-replying-message {
+    top: -2.25rem;
+    border-radius: 0.3rem;
+  }
 
   .c-mention-user,
   .c-mention-channel {

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -1372,7 +1372,7 @@ export default ({
   max-height: 12.25rem;
 
   &.is-above-replying-message {
-    top: -2.25rem;
+    top: -2.3rem;
     border-radius: 0.3rem;
   }
 


### PR DESCRIPTION
closes #3068 

https://github.com/user-attachments/assets/fa1cac38-c6c9-41f4-b2a1-e400e53a30c4


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/okturtles/group-income/pull/3089" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
