### PR TITLE
#3155 - `Marked` issue related to a bare link in the message

### DIFF
--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -25,11 +25,11 @@ marked.use({
           // For non-external links, validateURL() could perform some transformations to the path and
           // in that case, that is returned as 'url' property.
           const urlToUse = escapeHref(isExternalLink ? href : url)
-          // Render the inline markdown inside the link text (issue #3116) from the token's
-          // already-lexed child tokens. Do NOT call marked.parseInline(text) here: that starts a
-          // fresh top-level parse where the inLink guard is reset, so a link whose text is itself
-          // a URL (every GFM-autolinked bare URL is) gets tokenized as a link again, re-entering
-          // this renderer forever ("Maximum call stack size exceeded").
+          // Do NOT call marked.parseInline(text) here. That leads to a 'Maximum call stack size exceeded' runtime error. (issue #3155)
+          // Here is Fable's finding regarding this bug:
+          // Calling marked.parseInline(text) here  starts a fresh top-level parse where the inLink guard is reset,
+          // so a link whose text is itself a URL (every GFM-autolinked bare URL is) gets tokenized as a link again,
+          // re-entering this renderer forever and creates an infinite loop.
           const parsedText = this.parser.parseInline(token.tokens)
           return `<a class="link" href="${urlToUse}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${parsedText}</a>`
         }

--- a/frontend/views/utils/markdown-utils.js
+++ b/frontend/views/utils/markdown-utils.js
@@ -21,13 +21,16 @@ marked.use({
         const { isValid, isExternalLink, url } = validateURL(token.href, true)
 
         if (isValid) {
-          const { href, text } = token
+          const { href } = token
           // For non-external links, validateURL() could perform some transformations to the path and
           // in that case, that is returned as 'url' property.
           const urlToUse = escapeHref(isExternalLink ? href : url)
-          // marked with 'gfm' option doesn't perform markdown syntax conversion when they are inside link,
-          // So we need to perform another conversion step here.
-          const parsedText = marked.parseInline(text, { gfm: true })
+          // Render the inline markdown inside the link text (issue #3116) from the token's
+          // already-lexed child tokens. Do NOT call marked.parseInline(text) here: that starts a
+          // fresh top-level parse where the inLink guard is reset, so a link whose text is itself
+          // a URL (every GFM-autolinked bare URL is) gets tokenized as a link again, re-entering
+          // this renderer forever ("Maximum call stack size exceeded").
+          const parsedText = this.parser.parseInline(token.tokens)
           return `<a class="link" href="${urlToUse}" ${isExternalLink ? 'target="_blank" rel="noopener noreferrer"' : ''}>${parsedText}</a>`
         }
         return token.raw

--- a/test/cypress/integration/group-chat-markdown.spec.js
+++ b/test/cypress/integration/group-chat-markdown.spec.js
@@ -155,6 +155,16 @@ describe('Check basic markdown features - one feature per message', () => {
         cy.get('code').should('have.text', 'link with code')
       })
     })
+
+    cy.log('3-4. A bare URL must be auto-linked without crashing the renderer')
+
+    // A GFM-autolinked bare URL produces a link token whose text is the URL itself. Re-parsing
+    // that text in the link renderer used to recurse infinitely ('Maximum call stack size exceeded').
+    const bareUrl = 'https://github.com/okTurtles/group-income/wiki/Some-page'
+    sendMarkdownMessage(user1, `check this out: ${bareUrl}`)
+    checkLastSentMessage(() => {
+      cy.get('a').should('have.text', bareUrl).and('have.attr', 'href', bareUrl)
+    })
   })
 
   it('4. Verify fenced code block markdown element', () => {

--- a/test/cypress/integration/group-chat-markdown.spec.js
+++ b/test/cypress/integration/group-chat-markdown.spec.js
@@ -156,10 +156,10 @@ describe('Check basic markdown features - one feature per message', () => {
       })
     })
 
-    cy.log('3-4. A bare URL must be auto-linked without crashing the renderer')
+    cy.log('3-4. A bare URL must be auto-linked without crashing the renderer (issue #3155)')
 
-    // A GFM-autolinked bare URL produces a link token whose text is the URL itself. Re-parsing
-    // that text in the link renderer used to recurse infinitely ('Maximum call stack size exceeded').
+    // A GFM-autolinked bare URL previously caused a 'Maximum call stack size exceeded' runtime error.
+    // Below is to verify this issue doesn't reappear.
     const bareUrl = 'https://github.com/okTurtles/group-income/wiki/Some-page'
     sendMarkdownMessage(user1, `check this out: ${bareUrl}`)
     checkLastSentMessage(() => {


### PR DESCRIPTION
closes #3155 

### AI disclosure
This PR was generated using `Fable` under my supervision.

---
Below is `Fable`'s finding regarding the root cause of the bug, which seems to align with my observation during investigation:

#### Root cause

The crash is an infinite recursion in the custom link renderer in frontend/views/utils/markdown-utils.js — escapeHref is innocent; it's just the frame where the stack finally overflowed.

The loop: with GFM enabled, marked auto-links bare URLs into a link token whose text is the URL itself. The renderer then called `marked.parseInline(text)` to render inline markdown inside link text. But that starts a fresh top-level parse, which resets marked's internal inLink guard — the guard that normally prevents URLs inside link text
from being auto-linked again. So the URL text became a new link token → renderer → parseInline → forever. The repeated "Please report this to marked" lines are marked re-wrapping the error at each recursion level.

I verified this by bundling the project's actual markdown-utils.js and running it in Node: every message containing a bare URL crashed (`https://…`, `www.…`, `[url](url)`), while `[label](url)` was fine.