### PR TITLE
#3121 - Make settings menu animation smooth

### DIFF
--- a/frontend/assets/style/components/_cards.scss
+++ b/frontend/assets/style/components/_cards.scss
@@ -103,16 +103,17 @@ $card-shadow: 0 0 20px rgba(219, 219, 219, 0.6);
   }
 
   .tile-lower-section {
+    position: relative;
     display: flex;
     flex-direction: column;
     width: 100%;
-    padding: 0.75rem 1rem 1rem;
     user-select: text;
     white-space: initial;
-
-    @include tablet {
-      padding: 0.875rem 1.25rem 1.25rem;
-    }
+    max-height: 0;
+    overflow: hidden;
+    padding: 0;
+    opacity: 0;
+    transform: translate3d(0, -0.875rem, 0);
   }
 
   .tile-text {
@@ -215,6 +216,20 @@ $card-shadow: 0 0 20px rgba(219, 219, 219, 0.6);
   &.is-expanded {
     .tile-icon {
       transform: rotate(180deg);
+    }
+
+    .tile-lower-section {
+      max-height: unset;
+      overflow: visible;
+      padding: 0.75rem 1rem 1rem;
+      opacity: 1;
+      transform: translate3d(0, 0, 0);
+      transition: opacity 250ms ease-out 50ms,
+        transform 350ms ease-out;
+
+      @include tablet {
+        padding: 0.875rem 1.25rem 1.25rem;
+      }
     }
   }
 }

--- a/frontend/assets/style/components/_cards.scss
+++ b/frontend/assets/style/components/_cards.scss
@@ -224,7 +224,8 @@ $card-shadow: 0 0 20px rgba(219, 219, 219, 0.6);
       padding: 0.75rem 1rem 1rem;
       opacity: 1;
       transform: translate3d(0, 0, 0);
-      transition: opacity 250ms ease-out 50ms,
+      transition:
+        opacity 250ms ease-out 50ms,
         transform 350ms ease-out;
 
       @include tablet {

--- a/frontend/views/components/SettingsMenuTile.vue
+++ b/frontend/views/components/SettingsMenuTile.vue
@@ -4,6 +4,7 @@ button.is-unstyled.menu-tile(
   @click.stop='onTileClick'
   :class='["is-style-" + variant, { "is-expanded": ephemeral.expanded }]'
   :aria-disabled='isDisabled'
+  :aria-expanded='ephemeral.expanded'
 )
   .tile-upper-section(:data-test='testId')
     .tile-text {{ menuName }}
@@ -11,7 +12,10 @@ button.is-unstyled.menu-tile(
       slot(name='info')
     i(v-if='!noIcon' :class='iconClasses')
 
-  .tile-lower-section(v-if='isExpandable')
+  .tile-lower-section(
+    v-if='isExpandable'
+    :aria-hidden='!ephemeral.expanded'
+  )
     slot(name='lower')
 </template>
 

--- a/frontend/views/components/SettingsMenuTile.vue
+++ b/frontend/views/components/SettingsMenuTile.vue
@@ -11,19 +11,14 @@ button.is-unstyled.menu-tile(
       slot(name='info')
     i(v-if='!noIcon' :class='iconClasses')
 
-  transition-expand
-    .tile-lower-section(v-if='isExpandable && ephemeral.expanded')
-      slot(name='lower')
+  .tile-lower-section(v-if='isExpandable')
+    slot(name='lower')
 </template>
 
 <script>
-import TransitionExpand from './TransitionExpand.vue'
 
 export default {
   name: 'SettingsMenuTile',
-  components: {
-    TransitionExpand
-  },
   props: {
     variant: {
       type: String,

--- a/frontend/views/containers/user-settings/appearance/TextSizeTile.vue
+++ b/frontend/views/containers/user-settings/appearance/TextSizeTile.vue
@@ -8,7 +8,7 @@ MenuItem(
 
   template(#lower='')
     .c-slider-container
-      Slider(
+      Slider.c-size-slider(
         :value='fontSize'
         :data='fontData'
         :range='fontRange'
@@ -67,5 +67,9 @@ export default {
 <style lang="scss" scoped>
 .c-slider-container {
   padding: 0 0.75rem;
+
+  .c-size-slider {
+    padding-bottom: 0;
+  }
 }
 </style>


### PR DESCRIPTION
closes #3121 

https://github.com/user-attachments/assets/571bc98e-f308-4701-a5b9-a6002765871a

The cause of the issue apparently is the overhead of preparing animation via `TransitionExpand.vue`:

https://github.com/okTurtles/group-income/blob/master/frontend/views/components/TransitionExpand.vue#L17-L39

It computes some size-related css properties every time the animation is triggered and this job becomes heavier when the child is another non-trivial Vue component like in `/user-settings` page.

Removing `TransitionExpand.vue` and using css for this case fixes it. (Expand/fold behaviour is a relatively simple animation so using libraries like Anime.js isn't required but if the app needs any complex animations elsewhere in the future, we can def install/use it.)