### PR TITLE
#3138 - Disappearing message menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ strings.exe
 /.tldr*
 /.agents/
 /.crush/
+/.claude/

--- a/frontend/assets/style/components/_custom-markdowns.scss
+++ b/frontend/assets/style/components/_custom-markdowns.scss
@@ -307,7 +307,7 @@
 // hover styles
 .c-message {
   &:hover,
-  &:has(.c-menu .is-active) {
+  &:has(.c-menu[open]) {
     .table-container table {
       thead {
         background-color: $general_1;

--- a/frontend/views/components/menu/MenuContent.vue
+++ b/frontend/views/components/menu/MenuContent.vue
@@ -4,7 +4,7 @@
   data-test='menuContent'
 )
   .c-content-wrapper(
-    v-on-clickaway='closeMenu'
+    v-on-clickaway='onClickAway'
   )
     slot
 </template>
@@ -24,10 +24,11 @@ export default ({
     }
   },
   methods: {
-    closeMenu (e) {
+    onClickAway (e) {
       // Prevent closing the menu when clicking inside of the parent element,
       // except if the event was on `.c-content` (.c-responsive-menu)
-      if (e.target !== this.$el && e.target?.closest('details') === this.$el.closest('details')) {
+      const isInsideParent = e.target !== this.$el && e.target?.closest('details') === this.$el.closest('details')
+      if (!this.isActive || isInsideParent) {
         return
       }
       this.Menu.closeMenu()

--- a/frontend/views/containers/chatroom/ChatMain.vue
+++ b/frontend/views/containers/chatroom/ChatMain.vue
@@ -2127,7 +2127,7 @@ export default ({
     margin-top: 1rem;
   }
 
-  &:has(.c-message .c-menu .is-active) {
+  &:has(.c-message .c-menu[open]) {
     // fix: ensure the menu is visible (otherwise, absolute positioning makes
     // it hidden behind other messages)
     z-index: 1;
@@ -2135,7 +2135,7 @@ export default ({
 }
 
 ::v-deep .vue-recycle-scroller__item-wrapper {
-  &:has(.c-message .c-menu .is-active) {
+  &:has(.c-message .c-menu[open]) {
     // fix: ensure the menu is visible
     overflow: visible;
   }

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -2,7 +2,6 @@
 .c-message.force-motion(
   :class='componentRootClasses'
   @click='$emit("wrapperAction")'
-  @mouseleave='mouseLeave'
   v-touch:touchhold='longPressHandler'
   v-touch:swipe.left='reply'
 )
@@ -290,11 +289,6 @@ export default ({
   methods: {
     humanDate,
     swapMentionIDForDisplayname,
-    mouseLeave () {
-      if (this.$refs.messageAction?.$refs?.menu && this.$refs.messageAction.$refs.menu.isActive) {
-        this.$refs.messageAction.$refs.menu.closeMenu()
-      }
-    },
     editMessage () {
       this.$emit('message-is-editing', true)
     },

--- a/frontend/views/containers/chatroom/MessageBase.vue
+++ b/frontend/views/containers/chatroom/MessageBase.vue
@@ -446,7 +446,7 @@ export default ({
   }
 
   &:hover,
-  &:has(.c-menu .is-active) {
+  &:has(.c-menu[open]) {
     background-color: $general_2;
 
     &:not(.pending, .failed) {

--- a/scripts/esbuild-plugins/vue-plugin.js
+++ b/scripts/esbuild-plugins/vue-plugin.js
@@ -44,7 +44,16 @@ module.exports = ({ aliases = null, cache = null, debug = false, flowtype = null
   }
 }
 
-const compiler = componentCompiler.createDefaultCompiler()
+const compiler = componentCompiler.createDefaultCompiler({
+  style: {
+    // In production builds, @vue/component-compiler minifies component styles
+    // with clean-css v4, whose selector 'tidying' predates CSS Selectors
+    // Level 4 and strips descendant combinators inside :has(...), e.g.
+    // `:has(.c-menu .is-active)` becomes `:has(.c-menu.is-active)`, silently
+    // breaking those rules. Keep selectors as written.
+    postcssCleanOptions: { level: { 1: { tidySelectors: false } } }
+  }
+})
 const compile = ({ filename, source, options }) => {
   try {
     if (/^\s*$/.test(source)) {

--- a/scripts/esbuild-plugins/vue-plugin.js
+++ b/scripts/esbuild-plugins/vue-plugin.js
@@ -44,16 +44,7 @@ module.exports = ({ aliases = null, cache = null, debug = false, flowtype = null
   }
 }
 
-const compiler = componentCompiler.createDefaultCompiler({
-  style: {
-    // In production builds, @vue/component-compiler minifies component styles
-    // with clean-css v4, whose selector 'tidying' predates CSS Selectors
-    // Level 4 and strips descendant combinators inside :has(...), e.g.
-    // `:has(.c-menu .is-active)` becomes `:has(.c-menu.is-active)`, silently
-    // breaking those rules. Keep selectors as written.
-    postcssCleanOptions: { level: { 1: { tidySelectors: false } } }
-  }
-})
+const compiler = componentCompiler.createDefaultCompiler()
 const compile = ({ filename, source, options }) => {
   try {
     if (/^\s*$/.test(source)) {


### PR DESCRIPTION
closes #3138 

The cause of the issue is related to below lines of code:

https://github.com/okTurtles/group-income/blob/2ae28015d6c1b7ede5691d773b2649a890ffe7d0/frontend/views/containers/chatroom/MessageBase.vue#L448-L455

`&:has(.c-menu .is-active)` in L449 for some reason becomes **':has(.c-menu.is-active)'** (whitespace is removed) in the PROD build, probably during css minification step:

<img width="415" height="22" alt="has-selector-wrong-prod" src="https://github.com/user-attachments/assets/14ac3df6-bc0a-406a-abdc-ddf3d2f5dcd9" />

As a result the corresponding CSS block never gets matched and takes effect in Chrome.

#### Why does it work fine in FF and Chrome mobile browser then?

In these browsers, which behave differently from chrominium based desktop browsers, `&:has(.c-menu .is-active)` still doesn't take effect but apparently `&:hover` selector above it(L448) does take effect. Hence the menu UIs rendering properly in these cases.