### PR TITLE
#3107 - Enhance table rendering in chat

### DIFF
--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -168,9 +168,8 @@
 
       th,
       td {
-        min-width: max-content;
         padding: 0.5rem 1rem 0.5rem 0;
-        word-break: break-word;
+        word-break: normal;
 
         &:first-child {
           padding-left: 0.75rem;


### PR DESCRIPTION
closes #3107 

it appears the `min-width: max-content` css rule was the primary source of the issue. So removed it and made a fix.

No unecessary right-spacing thus no unecessary scroll-bar in wide screen:

<img width="100%" src="https://github.com/user-attachments/assets/e789db3b-de96-4f82-9895-339524188569" />


Have also tried extending the table to check for a scenario where the horizontal scroll-bar _DOES_ need to exist:

https://github.com/user-attachments/assets/3344776e-46c2-484e-a7a1-37ea2bc7d232

