### PR TITLE
#3159 - Wrong usage of `groupSettingsForGroup` getter

### DIFF
--- a/frontend/model/notifications/mainPeriodicNotificationEntries.js
+++ b/frontend/model/notifications/mainPeriodicNotificationEntries.js
@@ -57,7 +57,7 @@ const periodicNotificationEntries: {
           })
         })
       },
-      shouldClearStateKey ({ rootGetters }) {
+      shouldClearStateKey ({ rootState, rootGetters }) {
         const groupIds = rootGetters.ourGroups
 
         const groupedNotifications = rootGetters.notifications.filter(item => item.type === 'NEAR_DISTRIBUTION_END').reduce((acc, item) => {
@@ -69,7 +69,7 @@ const periodicNotificationEntries: {
         }, Object.create(null))
 
         return groupIds.every((groupId) => {
-          const currentPeriod = rootGetters.groupSettingsForGroup(groupId).distributionDate
+          const currentPeriod = rootGetters.groupSettingsForGroup(rootState[groupId]).distributionDate
           return !!groupedNotifications[groupId]?.every(period => period !== currentPeriod)
         })
       }


### PR DESCRIPTION
closes #3159 

As mentioned in the issue description, this is a missing update in a previous PR long time ago. Unrelated to the current notification issue found in 2.9.0.