### PR TITLE
#3091 - Broken dialog dismissal by `Esc` key in `Emoticons.vue`

### DIFF
--- a/frontend/views/containers/chatroom/Emoticons.vue
+++ b/frontend/views/containers/chatroom/Emoticons.vue
@@ -41,7 +41,8 @@ export default ({
   },
   methods: {
     handleKeyUp (e) {
-      if (this.content && e.key === 'Escape') {
+      const isFocused = e.target.closest('.c-picker-wrapper') !== null
+      if (this.isActive && isFocused && e.key === 'Escape') {
         e.preventDefault()
         this.closeEmoticonDlg()
       }


### PR DESCRIPTION
closes #3091 


[The original PR](https://github.com/okTurtles/group-income/pull/3092) was mixed up with changes for another task by mistake, so closed it and opened a new one here.