### PR TITLE
#3111 - Build minimal audio player for `SendArea.vue`

### DIFF
--- a/frontend/assets/style/_icons.scss
+++ b/frontend/assets/style/_icons.scss
@@ -50,6 +50,7 @@ $icons: (
   unlock-alt: "\f13e",
   minus: "\f068",
   minus-circle: "\f056",
+  music: "\f001",
   paper-plane: "\f1d8",
   pause: "\f04c",
   pencil-alt: "\f303",

--- a/frontend/assets/style/components/plyr/_plyr_override.scss
+++ b/frontend/assets/style/components/plyr/_plyr_override.scss
@@ -127,5 +127,16 @@ $phone_narrow: 430px;
         display: none;
       }
     }
+
+    &.is-minimal {
+      // minimal audio player controls for SendArea.vue
+      .plyr__volume {
+        display: none;
+      }
+
+      .plyr__progress__container {
+        margin-left: 0;
+      }
+    }
   }
 }

--- a/frontend/assets/style/components/plyr/_plyr_override.scss
+++ b/frontend/assets/style/components/plyr/_plyr_override.scss
@@ -136,6 +136,7 @@ $phone_narrow: 430px;
 
       .plyr__progress__container {
         margin-left: 0;
+        padding-left: 0;
       }
 
       .plyr--audio {
@@ -145,10 +146,6 @@ $phone_narrow: 430px;
       .plyr__time {
         font-size: v.$size_5;
         color: v.$text_1;
-      }
-
-      .plyr__progress__container {
-        padding-left: 0;
       }
 
       input[type="range"]::-moz-range-track,

--- a/frontend/assets/style/components/plyr/_plyr_override.scss
+++ b/frontend/assets/style/components/plyr/_plyr_override.scss
@@ -148,11 +148,15 @@ $phone_narrow: 430px;
         color: v.$text_1;
       }
 
+      input[type="range"]::-webkit-slider-runnable-track,
+      input[type="range"]::-ms-track,
       input[type="range"]::-moz-range-track,
       .plyr__progress__buffer {
         height: 4px;
       }
 
+      input[type="range"]::-webkit-slider-thumb,
+      input[type="range"]::-ms-thumb,
       input[type="range"]::-moz-range-thumb {
         width: 10px;
         height: 10px;

--- a/frontend/assets/style/components/plyr/_plyr_override.scss
+++ b/frontend/assets/style/components/plyr/_plyr_override.scss
@@ -137,6 +137,25 @@ $phone_narrow: 430px;
       .plyr__progress__container {
         margin-left: 0;
       }
+
+      .plyr--audio {
+        min-width: 0;
+      }
+
+      .plyr__time {
+        font-size: v.$size_5;
+        color: v.$text_1;
+      }
+
+      input[type="range"]::-moz-range-track,
+      .plyr__progress__buffer {
+        height: 4px;
+      }
+
+      input[type="range"]::-moz-range-thumb {
+        width: 10px;
+        height: 10px;
+      }
     }
   }
 }

--- a/frontend/assets/style/components/plyr/_plyr_override.scss
+++ b/frontend/assets/style/components/plyr/_plyr_override.scss
@@ -147,6 +147,10 @@ $phone_narrow: 430px;
         color: v.$text_1;
       }
 
+      .plyr__progress__container {
+        padding-left: 0;
+      }
+
       input[type="range"]::-moz-range-track,
       .plyr__progress__buffer {
         height: 4px;

--- a/frontend/views/components/AudioPlayer.vue
+++ b/frontend/views/components/AudioPlayer.vue
@@ -39,8 +39,7 @@ export default {
   data () {
     return {
       ephemeral: {
-        player: null,
-        isReady: false
+        player: null
       }
     }
   },
@@ -67,10 +66,6 @@ export default {
       )
 
       // event listeners
-      this.ephemeral.player.on('ready', () => {
-        this.ephemeral.isReady = true
-      })
-
       const events = ['play', 'playing', 'pause', 'ended']
       events.forEach(event => {
         this.ephemeral.player.on(event, () => this.$emit(event))

--- a/frontend/views/components/AudioPlayer.vue
+++ b/frontend/views/components/AudioPlayer.vue
@@ -91,6 +91,11 @@ export default {
   },
   mounted () {
     this.initPlayer()
+  },
+  beforeDestroy () {
+    if (this.ephemeral.player) {
+      this.ephemeral.player.destroy()
+    }
   }
 }
 </script>

--- a/frontend/views/components/AudioPlayer.vue
+++ b/frontend/views/components/AudioPlayer.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 .c-audio-player.plyr_override.for-audio(
-  :class='{ "hide-default-play-button": hideDefaultPlayButton, "is-unplayable": disabled }'
+  :class='{ "hide-default-play-button": hideDefaultPlayButton, "is-unplayable": disabled, "is-minimal": mode === "minimal" }'
 )
   audio(ref='audioEl' controls playsinline)
     source(:src='src' :type='mimeType')
@@ -23,6 +23,11 @@ export default {
     autoPlay: {
       type: Boolean,
       default: false
+    },
+    mode: {
+      type: String,
+      validator: v => ['default', 'minimal'].includes(v), // 'minimal' mode is intended for use in send area
+      default: 'default'
     },
     disabled: {
       type: Boolean,

--- a/frontend/views/components/AudioPlayer.vue
+++ b/frontend/views/components/AudioPlayer.vue
@@ -1,7 +1,5 @@
 <template lang="pug">
-.c-audio-player.plyr_override.for-audio(
-  :class='{ "hide-default-play-button": hideDefaultPlayButton, "is-unplayable": disabled, "is-minimal": mode === "minimal" }'
-)
+.c-audio-player.plyr_override.for-audio(:class='classObjs')
   audio(ref='audioEl' controls playsinline)
     source(:src='src' :type='mimeType')
 </template>
@@ -43,6 +41,15 @@ export default {
       ephemeral: {
         player: null,
         isReady: false
+      }
+    }
+  },
+  computed: {
+    classObjs () {
+      return {
+        'hide-default-play-button': this.hideDefaultPlayButton,
+        'is-unplayable': this.disabled,
+        'is-minimal': this.mode === 'minimal'
       }
     }
   },

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -1067,7 +1067,7 @@ export default ({
         [CHATROOM_ATTACHMENT_TYPES.VIDEO]: 0,
         [CHATROOM_ATTACHMENT_TYPES.IMAGE]: 1,
         [CHATROOM_ATTACHMENT_TYPES.AUDIO]: 2,
-        [CHATROOM_ATTACHMENT_TYPES.NON_MEDIA]: 2
+        [CHATROOM_ATTACHMENT_TYPES.NON_MEDIA]: 3
       }
       list.sort((a, b) => priority[getFileType(a.mimeType)] - priority[getFileType(b.mimeType)])
 

--- a/frontend/views/containers/chatroom/SendArea.vue
+++ b/frontend/views/containers/chatroom/SendArea.vue
@@ -1062,7 +1062,7 @@ export default ({
         list.push(attachment)
       }
 
-      // sort the list so that the media types come first in the array. (videos -> images -> non-media files)
+      // sort the list so that the media types come first in the array. (videos -> images -> audio -> non-media files)
       const priority = {
         [CHATROOM_ATTACHMENT_TYPES.VIDEO]: 0,
         [CHATROOM_ATTACHMENT_TYPES.IMAGE]: 1,

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -189,6 +189,20 @@ export default {
     padding-left: 0.25rem;
     margin-top: 0.25rem;
   }
+
+  &.for-send-area {
+    // minimal layout/styles for audio attachments in send area
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    grid-template-areas:
+      "play-button metadata"
+      "play-button player";
+    column-gap: 0.5rem;
+    padding-top: 0;
+    align-items: center;
+    background-color: $general_2;
+    max-width: 100%;
+  }
 }
 
 .c-spinner {

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -1,21 +1,20 @@
 <template lang="pug">
 .c-audio-player-card(:class='{ "for-send-area": forSendArea }')
-  .c-card-upper-section
-    button.is-unstyled.c-audio-play-button(
-      :class='{ "is-loading": ephemeral.isLoading }'
-      type='button'
-      :aria-label='L("Play")'
-      @click.stop='togglePlay'
-    )
-      .simple-spinner.c-spinner(v-if='ephemeral.loadingStatus === "loading"')
-      i.icon-pause(v-else-if='ephemeral.isPlaying')
-      i.icon-play(v-else)
+  button.is-unstyled.c-audio-play-button(
+    :class='{ "is-loading": ephemeral.isLoading }'
+    type='button'
+    :aria-label='L("Play")'
+    @click.stop='togglePlay'
+  )
+    .simple-spinner.c-spinner(v-if='ephemeral.loadingStatus === "loading"')
+    i.icon-pause(v-else-if='ephemeral.isPlaying')
+    i.icon-play(v-else)
 
-    .c-audio-metadata
-      .c-file-name.has-ellipsis(v-if='attachment.name' :title='attachment.name') {{ attachment.name }}
-      .c-file-size(v-if='size') {{ size }}
+  .c-audio-metadata
+    .c-file-name.has-ellipsis(v-if='attachment.name' :title='attachment.name') {{ attachment.name }}
+    .c-file-size(v-if='size') {{ size }}
 
-  audio-player.c-audio-player(
+  audio-player.c-audio-player-controls(
     ref='audioPlayer'
     :key='src || "audio-player"'
     :hideDefaultPlayButton='true'
@@ -113,16 +112,19 @@ export default {
 .c-audio-player-card {
   position: relative;
   width: 100%;
-
-  .c-card-upper-section {
-    display: flex;
-    align-items: center;
-    column-gap: 0.75rem;
-    padding: 0.25rem 1rem 0 0.25rem;
-    margin-bottom: 0.25rem;
-  }
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto auto;
+  grid-template-areas:
+    "play-button metadata"
+    "player player"
+    "error error";
+  column-gap: 0.75rem;
+  padding-top: 0.25rem;
+  align-items: center;
 
   button.c-audio-play-button {
+    grid-area: play-button;
     position: relative;
     display: inline-flex;
     align-items: center;
@@ -130,6 +132,7 @@ export default {
     flex-shrink: 0;
     width: 2.5rem;
     height: 2.5rem;
+    margin-left: 0.25rem;
     min-height: 0;
     border-radius: 50%;
     border: 1px solid rgba(0, 0, 0, 0);
@@ -151,9 +154,10 @@ export default {
   }
 
   .c-audio-metadata {
+    grid-area: metadata;
     position: relative;
-    flex-grow: 1;
     min-width: 0;
+    padding-right: 0.25rem;
 
     .c-file-name {
       position: relative;
@@ -174,10 +178,17 @@ export default {
       }
     }
   }
-}
 
-.is-dark-theme button.c-audio-play-button {
-  background-color: $primary_2;
+  .c-audio-player-controls {
+    grid-area: player;
+  }
+
+  .c-error {
+    grid-area: error;
+    font-size: $size_5;
+    padding-left: 0.25rem;
+    margin-top: 0.25rem;
+  }
 }
 
 .c-spinner {
@@ -187,9 +198,8 @@ export default {
   color: $primary_0;
 }
 
-.c-error {
-  font-size: $size_5;
-  padding-left: 0.25rem;
-  margin-top: 0.25rem;
+// dark-theme style adjustments
+.is-dark-theme button.c-audio-play-button {
+  background-color: $primary_2;
 }
 </style>

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -192,7 +192,7 @@ export default {
 
   &.for-send-area {
     // minimal layout/styles for audio attachments in send area
-    grid-template-columns: auto 1fr;
+    grid-template-columns: auto minmax(0, 1fr);
     grid-template-rows: auto auto;
     grid-template-areas:
       "play-button metadata"
@@ -201,7 +201,34 @@ export default {
     padding-top: 0;
     align-items: center;
     background-color: $general_2;
+    min-width: 0;
     max-width: 100%;
+
+    button.c-audio-play-button {
+      margin-left: 0;
+      width: 2.25rem;
+    height: 2.25rem;
+    }
+
+    .c-audio-metadata {
+      max-width: 100%;
+      line-height: 1.15;
+
+      .c-file-name {
+        padding-top: 0.25rem;
+        font-size: $size_5;
+        line-height: 1.125;
+      }
+    }
+
+    .c-audio-player-controls {
+      max-width: 100%;
+      min-width: 0;
+
+      ::v-deep plyr--audio {
+        min-width: 0;
+      }
+    }
   }
 }
 

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -11,6 +11,7 @@
     i.icon-play(v-else)
 
   .c-audio-metadata
+    i.icon-music.c-audio-icon
     .c-file-name.has-ellipsis(v-if='attachment.name' :title='attachment.name') {{ attachment.name }}
     .c-file-size(v-if='size') {{ size }}
 
@@ -165,6 +166,17 @@ export default {
       max-width: 100%;
     }
 
+    .c-audio-icon {
+      display: none;
+      font-size: 0.725em;
+      padding: 0.125rem 0.175rem;
+      border-radius: 2px;
+      color: $success_0;
+      background-color: $success_2;
+      transform: translateY(1px);
+      margin-bottom: 1px;
+    }
+
     .c-file-size {
       display: flex;
       align-items: center;
@@ -207,16 +219,23 @@ export default {
     button.c-audio-play-button {
       margin-left: 0;
       width: 2.25rem;
-    height: 2.25rem;
+      height: 2.25rem;
     }
 
     .c-audio-metadata {
+      display: flex;
+      align-items: center;
+      column-gap: 0.2rem;
       max-width: 100%;
+      padding-top: 0.25rem;
       line-height: 1.15;
 
+      .c-audio-icon {
+        display: inline-block;
+      }
+
       .c-file-name {
-        padding-top: 0.25rem;
-        font-size: $size_5;
+        font-size: 0.8rem;
         line-height: 1.125;
       }
     }
@@ -225,7 +244,7 @@ export default {
       max-width: 100%;
       min-width: 0;
 
-      ::v-deep plyr--audio {
+      ::v-deep .plyr--audio {
         min-width: 0;
       }
     }

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -27,7 +27,7 @@
   )
 
   i18n.error.c-error(
-    v-if='ephemeral.loadingStatus === "error"'
+    v-if='ephemeral.loadingStatus === "error" || true'
     tag='p'
   ) Failed to load audio. Please retry.
 </template>
@@ -228,6 +228,11 @@ export default {
       ::v-deep .plyr--audio {
         min-width: 0;
       }
+    }
+
+    .c-error {
+      // irrelevant in send area (any file attachment with a problem just won't be shown in the send area)
+      display: none;
     }
   }
 }

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -1,12 +1,12 @@
 <template lang="pug">
 .c-audio-player-card(:class='{ "for-send-area": forSendArea }')
   button.is-unstyled.c-audio-play-button(
-    :class='{ "is-loading": ephemeral.isLoading }'
+    :class='{ "is-loading": isLoading }'
     type='button'
     :aria-label='L("Play")'
     @click.stop='togglePlay'
   )
-    .simple-spinner.c-spinner(v-if='ephemeral.loadingStatus === "loading"')
+    .simple-spinner.c-spinner(v-if='isLoading')
     i.icon-pause(v-else-if='ephemeral.isPlaying')
     i.icon-play(v-else)
 
@@ -27,7 +27,7 @@
   )
 
   i18n.error.c-error(
-    v-if='ephemeral.loadingStatus === "error" || true'
+    v-if='ephemeral.loadingStatus === "error"'
     tag='p'
   ) Failed to load audio. Please retry.
 </template>
@@ -64,6 +64,11 @@ export default {
         loadingStatus: 'idle',
         isPlaying: false
       }
+    }
+  },
+  computed: {
+    isLoading () {
+      return this.ephemeral.loadingStatus === 'loading'
     }
   },
   methods: {

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -11,7 +11,6 @@
     i.icon-play(v-else)
 
   .c-audio-metadata
-    i.icon-music.c-audio-icon
     .c-file-name.has-ellipsis(v-if='attachment.name' :title='attachment.name') {{ attachment.name }}
     .c-file-size(v-if='size') {{ size }}
 
@@ -166,17 +165,6 @@ export default {
       max-width: 100%;
     }
 
-    .c-audio-icon {
-      display: none;
-      font-size: 0.725em;
-      padding: 0.125rem 0.175rem;
-      border-radius: 2px;
-      color: $success_0;
-      background-color: $success_2;
-      transform: translateY(1px);
-      margin-bottom: 1px;
-    }
-
     .c-file-size {
       display: flex;
       align-items: center;
@@ -223,16 +211,9 @@ export default {
     }
 
     .c-audio-metadata {
-      display: flex;
-      align-items: center;
-      column-gap: 0.2rem;
       max-width: 100%;
       padding-top: 0.25rem;
       line-height: 1.15;
-
-      .c-audio-icon {
-        display: inline-block;
-      }
 
       .c-file-name {
         font-size: 0.8rem;

--- a/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
+++ b/frontend/views/containers/chatroom/audio-player/AudioPlayerCard.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.c-audio-player-card
+.c-audio-player-card(:class='{ "for-send-area": forSendArea }')
   .c-card-upper-section
     button.is-unstyled.c-audio-play-button(
       :class='{ "is-loading": ephemeral.isLoading }'
@@ -22,6 +22,7 @@
     :disabled='!src'
     :src='src'
     :mimeType='mimeType'
+    :mode='forSendArea ? "minimal" : "default"'
     @playing='onPlaying'
     @pause='onPaused'
   )
@@ -50,6 +51,10 @@ export default {
     mimeType: {
       type: String,
       required: false
+    },
+    forSendArea: {
+      type: Boolean,
+      default: false
     },
     attachment: Object,
     size: String

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -65,8 +65,7 @@
         )
           .c-preview-non-media(@click.stop='')
             .c-non-media-icon
-              i.icon-headphones(v-if='fileType(entry) === config.CHATROOM_ATTACHMENT_TYPES.AUDIO')
-              i.icon-file(v-else)
+              i.icon-file
 
             .c-non-media-file-info
               .c-file-name.has-ellipsis {{ entry.name }}
@@ -514,7 +513,6 @@ export default {
   border-radius: 0.25rem;
   flex-shrink: 0;
 
-  &.is-audio,
   &.is-non-media {
     max-width: 17.25rem;
     min-width: 14rem;

--- a/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
+++ b/frontend/views/containers/chatroom/file-attachment/ChatAttachmentPreview.vue
@@ -59,7 +59,7 @@
     send-area-attachments-gallery
       template(v-for='(entry, entryIndex) in attachmentList')
         .c-attachment-preview(
-          v-if='[config.CHATROOM_ATTACHMENT_TYPES.NON_MEDIA, config.CHATROOM_ATTACHMENT_TYPES.AUDIO].includes(fileType(entry))'
+          v-if='config.CHATROOM_ATTACHMENT_TYPES.NON_MEDIA === fileType(entry)'
           :key='entry.url'
           :class='"is-" + fileType(entry)'
         )

--- a/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
+++ b/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
@@ -226,8 +226,12 @@ export default {
   }
 
   &.is-audio {
-    width: 14.25rem;
-
+    min-width: 14rem;
+    max-width: 17.25rem;
+    min-height: 3.5rem;
+    height: auto;
+    width: auto;
+  
     .c-audio-preview-container {
       position: relative;
       width: 100%;

--- a/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
+++ b/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
@@ -231,7 +231,7 @@ export default {
     min-height: 3.5rem;
     height: auto;
     width: auto;
-  
+
     .c-audio-preview-container {
       position: relative;
       width: 100%;

--- a/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
+++ b/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
@@ -232,7 +232,7 @@ export default {
       position: relative;
       width: 100%;
       height: 100%;
-      background-color: $general_1;
+      background-color: $general_2;
       overflow: hidden;
       border-radius: inherit;
       display: flex;

--- a/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
+++ b/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
@@ -20,18 +20,12 @@
           i.icon-play
   template(v-else-if='fileType === "audio"')
     .c-audio-preview-container
-      button.c-audio-play-btn
-        i.icon-play
-
-      .c-play-panel
-        .c-audio-metadata
-          .c-file-name.has-ellipsis {{ attachment.name }}
-        .c-audio-progress
-          .c-audio-progress-bar
-            audio-player.c-audio-player(
-              :src='attachment.url'
-              :mimeType='attachment.mimeType'
-            )
+      audio-player-card(
+        :attachment='attachment'
+        :src='attachment.url'
+        :mimeType='attachment.mimeType'
+        :forSendArea='true'
+      )
 
   button.c-attachment-remove-btn(
     type='button'
@@ -42,13 +36,13 @@
 </template>
 
 <script>
-import AudioPlayer from '@components/AudioPlayer.vue'
+import AudioPlayerCard from '@containers/chatroom/audio-player/AudioPlayerCard.vue'
 import { getFileType } from '@view-utils/filters.js'
 
 export default {
   name: 'MediaPreviewInTextArea',
   components: {
-    AudioPlayer
+    AudioPlayerCard
   },
   props: {
     attachment: {

--- a/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
+++ b/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
@@ -18,6 +18,20 @@
         )
         .c-video-play-icon
           i.icon-play
+  template(v-else-if='fileType === "audio"')
+    .c-audio-preview-container
+      button.c-audio-play-btn
+        i.icon-play
+
+      .c-play-panel
+        .c-audio-metadata
+          .c-file-name.has-ellipsis {{ attachment.name }}
+        .c-audio-progress
+          .c-audio-progress-bar
+            audio-player.c-audio-player(
+              :src='attachment.url'
+              :mimeType='attachment.mimeType'
+            )
 
   button.c-attachment-remove-btn(
     type='button'
@@ -28,10 +42,14 @@
 </template>
 
 <script>
+import AudioPlayer from '@components/AudioPlayer.vue'
 import { getFileType } from '@view-utils/filters.js'
 
 export default {
   name: 'MediaPreviewInTextArea',
+  components: {
+    AudioPlayer
+  },
   props: {
     attachment: {
       type: Object,
@@ -209,6 +227,37 @@ export default {
 
       i {
         transform: translateX(1px);
+      }
+    }
+  }
+
+  &.is-audio {
+    width: 14.25rem;
+
+    .c-audio-preview-container {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      background-color: $general_1;
+      overflow: hidden;
+      border-radius: inherit;
+      display: flex;
+      align-items: center;
+      column-gap: 0.5rem;
+      padding: 0.5rem;
+
+      .c-audio-play-btn {
+        flex-shrink: 0;
+      }
+
+      .c-play-panel {
+        flex-grow: 1;
+
+        .c-audio-metadata {
+          .c-file-name {
+            font-weight: bold;
+          }
+        }
       }
     }
   }

--- a/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
+++ b/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
@@ -242,20 +242,6 @@ export default {
       align-items: center;
       column-gap: 0.5rem;
       padding: 0.5rem;
-
-      .c-audio-play-btn {
-        flex-shrink: 0;
-      }
-
-      .c-play-panel {
-        flex-grow: 1;
-
-        .c-audio-metadata {
-          .c-file-name {
-            font-weight: bold;
-          }
-        }
-      }
     }
   }
 }

--- a/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
+++ b/frontend/views/containers/chatroom/file-attachment/MediaPreviewInTextArea.vue
@@ -237,7 +237,6 @@ export default {
       width: 100%;
       height: 100%;
       background-color: $general_2;
-      overflow: hidden;
       border-radius: inherit;
       display: flex;
       align-items: center;

--- a/frontend/views/pages/DesignSystem.vue
+++ b/frontend/views/pages/DesignSystem.vue
@@ -208,6 +208,7 @@ page(
               i.icon-link icon-link
               i.icon-lock icon-lock
               i.icon-minus-circle icon-minus-circle
+              i.icon-music icon-music
               i.icon-newspaper icon-newspaper
               i.icon-paper-plane icon-paper-plane
               i.icon-pencil-alt icon-pencil-alt


### PR DESCRIPTION
closes #3111 

Just like the minimal audio preview UI in Slack:

<img width="370"  src="https://github.com/user-attachments/assets/094a960e-930a-49f3-b95f-ebf53bb1069a" />

---

Ensured the audio files are playable in `SendArea.vue` before sending:

**[Light theme]**

<img width="390" src="https://github.com/user-attachments/assets/a379c108-35f0-4600-b963-299858b75da1" />

**[Dark theme]**

<img width="390" src="https://github.com/user-attachments/assets/ee948d32-97ba-4606-9e87-f67824ae76ba" />
