### PR TITLE
#3104, #3105 - Two issues with chat markdown

### DIFF
--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -199,10 +199,9 @@
   // horizontal rule styles
   hr {
     margin: 1rem 0;
-    height: 0;
-    border: none;
-    background: none;
-    border-top: 1px dotted $text_1;
+    height: 1px;
+    background-color: $general_0;
+    opacity: 0.785;
   }
 
   // code-fence block styles

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -45,6 +45,7 @@
   h6 {
     font-family: "Poppins";
     font-weight: bold;
+    line-height: 1.3;
 
     code {
       font-size: inherit;
@@ -216,7 +217,7 @@
     margin: 1rem 0;
     height: 1px;
     background-color: $general_0;
-    opacity: 0.785;
+    opacity: 0.8;
   }
 
   // code-fence block styles

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -196,6 +196,15 @@
     padding-top: 0;
   }
 
+  // horizontal rule styles
+  hr {
+    margin: 1rem 0;
+    height: 0;
+    border: none;
+    background: none;
+    border-top: 1px dotted $text_1;
+  }
+
   // code-fence block styles
   .code-fence-block {
     display: block;

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -36,6 +36,21 @@
     }
   }
 
+  // heading styles
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: "Poppins";
+    font-weight: bold;
+
+    code {
+      font-size: inherit;
+    }
+  }
+
   // inline code styles
   code {
     display: inline-block;

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -69,8 +69,8 @@ export function renderMarkdown (str: string): any {
   // STEP 4. Sanitize some <br/>s that directly precedes/follows <ul>, <ol>, <blockquote> elements.
   //         - These are block elements by themselves, meaning they naturally carry one line-breaks at the start/end the tag(s).
   //           So remove 1 direct sibling <br>s. (reference issue: https://github.com/okTurtles/group-income/issues/2529)
-  converted = converted.replace(/<br\/>\s*?(<ul>|<ol>|<blockquote>)/g, '$1')
-    .replace(/(<\/ul>|<\/ol>|<\/blockquote>)\s*?<br\/>/g, '$1')
+  converted = converted.replace(/<br\/>\s*?(<ul>|<ol>|<blockquote>|<hr>)/g, '$1')
+    .replace(/(<\/ul>|<\/ol>|<\/blockquote>|<hr>)\s*?<br\/>/g, '$1')
   return converted
 }
 


### PR DESCRIPTION
closes #3104 
closes #3105 

[Light theme]

<img width="490" src="https://github.com/user-attachments/assets/6bbd4779-e57a-4a9b-88d8-80ef9855924a" />

[Dark theme]

<img width="490" src="https://github.com/user-attachments/assets/fadc87ed-b3d4-429e-835b-2593670ae03c" />

---
[ Fix for heading-related issues ]

<img width="490" src="https://github.com/user-attachments/assets/6774eaa3-07f3-434e-9571-d964ec7ad830" />
