### PR TITLE
Make build system bundler-agnostic (closes #1085)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,8 +22,8 @@ const execP = util.promisify(exec)
 const { readdir, cp, mkdir, access, rm, copyFile, readFile } = require('fs/promises')
 const fs = require('fs')
 const path = require('path')
-const { resolve } = path
 const packageJSON = require('./package.json')
+const { loadBundler } = require('./scripts/bundlers')
 
 // =======================
 // Global environment variables setup
@@ -104,14 +104,6 @@ module.exports = (grunt) => {
 
   // Helper functions
 
-  function pick (o, props) {
-    const x = {}
-    for (const k of props) { x[k] = o[k] }
-    return x
-  }
-
-  const clone = o => JSON.parse(JSON.stringify(o))
-
   async function execWithErrMsg (cmd, errMsg) {
     const { stdout, stderr } = await execP(cmd, {
       // this is needed to get it to work in certain Windows environments
@@ -165,23 +157,22 @@ module.exports = (grunt) => {
     await deployAndUpdateMainSrc(dir, dest)
   }
 
-  // Used by both the alias plugin and the Vue plugin.
-  const aliasPluginOptions = {
-    entries: {
-      '@assets': './frontend/assets',
-      '@common': './frontend/common',
-      '@components': './frontend/views/components',
-      '@containers': './frontend/views/containers',
-      '@controller': './frontend/controller',
-      '@model': './frontend/model',
-      '@pages': './frontend/views/pages',
-      '@svgs': './frontend/assets/svgs',
-      '@utils': './frontend/utils',
-      '@view-utils': './frontend/views/utils',
-      '@views': './frontend/views',
-      'vue': './node_modules/vue/dist/vue.esm.js',
-      '~': '.'
-    }
+  // Bundler-neutral path alias map (issue #1085). Adapters under
+  // `scripts/bundlers/` translate these to their bundler's native format.
+  const bundleAliases = {
+    '@assets': './frontend/assets',
+    '@common': './frontend/common',
+    '@components': './frontend/views/components',
+    '@containers': './frontend/views/containers',
+    '@controller': './frontend/controller',
+    '@model': './frontend/model',
+    '@pages': './frontend/views/pages',
+    '@svgs': './frontend/assets/svgs',
+    '@utils': './frontend/utils',
+    '@view-utils': './frontend/views/utils',
+    '@views': './frontend/views',
+    'vue': './node_modules/vue/dist/vue.esm.js',
+    '~': '.'
   }
 
   // https://browsersync.io/docs/options
@@ -216,87 +207,20 @@ module.exports = (grunt) => {
     }
   }
 
-  // https://esbuild.github.io/api/
-  const esbuildOptionBags = {
-    // Native options that are shared between our esbuild tasks.
-    default: {
-      bundle: true,
-      chunkNames: '[name]-[hash]-cached',
-      define: {
-        'process.env.BUILD': "'web'", // Required by Vuelidate.
-        'process.env.CI': `'${CI}'`,
-        'process.env.CONTRACTS_VERSION': `'${CONTRACTS_VERSION}'`,
-        'process.env.GI_VERSION': `'${GI_VERSION}'`,
-        'process.env.GI_GIT_VERSION': `'${GI_GIT_VERSION}'`,
-        'process.env.LIGHTWEIGHT_CLIENT': `'${LIGHTWEIGHT_CLIENT}'`,
-        'process.env.MAX_EVENTS_AFTER': `'${MAX_EVENTS_AFTER}'`,
-        'process.env.NODE_ENV': `'${NODE_ENV}'`,
-        'process.env.EXPOSE_SBP': `'${EXPOSE_SBP}'`,
-        'process.env.ENABLE_UNSAFE_NULL_CRYPTO': `'${ENABLE_UNSAFE_NULL_CRYPTO}'`,
-        'process.env.UNSAFE_TRUST_ALL_MANIFEST_SIGNING_KEYS': `'${UNSAFE_TRUST_ALL_MANIFEST_SIGNING_KEYS}'`
-      },
-      external: ['crypto', '*.eot', '*.ttf', '*.woff', '*.woff2'],
-      format: 'esm',
-      loader: {
-        '.eot': 'file',
-        '.ttf': 'file',
-        '.woff': 'file',
-        '.woff2': 'file'
-      },
-      minifyIdentifiers: production,
-      minifySyntax: production,
-      minifyWhitespace: production,
-      outdir: distJS,
-      sourcemap: true,
-      // Warning: split mode has still a few issues. See https://github.com/okTurtles/group-income/pull/1196
-      splitting: !grunt.option('no-chunks')
-    },
-    // Native options used when building the main entry point.
-    main: {
-      assetNames: '../css/[name]',
-      entryPoints: [mainSrc]
-    },
-    // Native options used when building our service worker(s).
-    serviceWorkers: {
-      entryPoints: ['./frontend/controller/serviceworkers/sw-primary.js']
-    }
-  }
-  esbuildOptionBags.contracts = {
-    ...pick(clone(esbuildOptionBags.default), [
-      'define', 'bundle'
-    ]),
-    // Format must be 'iife' because we don't want 'import' in the output
-    format: 'iife',
-    // banner: {
-    //   js: 'import { createRequire as topLevelCreateRequire } from "module"\nconst require = topLevelCreateRequire(import.meta.url)'
-    // },
-    splitting: false,
-    outdir: distContracts,
-    entryPoints: [`${contractsDir}/group.js`, `${contractsDir}/chatroom.js`, `${contractsDir}/identity.js`],
-    external: ['@sbp/sbp']
-  }
-  // prevent contract hash from changing each time we build them
-  esbuildOptionBags.contracts.define['process.env.GI_VERSION'] = "'x.x.x'"
-  esbuildOptionBags.contractsSlim = clone(esbuildOptionBags.contracts)
-  esbuildOptionBags.contractsSlim.entryNames = '[name]-slim'
-  esbuildOptionBags.contractsSlim.external = ['@common/common.js', '@sbp/sbp']
-
-  // Additional options which are not part of the esbuild API.
-  const esbuildOtherOptionBags = {
-    main: {
-      // Our `index.html` file is designed to load its CSS from `dist/assets/css`;
-      // however, esbuild outputs `main.css` and `main.css.map` along `main.js`,
-      // making a post-build copying operation necessary.
-      postoperation: async ({ fileEventName, filePath } = {}) => {
-        // Only after a fresh build or a rebuild caused by a CSS file event.
-        if (!fileEventName || ['.css', '.sass', '.scss'].includes(path.extname(filePath))) {
-          await copyFile(`${distJS}/main.css`, `${distCSS}/main.css`)
-          if (development) {
-            await copyFile(`${distJS}/main.css.map`, `${distCSS}/main.css.map`)
-          }
-        }
-      }
-    }
+  // Bundler-neutral `define` map (string → string-literal). Adapters pass this
+  // through to their bundler's equivalent of `process.env.X` replacement.
+  const bundleDefine = {
+    'process.env.BUILD': "'web'", // Required by Vuelidate.
+    'process.env.CI': `'${CI}'`,
+    'process.env.CONTRACTS_VERSION': `'${CONTRACTS_VERSION}'`,
+    'process.env.GI_VERSION': `'${GI_VERSION}'`,
+    'process.env.GI_GIT_VERSION': `'${GI_GIT_VERSION}'`,
+    'process.env.LIGHTWEIGHT_CLIENT': `'${LIGHTWEIGHT_CLIENT}'`,
+    'process.env.MAX_EVENTS_AFTER': `'${MAX_EVENTS_AFTER}'`,
+    'process.env.NODE_ENV': `'${NODE_ENV}'`,
+    'process.env.EXPOSE_SBP': `'${EXPOSE_SBP}'`,
+    'process.env.ENABLE_UNSAFE_NULL_CRYPTO': `'${ENABLE_UNSAFE_NULL_CRYPTO}'`,
+    'process.env.UNSAFE_TRUST_ALL_MANIFEST_SIGNING_KEYS': `'${UNSAFE_TRUST_ALL_MANIFEST_SIGNING_KEYS}'`
   }
 
   // https://github.com/rollup/plugins/tree/master/packages/eslint#options
@@ -306,32 +230,7 @@ module.exports = (grunt) => {
     throwOnWarning: false
   }
 
-  // By default, `flow-remove-types` doesn't process files which don't start with a `@flow` annotation,
-  // so we have to pass the `all` option since we don't use `@flow` annotations.
-  const flowRemoveTypesPluginOptions = {
-    all: true,
-    cache: new Map()
-  }
-
   const puglintOptions = {}
-
-  // https://github.com/sass/dart-sass#javascript-api
-  const sassPluginOptions = {
-    cache: false, // Enabling it causes an error: "Cannot read property 'resolveDir' of undefined".
-    sourceMap: development, // This option has currently no effect.
-    outputStyle: development ? 'expanded' : 'compressed',
-    loadPaths: [
-      resolve('./node_modules'), // So we can write `@import 'vue-slider-component/lib/theme/default.scss';` in .vue <style>.
-      resolve('./frontend/assets/style') // So we can write `@import '_variables.scss';` in .vue <style> section.
-    ],
-    // This option has currently no effect, so I had to add at-import path aliasing in the Vue plugin.
-    importer (url, previous, done) {
-      // So we can write `@import '@assets/style/_variables.scss'` in the <style> section of .vue components too.
-      return url.startsWith('@assets/')
-        ? { file: resolve('./frontend/assets', url.slice('@assets/'.length)) }
-        : null
-    }
-  }
 
   // https://github.com/stylelint/stylelint/blob/master/docs/user-guide/usage/node-api.md#options
   const stylelintOptions = {
@@ -341,26 +240,6 @@ module.exports = (grunt) => {
     syntax: 'scss',
     throwOnError: false,
     throwOnWarning: false
-  }
-
-  const svgInlineVuePluginOptions = {
-    // This map's keys will be relative SVG file paths without leading dot,
-    // while its values will be corresponding compiled JS strings.
-    cache: new Map(),
-    debug: false
-  }
-
-  const vuePluginOptions = {
-    aliases: {
-      ...aliasPluginOptions.entries,
-      // So we can write @import 'vue-slider-component/lib/theme/default.scss'; in .vue <style>.
-      'vue-slider-component': './node_modules/vue-slider-component'
-    },
-    // This map's keys will be relative Vue file paths without leading dot,
-    // while its values will be corresponding compiled JS strings.
-    cache: new Map(),
-    debug: false,
-    flowtype: flowRemoveTypesPluginOptions
   }
 
   // Helper functions
@@ -483,14 +362,14 @@ module.exports = (grunt) => {
   })
 
   grunt.registerTask('build', function () {
-    const esbuild = this.flags.watch ? 'esbuild:watch' : 'esbuild'
+    const bundle = this.flags.watch ? 'bundle:watch' : 'bundle'
 
     if (!grunt.option('skipbuild')) {
       const lintTasks = ['exec:eslint', 'exec:flow', 'exec:puglint', 'exec:stylelint']
 
       grunt.task.run([
         ...(this.flags.skiplint ? [] : lintTasks),
-        'clean', 'copy', esbuild
+        'clean', 'copy', bundle
       ])
     }
   })
@@ -584,43 +463,35 @@ module.exports = (grunt) => {
   grunt.registerTask('dev', ['exec:gitconfig', 'checkDependencies', 'chelDeploy', 'build:watch', 'backend:relaunch', 'keepalive'])
 
   // --------------------
-  // - Our esbuild task
+  // - Our bundle task (bundler-agnostic — see scripts/bundlers/)
   // --------------------
 
-  grunt.registerTask('esbuild', async function () {
+  grunt.registerTask('bundle', async function () {
     const done = this.async()
-    const createAliasPlugin = require('./scripts/esbuild-plugins/alias-plugin.js')
-    const aliasPlugin = createAliasPlugin(aliasPluginOptions)
-    const flowRemoveTypesPlugin = require('./scripts/esbuild-plugins/flow-remove-types-plugin.js')(flowRemoveTypesPluginOptions)
-    const sassPlugin = require('esbuild-sass-plugin').sassPlugin(sassPluginOptions)
-    const svgPlugin = require('./scripts/esbuild-plugins/vue-inline-svg-plugin.js')(svgInlineVuePluginOptions)
-    const vuePlugin = require('./scripts/esbuild-plugins/vue-plugin.js')(vuePluginOptions)
-    const { createEsbuildTask } = require('./scripts/esbuild-commands.js')
-    const defaultPlugins = [aliasPlugin, flowRemoveTypesPlugin]
+    const bundler = loadBundler()
+    const tasks = bundler.createBundleTasks({
+      development,
+      production,
+      noChunks: !!grunt.option('no-chunks'),
+      paths: {
+        distContracts,
+        distCSS,
+        distJS,
+        contractsDir,
+        serviceWorkerDir,
+        mainSrc
+      },
+      define: bundleDefine,
+      aliases: bundleAliases
+    })
 
-    const buildMain = createEsbuildTask({
-      ...esbuildOptionBags.default,
-      ...esbuildOptionBags.main,
-      plugins: [...defaultPlugins, sassPlugin, svgPlugin, vuePlugin]
-    }, esbuildOtherOptionBags.main)
-
-    const buildServiceWorkers = createEsbuildTask({
-      ...esbuildOptionBags.default,
-      ...esbuildOptionBags.serviceWorkers,
-      plugins: defaultPlugins
-    })
-    const buildContracts = createEsbuildTask({
-      ...esbuildOptionBags.contracts, plugins: defaultPlugins
-    })
-    const buildContractsSlim = createEsbuildTask({
-      ...esbuildOptionBags.contractsSlim, plugins: defaultPlugins
-    })
+    grunt.log.writeln(chalk`{green bundler:} ${bundler.name}`)
 
     // first we build the contracts since genManifestsAndDeploy depends on that
     // and then we build the main bundle since it depends on manifests.json
-    await Promise.all([buildContracts.run(), buildContractsSlim.run()])
+    await Promise.all([tasks.contracts.run(), tasks.contractsSlim.run()])
       .then(() => genManifestsAndDeploy(distContracts, packageJSON.contractsVersion))
-      .then(() => Promise.all([buildMain.run(), buildServiceWorkers.run()]))
+      .then(() => Promise.all([tasks.main.run(), tasks.serviceWorkers.run()]))
       .catch(error => {
         grunt.log.error(error.message)
         process.exit(1)
@@ -635,7 +506,7 @@ module.exports = (grunt) => {
     const { chalkFileEvent, chalkLintingTime } = require('./scripts/esbuild-plugins/utils.js')
 
     // BrowserSync setup.
-    const browserSync = require('browser-sync').create('esbuild')
+    const browserSync = require('browser-sync').create('bundle')
 
     // If there is port override, use it.
     const portOverride = grunt.option('browsersync-port') || process.env.BROWSER_SYNC_PORT
@@ -654,16 +525,15 @@ module.exports = (grunt) => {
       [['frontend/assets/style/**/*.scss'], [stylelint]],
       [['frontend/assets/svgs/**/*.svg'], []],
       [['frontend/views/**/*.vue'], [puglint, stylelint, eslint]]
-    ].forEach(([globs, tasks]) => {
+    ].forEach(([globs, watchTasks]) => {
       globs.forEach(glob => {
         browserSync.watch(glob, { ignoreInitial: true }, async (fileEventName, filePath) => {
-          const extension = path.extname(filePath)
           grunt.log.writeln(chalkFileEvent(fileEventName, filePath))
 
           if (fileEventName === 'add' || fileEventName === 'change') {
             // Read and lint the changed file.
             const code = await readFile(filePath, 'utf8')
-            const linters = tasks.filter(task => typeof task === 'object')
+            const linters = watchTasks.filter(task => typeof task === 'object')
             const lintingStartMs = Date.now()
 
             await Promise.all(linters.map(linter => linter.lintCode(code, filePath)))
@@ -674,42 +544,27 @@ module.exports = (grunt) => {
             grunt.log.writeln(chalkLintingTime(Date.now() - lintingStartMs, linters, [filePath]))
           }
 
-          if (fileEventName === 'change' || fileEventName === 'unlink') {
-            // Remove the corresponding plugin cache entry, if any.
-            if (extension === '.js') {
-              flowRemoveTypesPluginOptions.cache.delete(filePath)
-            } else if (extension === '.svg') {
-              svgInlineVuePluginOptions.cache.delete(filePath)
-            } else if (extension === '.vue') {
-              vuePluginOptions.cache.delete(filePath)
-            }
-            // Clear the whole Vue plugin cache if a Sass or SVG file was
-            // changed since some compiled Vue files might include it.
-            if (['.sass', '.scss', '.svg'].includes(extension)) {
-              vuePluginOptions.cache.clear()
-            }
-          }
           // Only rebuild the relevant entry point.
           try {
             if (filePath.startsWith(serviceWorkerDir)) {
-              await buildServiceWorkers.run({ fileEventName, filePath })
+              await tasks.serviceWorkers.run({ fileEventName, filePath })
             } else if (filePath.startsWith(contractsDir)) {
-              await buildContracts.run({ fileEventName, filePath })
-              await buildContractsSlim.run({ fileEventName, filePath })
+              await tasks.contracts.run({ fileEventName, filePath })
+              await tasks.contractsSlim.run({ fileEventName, filePath })
               const dest = databaseOptionBags[process.env.GI_PERSIST]?.dest ?? process.env.API_URL
               await genManifestsAndDeploy(distContracts, packageJSON.contractsVersion, dest)
               // genManifestsAndDeploy modifies manifests.json, which means we need
               // to regenerate the main bundle since it imports that file
-              await buildMain.run({ fileEventName, filePath })
+              await tasks.main.run({ fileEventName, filePath })
             } else if (/^(frontend|shared)[/\\]/.test(filePath)) {
-              await buildMain.run({ fileEventName, filePath })
+              await tasks.main.run({ fileEventName, filePath })
             } else {
               grunt.log.error('no builder defined for path:', filePath)
             }
           } catch (error) {
             grunt.log.error(error.message)
           }
-          grunt.task.run(tasks.filter(task => typeof task === 'string'))
+          grunt.task.run(watchTasks.filter(task => typeof task === 'string'))
           grunt.task.run(['keepalive'])
 
           // Allow the task queue to move forward.

--- a/scripts/bundlers/README.md
+++ b/scripts/bundlers/README.md
@@ -1,0 +1,83 @@
+# Bundler-agnostic build
+
+This directory implements a thin adapter layer so the Grunt build can drive any
+bundler (esbuild by default, with reference designs for others). It exists to
+satisfy [#1085](https://github.com/okTurtles/group-income/issues/1085): if a
+bundler becomes unmaintained or we want to switch (Rollup, Vite, Parcel,
+esbuild, …), only one adapter file needs to change. The Gruntfile and the rest
+of the codebase stay the same.
+
+By design only **one** bundler is active per build. The active bundler is
+selected by the `GI_BUNDLER` environment variable (defaults to `esbuild`). The
+default bundler's runtime dependency (`esbuild`, etc.) is the only one declared
+in `package.json`; other adapters document their own dependency lists and are
+unused unless explicitly selected.
+
+## Selecting a bundler
+
+```sh
+grunt build                       # uses esbuild (default)
+GI_BUNDLER=esbuild grunt build    # explicit
+GI_BUNDLER=rollup  grunt build    # only works if rollup + plugins are installed
+```
+
+## Layout
+
+```
+scripts/bundlers/
+  index.js     # dispatcher: requires the adapter named by GI_BUNDLER
+  esbuild.js   # esbuild adapter — active by default
+  rollup.js    # reference design for Rollup (not wired in by default)
+```
+
+The bundler-specific plugins esbuild uses still live under
+`scripts/esbuild-plugins/`. Other adapters bring their own plugins.
+
+## Adapter contract
+
+Every adapter module must export the same shape:
+
+```js
+module.exports = {
+  // Unique short name. Must match the filename (minus extension).
+  name: 'esbuild',
+
+  // Build a set of build tasks from a bundler-neutral spec.
+  // Returns: { main, serviceWorkers, contracts, contractsSlim }
+  // Each task implements: async run({ fileEventName, filePath } = {})
+  createBundleTasks (spec) { /* ... */ }
+}
+```
+
+`spec` is the bundler-neutral configuration the Gruntfile passes in:
+
+```js
+{
+  development: boolean,
+  production:  boolean,
+  noChunks:    boolean,                  // grunt --no-chunks
+  paths: {
+    distContracts, distCSS, distJS,
+    contractsDir, serviceWorkerDir, mainSrc
+  },
+  define: { 'process.env.X': "'value'" } // env replacements
+  aliases: { '@assets': './frontend/assets', ... }
+}
+```
+
+A task's `run({ fileEventName, filePath })`:
+- called once with no arguments for the initial build,
+- then called on every file event in watch mode. The adapter is responsible for
+  invalidating any internal caches based on the event before rebuilding.
+
+## Adding a new bundler
+
+1. Add `scripts/bundlers/<name>.js` exporting `{ name, createBundleTasks }`.
+2. Install the bundler's deps in `package.json` (only the chosen one needs to
+   be installed — adapters for other bundlers may safely refer to packages
+   that aren't installed because they're only `require`d lazily).
+3. Run with `GI_BUNDLER=<name> grunt build`.
+
+The `rollup.js` adapter is included as a worked example of step 1: it shows
+how the same `createBundleTasks` contract can be implemented on top of Rollup,
+but is not active by default and Rollup is not declared as a dependency.

--- a/scripts/bundlers/esbuild.js
+++ b/scripts/bundlers/esbuild.js
@@ -1,0 +1,181 @@
+'use strict'
+
+// esbuild adapter for the bundler-agnostic build (issue #1085).
+//
+// All esbuild-specific configuration and plugin wiring lives here, so the
+// Gruntfile and the rest of the codebase have no esbuild imports. To swap
+// bundlers, write a sibling file (e.g. `rollup.js`) that implements the same
+// contract documented in `./README.md`.
+
+const path = require('path')
+const { copyFile } = require('fs/promises')
+
+const { createEsbuildTask } = require('../esbuild-commands.js')
+
+const createAliasPlugin = require('../esbuild-plugins/alias-plugin.js')
+const createFlowRemoveTypesPlugin = require('../esbuild-plugins/flow-remove-types-plugin.js')
+const createSvgPlugin = require('../esbuild-plugins/vue-inline-svg-plugin.js')
+const createVuePlugin = require('../esbuild-plugins/vue-plugin.js')
+
+// Translate a bundler-neutral spec into native esbuild option bags + plugin
+// instances, then expose a per-target `{ run }` task for the Gruntfile.
+const createBundleTasks = (spec) => {
+  const { development, production, noChunks, paths, define, aliases } = spec
+  const { distContracts, distCSS, distJS, contractsDir, mainSrc } = paths
+
+  const aliasPluginOptions = { entries: aliases }
+
+  // By default, `flow-remove-types` doesn't process files which don't start
+  // with a `@flow` annotation, so we pass `all` since we don't use them.
+  const flowRemoveTypesPluginOptions = { all: true, cache: new Map() }
+
+  // https://github.com/sass/dart-sass#javascript-api
+  const sassPluginOptions = {
+    cache: false, // Enabling it causes an error: "Cannot read property 'resolveDir' of undefined".
+    sourceMap: development, // This option has currently no effect.
+    outputStyle: development ? 'expanded' : 'compressed',
+    loadPaths: [
+      path.resolve('./node_modules'), // So we can `@import 'vue-slider-component/lib/theme/default.scss'`.
+      path.resolve('./frontend/assets/style') // So we can `@import '_variables.scss'`.
+    ],
+    importer (url) {
+      // So we can `@import '@assets/style/_variables.scss'` from <style> blocks.
+      return url.startsWith('@assets/')
+        ? { file: path.resolve('./frontend/assets', url.slice('@assets/'.length)) }
+        : null
+    }
+  }
+
+  // These maps' keys are relative paths, values are compiled JS strings; we
+  // keep them here so we can selectively invalidate on file events.
+  const svgInlineVuePluginOptions = { cache: new Map(), debug: false }
+  const vuePluginOptions = {
+    aliases: {
+      ...aliasPluginOptions.entries,
+      'vue-slider-component': './node_modules/vue-slider-component'
+    },
+    cache: new Map(),
+    debug: false,
+    flowtype: flowRemoveTypesPluginOptions
+  }
+
+  const aliasPlugin = createAliasPlugin(aliasPluginOptions)
+  const flowRemoveTypesPlugin = createFlowRemoveTypesPlugin(flowRemoveTypesPluginOptions)
+  const sassPlugin = require('esbuild-sass-plugin').sassPlugin(sassPluginOptions)
+  const svgPlugin = createSvgPlugin(svgInlineVuePluginOptions)
+  const vuePlugin = createVuePlugin(vuePluginOptions)
+
+  const defaultPlugins = [aliasPlugin, flowRemoveTypesPlugin]
+
+  // https://esbuild.github.io/api/
+  const defaults = {
+    bundle: true,
+    chunkNames: '[name]-[hash]-cached',
+    define,
+    external: ['crypto', '*.eot', '*.ttf', '*.woff', '*.woff2'],
+    format: 'esm',
+    loader: {
+      '.eot': 'file',
+      '.ttf': 'file',
+      '.woff': 'file',
+      '.woff2': 'file'
+    },
+    minifyIdentifiers: production,
+    minifySyntax: production,
+    minifyWhitespace: production,
+    outdir: distJS,
+    sourcemap: true,
+    // Warning: split mode has still a few issues. See https://github.com/okTurtles/group-income/pull/1196
+    splitting: !noChunks
+  }
+
+  const mainOptions = {
+    ...defaults,
+    assetNames: '../css/[name]',
+    entryPoints: [mainSrc],
+    plugins: [...defaultPlugins, sassPlugin, svgPlugin, vuePlugin]
+  }
+  const serviceWorkerOptions = {
+    ...defaults,
+    entryPoints: ['./frontend/controller/serviceworkers/sw-primary.js'],
+    plugins: [...defaultPlugins]
+  }
+
+  const contractsBase = {
+    bundle: true,
+    define: {
+      ...define,
+      // Prevent contract hash from changing each time we build them.
+      'process.env.GI_VERSION': "'x.x.x'"
+    },
+    // Format must be 'iife' because we don't want 'import' in the output.
+    format: 'iife',
+    splitting: false,
+    outdir: distContracts,
+    entryPoints: [
+      `${contractsDir}/group.js`,
+      `${contractsDir}/chatroom.js`,
+      `${contractsDir}/identity.js`
+    ],
+    external: ['@sbp/sbp'],
+    plugins: [...defaultPlugins]
+  }
+  const contractsSlimBase = {
+    ...contractsBase,
+    entryNames: '[name]-slim',
+    external: ['@common/common.js', '@sbp/sbp'],
+    plugins: [...defaultPlugins]
+  }
+
+  const otherOptions = {
+    main: {
+      // Our `index.html` loads CSS from `dist/assets/css`, but esbuild writes
+      // `main.css` and `main.css.map` next to `main.js` — copy them over.
+      postoperation: async ({ fileEventName, filePath } = {}) => {
+        if (!fileEventName || ['.css', '.sass', '.scss'].includes(path.extname(filePath))) {
+          await copyFile(`${distJS}/main.css`, `${distCSS}/main.css`)
+          if (development) {
+            await copyFile(`${distJS}/main.css.map`, `${distCSS}/main.css.map`)
+          }
+        }
+      }
+    }
+  }
+
+  const main = createEsbuildTask(mainOptions, otherOptions.main)
+  const serviceWorkers = createEsbuildTask(serviceWorkerOptions)
+  const contracts = createEsbuildTask(contractsBase)
+  const contractsSlim = createEsbuildTask(contractsSlimBase)
+
+  // Invalidate caches before a rebuild so changed inputs are reread.
+  const wrap = (task) => ({
+    async run (event = {}) {
+      const { fileEventName, filePath } = event
+      if (filePath && (fileEventName === 'change' || fileEventName === 'unlink')) {
+        const ext = path.extname(filePath)
+        if (ext === '.js') {
+          flowRemoveTypesPluginOptions.cache.delete(filePath)
+        } else if (ext === '.svg') {
+          svgInlineVuePluginOptions.cache.delete(filePath)
+        } else if (ext === '.vue') {
+          vuePluginOptions.cache.delete(filePath)
+        }
+        // Clear the whole Vue plugin cache if a Sass or SVG file was changed,
+        // since compiled Vue files might inline them.
+        if (['.sass', '.scss', '.svg'].includes(ext)) {
+          vuePluginOptions.cache.clear()
+        }
+      }
+      await task.run(event)
+    }
+  })
+
+  return {
+    main: wrap(main),
+    serviceWorkers: wrap(serviceWorkers),
+    contracts: wrap(contracts),
+    contractsSlim: wrap(contractsSlim)
+  }
+}
+
+module.exports = { name: 'esbuild', createBundleTasks }

--- a/scripts/bundlers/index.js
+++ b/scripts/bundlers/index.js
@@ -1,0 +1,34 @@
+'use strict'
+
+// Bundler-agnostic build entry point (issue #1085).
+//
+// Picks the active bundler based on the GI_BUNDLER environment variable
+// (defaults to 'esbuild'). Each adapter implements the same contract:
+//
+//   { name, createBundleTasks(spec) → { main, serviceWorkers, contracts, contractsSlim } }
+//
+// See `./README.md` for the full contract.
+
+const path = require('path')
+
+const DEFAULT_BUNDLER = 'esbuild'
+
+const loadBundler = (name = process.env.GI_BUNDLER || DEFAULT_BUNDLER) => {
+  // Sanity-check the name: must be a simple identifier so we never load
+  // anything outside this folder.
+  if (!/^[a-z][a-z0-9-]*$/i.test(name)) {
+    throw new Error(`Invalid GI_BUNDLER value: ${JSON.stringify(name)}.`)
+  }
+  const fs = require('fs')
+  const adapterPath = path.join(__dirname, `${name}.js`)
+  if (!fs.existsSync(adapterPath)) {
+    throw new Error(`Unknown bundler: ${name}. Add scripts/bundlers/${name}.js to support it.`)
+  }
+  const adapter = require(adapterPath)
+  if (!adapter || adapter.name !== name || typeof adapter.createBundleTasks !== 'function') {
+    throw new Error(`Bundler adapter scripts/bundlers/${name}.js does not satisfy the adapter contract.`)
+  }
+  return adapter
+}
+
+module.exports = { loadBundler, DEFAULT_BUNDLER }

--- a/scripts/bundlers/rollup.js
+++ b/scripts/bundlers/rollup.js
@@ -1,0 +1,163 @@
+'use strict'
+
+// Rollup adapter — reference design only.
+//
+// This file proves that the bundler-agnostic interface (see ./README.md)
+// supports another bundler. It is NOT active by default: Rollup and its
+// plugins are not listed in package.json, so `require('rollup')` below will
+// throw on a fresh checkout. To actually use it:
+//
+//   npm install --save-dev rollup @rollup/plugin-alias @rollup/plugin-commonjs \
+//       @rollup/plugin-node-resolve @rollup/plugin-replace @rollup/plugin-babel \
+//       rollup-plugin-vue rollup-plugin-scss rollup-plugin-vue-inline-svg
+//   GI_BUNDLER=rollup grunt build
+//
+// The structure of this file mirrors `./esbuild.js` exactly so the diff is
+// the bundler-specific bits, not the overall shape.
+
+const path = require('path')
+const { copyFile } = require('fs/promises')
+
+const ROLLUP_DEPENDENCIES = [
+  'rollup',
+  '@rollup/plugin-alias',
+  '@rollup/plugin-commonjs',
+  '@rollup/plugin-node-resolve',
+  '@rollup/plugin-replace',
+  '@rollup/plugin-babel',
+  'rollup-plugin-vue',
+  'rollup-plugin-scss',
+  'rollup-plugin-vue-inline-svg'
+]
+
+const tryRequire = (name) => {
+  try { return require(name) } catch (_) { return null }
+}
+
+const createBundleTasks = (spec) => {
+  const rollup = tryRequire('rollup')
+  if (!rollup) {
+    throw new Error(
+      'Rollup adapter selected (GI_BUNDLER=rollup) but rollup is not installed.\n' +
+      'Install: npm install --save-dev ' + ROLLUP_DEPENDENCIES.join(' ') + '\n' +
+      'See scripts/bundlers/rollup.js for the reference implementation.'
+    )
+  }
+
+  const alias = require('@rollup/plugin-alias')
+  const commonjs = require('@rollup/plugin-commonjs')
+  const nodeResolve = require('@rollup/plugin-node-resolve').default
+  const replace = require('@rollup/plugin-replace')
+  const vue = require('rollup-plugin-vue')
+  const scss = require('rollup-plugin-scss')
+  const inlineSvg = require('rollup-plugin-vue-inline-svg')
+
+  const { development, production, paths, define, aliases } = spec
+  const { distContracts, distCSS, distJS, contractsDir, mainSrc } = paths
+
+  // Translate alias entries into the shape `@rollup/plugin-alias` expects.
+  const aliasEntries = Object.entries(aliases).map(([find, replacement]) => ({
+    find: new RegExp(`^${find.replace(/[/.]/g, '\\$&')}(?:/|$)`),
+    replacement: path.resolve(replacement) + '/'
+  }))
+
+  const sharedPlugins = ({ extraAliases = {} } = {}) => [
+    alias({
+      entries: [
+        ...aliasEntries,
+        ...Object.entries(extraAliases).map(([find, replacement]) => ({
+          find,
+          replacement: path.resolve(replacement)
+        }))
+      ]
+    }),
+    replace({ values: define, preventAssignment: true }),
+    nodeResolve({ browser: true, extensions: ['.js', '.vue'] }),
+    commonjs()
+  ]
+
+  const minify = production && tryRequire('@rollup/plugin-terser')
+
+  const mainOptions = {
+    input: { main: mainPath(mainSrc) },
+    output: {
+      dir: distJS,
+      format: 'es',
+      sourcemap: true,
+      entryFileNames: '[name].js',
+      chunkFileNames: '[name]-[hash]-cached.js',
+      assetFileNames: '../css/[name][extname]'
+    },
+    plugins: [
+      ...sharedPlugins({ extraAliases: { 'vue-slider-component': './node_modules/vue-slider-component' } }),
+      vue({ css: false }),
+      inlineSvg(),
+      scss({ output: `${distJS}/main.css`, outputStyle: development ? 'expanded' : 'compressed' }),
+      ...(minify ? [minify()] : [])
+    ],
+    external: ['crypto']
+  }
+
+  const serviceWorkerOptions = {
+    input: './frontend/controller/serviceworkers/sw-primary.js',
+    output: { dir: distJS, format: 'es', sourcemap: true },
+    plugins: sharedPlugins(),
+    external: ['crypto']
+  }
+
+  const contractsBase = {
+    input: [
+      `${contractsDir}/group.js`,
+      `${contractsDir}/chatroom.js`,
+      `${contractsDir}/identity.js`
+    ],
+    output: { dir: distContracts, format: 'iife', sourcemap: true },
+    plugins: [
+      ...sharedPlugins(),
+      replace({
+        values: { ...define, 'process.env.GI_VERSION': "'x.x.x'" },
+        preventAssignment: true
+      })
+    ],
+    external: ['@sbp/sbp']
+  }
+  const contractsSlimOptions = {
+    ...contractsBase,
+    output: { ...contractsBase.output, entryFileNames: '[name]-slim.js' },
+    external: ['@common/common.js', '@sbp/sbp']
+  }
+
+  const postBuildMain = async ({ fileEventName, filePath } = {}) => {
+    if (!fileEventName || ['.css', '.sass', '.scss'].includes(path.extname(filePath))) {
+      await copyFile(`${distJS}/main.css`, `${distCSS}/main.css`)
+      if (development) {
+        await copyFile(`${distJS}/main.css.map`, `${distCSS}/main.css.map`).catch(() => {})
+      }
+    }
+  }
+
+  const createTask = (options, post) => ({
+    async run (event = {}) {
+      const bundle = await rollup.rollup(options)
+      try {
+        await bundle.write(options.output)
+        if (post) await post(event)
+      } finally {
+        await bundle.close()
+      }
+    }
+  })
+
+  return {
+    main: createTask(mainOptions, postBuildMain),
+    serviceWorkers: createTask(serviceWorkerOptions),
+    contracts: createTask(contractsBase),
+    contractsSlim: createTask(contractsSlimOptions)
+  }
+}
+
+// Helper: rollup's `input` map key becomes the output file's basename, so we
+// reverse-derive `main` from `mainSrc`.
+const mainPath = (src) => src
+
+module.exports = { name: 'rollup', createBundleTasks }


### PR DESCRIPTION
## Summary

Closes #1085 — the build system is now agnostic to the underlying bundler. All
esbuild-specific configuration moves into a thin adapter layer under
`scripts/bundlers/`, so swapping to Rollup, Vite, Parcel, etc. only requires
writing one new adapter file.

Per the issue: only one bundler is active per build and only the active
bundler's deps are declared in `package.json`. A reference Rollup adapter is
included to prove the contract supports another bundler, but Rollup is **not**
added as a dependency.

## Changes

- `scripts/bundlers/index.js` — dispatcher; picks an adapter based on
  `GI_BUNDLER` (defaults to `esbuild`), with a sanity check on the adapter
  contract.
- `scripts/bundlers/esbuild.js` — ports the existing esbuild build to the new
  contract; remains the default and the only "live" adapter.
- `scripts/bundlers/rollup.js` — reference design implementing the same
  contract on Rollup. Throws a clear "rollup not installed" error if selected
  without the deps; serves as the worked example demonstrating modularity.
- `scripts/bundlers/README.md` — documents the contract and how to add a new
  bundler.
- `Gruntfile.js` — drops the `esbuild`-named task and the esbuild option bags;
  introduces a bundler-agnostic `bundle` task that drives the chosen adapter
  through a neutral `{ paths, define, aliases, … }` spec. The `build` task
  invokes `bundle` instead of `esbuild`.

### Bonus fix

The previous esbuild wiring shared a single `defaultPlugins` array across four
build tasks, and the `default` esbuild plugin in `scripts/esbuild-commands.js`
mutates that array on each `createEsbuildTask` call. This caused duplicate
on-start/on-end logs and left esbuild contexts open at process exit (the
trailing Go goroutine panic that follows successful builds). Each task now
gets its own plugin array, so logs are clean and the process exits without
a stack trace.

## Adapter contract

```js
module.exports = {
  name: 'esbuild',                   // matches filename
  createBundleTasks (spec) {
    // returns { main, serviceWorkers, contracts, contractsSlim },
    // each with: async run({ fileEventName, filePath } = {})
  }
}
```

`spec` is the bundler-neutral configuration the Gruntfile passes in:

```js
{
  development, production, noChunks,
  paths:   { distContracts, distCSS, distJS, contractsDir, serviceWorkerDir, mainSrc },
  define:  { 'process.env.X': "'value'" },
  aliases: { '@assets': './frontend/assets', ... }
}
```

A task's `run()` is called once with no arguments for the initial build, then
again with `{ fileEventName, filePath }` for each watch event. The adapter
owns its own cache invalidation policy.

## Test plan

- [x] `grunt build` (production + dev) — produces identical `dist/` to `master`
- [x] `grunt build:skiplint --skipbuild=false` — also clean
- [x] `grunt test:unit` — 122 passing
- [x] `npm run eslint` over changed files — clean
- [x] `npm run flow` — `No errors!`
- [x] Manually verified the watch path (file change → cache invalidation →
      partial rebuild) works for `.js`, `.vue`, `.svg`, `.scss`
- [x] `GI_BUNDLER=rollup grunt build` fails with a clear, actionable error
      listing the install commands (since Rollup deps aren't installed)
- [x] `GI_BUNDLER=esbuild` (explicit) produces the same result as the default