### PR TITLE
#3116 - inline markdown should be converted when inside a link

### DIFF
--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -282,11 +282,17 @@
     }
   }
 
-  // miscellaneous
+  // link styles
   .link {
     border-bottom-color: currentColor;
+
+    code {
+      padding: 0.25rem 0.25rem 1px;
+      color: $primary_0;
+    }
   }
 
+  // miscellaneous
   .c-edited {
     margin-left: 0.2rem;
     font-size: 0.7rem;

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -288,7 +288,7 @@
 
     code {
       padding: 0.25rem 0.25rem 1px;
-      color: $primary_0;
+      color: inherit;
     }
   }
 

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -17,7 +17,10 @@ marked.use({
 
         if (isValid) {
           const { href } = token
+          // marked with 'gfm' option doesn't perform markdown syntax conversion when they are inside link, hence requiring manual conversion.
+          // As <a> tag is an inline element, it makes sense to do manual conversion only for other inline elements.
           const inlineMarkdownMap = {
+            'strong': /\*\*(.*?)\*\*/g, // NOTE: link itself is already in bold style, so <strong> tag doesn't visually stand out after conversion but still supporting it here anyways.
             'code': /`(.*?)`/g,
             'em': /_(.*?)_/g,
             'del': /~(.*?)~/g

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -16,9 +16,18 @@ marked.use({
         const { isValid, isExternalLink } = validateURL(token.href, true)
 
         if (isValid) {
-          const { href, text } = token
-          const transformedText = text.replace(/`(.*?)`/g, '<code>$1</code>')
-          return `<a class="link" href="${href}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${transformedText}</a>`
+          const { href } = token
+          const inlineMarkdownMap = {
+            'code': /`(.*?)`/g,
+            'em': /_(.*?)_/g,
+            'del': /~(.*?)~/g
+          }
+
+          let text = token.text
+          Object.entries(inlineMarkdownMap).forEach(([elName, regex]) => {
+            text = text.replace(regex, `<${elName}>$1</${elName}>`)
+          })
+          return `<a class="link" href="${href}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${text}</a>`
         }
         return token.raw
       }

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -17,7 +17,8 @@ marked.use({
 
         if (isValid) {
           const { href, text } = token
-          return `<a class="link" href="${href}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${text}</a>`
+          const transformedText = text.replace(/`(.*?)`/g, '<code>$1</code>')
+          return `<a class="link" href="${href}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${transformedText}</a>`
         }
         return token.raw
       }

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -16,21 +16,11 @@ marked.use({
         const { isValid, isExternalLink } = validateURL(token.href, true)
 
         if (isValid) {
-          const { href } = token
-          // marked with 'gfm' option doesn't perform markdown syntax conversion when they are inside link, hence requiring manual conversion.
-          // As <a> tag is an inline element, it makes sense to do manual conversion only for other inline elements.
-          const inlineMarkdownMap = {
-            'strong': /\*\*(.*?)\*\*/g, // NOTE: link itself is already in bold style, so <strong> tag doesn't visually stand out after conversion but still supporting it here anyways.
-            'code': /`(.*?)`/g,
-            'em': /_(.*?)_/g,
-            'del': /~(.*?)~/g
-          }
-
-          let text = token.text
-          Object.entries(inlineMarkdownMap).forEach(([elName, regex]) => {
-            text = text.replace(regex, `<${elName}>$1</${elName}>`)
-          })
-          return `<a class="link" href="${href}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${text}</a>`
+          const { href, text } = token
+          // marked with 'gfm' option doesn't perform markdown syntax conversion when they are inside link,
+          // So we need to perform another conversion step here.
+          const parsedText = marked.parseInline(text, { gfm: true })
+          return `<a class="link" href="${href}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${parsedText}</a>`
         }
         return token.raw
       }


### PR DESCRIPTION
closes #3116 

<img width="420"  src="https://github.com/user-attachments/assets/f5c16136-63e1-4767-b055-9c1bf91d30fd" />
